### PR TITLE
Add Sign-In button on Launch page

### DIFF
--- a/src/pages/LaunchPage.tsx
+++ b/src/pages/LaunchPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useMockLaunchProducts } from '../mockData';
 
 const LaunchPage: React.FC = () => {
-  const { user } = useAuth();
+  const { user, login } = useAuth();
   const features = useMockLaunchProducts();
   const [view, setView] = useState<'upcoming' | 'past'>('upcoming');
 
@@ -31,9 +31,18 @@ const LaunchPage: React.FC = () => {
                 Go to Dashboard
               </Link>
             ) : (
-              <div className="text-gray-400">
-                Sign in from the dashboard to access admin features
-              </div>
+              <button
+                onClick={login}
+                className="bg-blue-600 text-white font-bold py-3 px-6 rounded-lg hover:bg-blue-700 transition duration-300 ease-in-out transform hover:scale-105 flex items-center gap-2"
+              >
+                <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                  <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                  <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                  <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                </svg>
+                Sign in with Google
+              </button>
             )}
           </div>
         </header>


### PR DESCRIPTION
Replace the static text message with an interactive 'Sign in with Google' button for signed-out users on the Launch page. This improves the user experience by allowing users to sign in directly from the public launch hub instead of needing to navigate to the dashboard first.

## Changes
- Import `login` from `useAuth()` hook
- Replace text div with blue button matching dashboard link styling
- Add Google icon SVG to sign-in button
- Button calls `login()` onClick to trigger Google authentication

## UI/UX
- Maintains consistent blue button styling across signed-in and signed-out states
- Uses same hover effects and transitions as existing dashboard link
- Shows appropriate action based on authentication state:
  - Signed in: 'Go to Dashboard' link
  - Signed out: 'Sign in with Google' button