### PR TITLE
Deploy workflow fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,13 @@ name: Deploy to Firebase Hosting
 on:
   push:
     branches: [ main ]
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    env:
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,9 +19,7 @@ jobs:
       - name: Build (Vite)
         run: npm run build
       - name: Deploy Hosting
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
-          PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        if: ${{ env.FIREBASE_TOKEN != '' && env.PROJECT_ID != '' }}
         run: |
           npm i -g firebase-tools
           firebase use "$PROJECT_ID"


### PR DESCRIPTION
Moves environment variables from step-level to job-level to fix deployment workflow and avoid GitHub Actions warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Firebase env vars to job-level and adds a guard to only run deploy when secrets are present.
> 
> - **CI/CD** (`.github/workflows/deploy.yml`):
>   - Move `FIREBASE_TOKEN` and `PROJECT_ID` from step-level to job-level `env`.
>   - Add `if` condition to `Deploy Hosting` step to run only when both env vars are non-empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0071b5b9ea63c5d75eed5f632cdacdc7d82be968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->