### PR TITLE
Settings: Firestore-backed attributes with add/edit/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,27 @@ To seed initial settings data to Firestore:
 This will create the following documents in Firestore:
 - `/settings/ai` - AI model configuration (model, temperature, tone, etc.)
 - `/settings/vocab` - Vocabulary settings (banned words, synonyms)
+- `/settings/attributes` - Product attributes (departments, classes, categories, etc.)
+
+### Seeding Product Attributes
+
+To seed product attribute dropdowns (departments, classes, categories, etc.):
+
+```bash
+npm run seed:attributes
+```
+
+This creates `/settings/attributes` with starter data for:
+- departments (Footwear, Apparel, Accessories)
+- classes (Running, Basketball, Lifestyle, Tops, etc.)
+- categories (Shoes, Tops, Hoodies, etc.)
+- ageGroups (Adult, Youth, Toddler)
+- genders (Mens, Womens, Unisex)
+- statuses (intake, in-progress, validated, uploaded)
+- websites (Shiekh.com, Karmaloop.com)
+- sportsTeams (Lakers, Dodgers, Raiders, 49ers)
+- leagues (NBA, MLB, NFL)
+
+Users can add/edit/delete these values through the Settings → Vocab/Dropdowns tab in the UI.
 
 You only need to run this once to initialize your Firestore database with default settings.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "seed": "ts-node scripts/seed.ts"
+    "seed": "ts-node scripts/seed.ts",
+    "seed:attributes": "ts-node scripts/seed-attributes.ts"
   },
   "dependencies": {
     "firebase": "^12.5.0",

--- a/scripts/seed-attributes.ts
+++ b/scripts/seed-attributes.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Firestore Seed Script for Attributes
+ * Seeds /settings/attributes with starter vocabulary data
+ * Run with: npm run seed:attributes
+ */
+
+import { initializeApp, cert, type ServiceAccount } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import * as dotenv from 'dotenv';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// Load environment variables
+dotenv.config({ path: resolve(__dirname, '../.env.local') });
+
+// Initialize Firebase Admin
+let app;
+try {
+  // Try to use service account if available
+  const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || 
+                              resolve(__dirname, '../service-account.json');
+  
+  if (existsSync(serviceAccountPath)) {
+    const serviceAccount = JSON.parse(
+      readFileSync(serviceAccountPath, 'utf8')
+    ) as ServiceAccount;
+    
+    app = initializeApp({
+      credential: cert(serviceAccount),
+    });
+  } else {
+    // Fallback to environment variables
+    const projectId = process.env.VITE_FIREBASE_PROJECT_ID || 'ropi-bccee';
+    console.log(`Using project ID: ${projectId}`);
+    app = initializeApp({
+      projectId,
+    });
+  }
+} catch (error) {
+  console.error('Failed to initialize Firebase Admin:', error);
+  process.exit(1);
+}
+
+const db = getFirestore(app);
+
+// Seed data for attributes
+const attributesData = {
+  departments: ['Footwear', 'Apparel', 'Accessories'],
+  classes: ['Running', 'Basketball', 'Lifestyle', 'Tops', 'Hoodies', 'Hats'],
+  categories: ['Shoes', 'Tops', 'Hoodies', 'Hats', 'Pants', 'Shorts', 'Jerseys', 'Bottoms', 'Bags'],
+  ageGroups: ['Adult', 'Youth', 'Toddler'],
+  genders: ['Mens', 'Womens', 'Unisex'],
+  statuses: ['intake', 'in-progress', 'validated', 'uploaded'],
+  websites: ['Shiekh.com', 'Karmaloop.com'],
+  sportsTeams: ['Lakers', 'Dodgers', 'Raiders', '49ers'],
+  leagues: ['NBA', 'MLB', 'NFL'],
+};
+
+async function seedAttributes() {
+  try {
+    console.log('🌱 Starting attributes seed...\n');
+
+    console.log('📝 Writing /settings/attributes...');
+    await db.collection('settings').doc('attributes').set(attributesData);
+    console.log('✅ Attributes seeded successfully');
+
+    console.log('\n🎉 Seed completed successfully!');
+    console.log('\nSeeded document:');
+    console.log('  - /settings/attributes');
+    console.log('\nAttribute keys:');
+    Object.keys(attributesData).forEach(key => {
+      const count = (attributesData as any)[key].length;
+      console.log(`    - ${key}: ${count} items`);
+    });
+    
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Error seeding attributes:', error);
+    process.exit(1);
+  }
+}
+
+// Run the seed function
+seedAttributes();

--- a/src/hooks/__tests__/useAttributesSettings.test.ts
+++ b/src/hooks/__tests__/useAttributesSettings.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for attribute settings validation functions
+ */
+
+import { 
+  normalizeString, 
+  isDuplicate, 
+  deduplicateArray, 
+  validateItem 
+} from '../useAttributesSettings';
+
+describe('Attribute Settings - Validation', () => {
+  describe('normalizeString', () => {
+    test('trims whitespace', () => {
+      expect(normalizeString('  test  ')).toBe('test');
+    });
+
+    test('converts to lowercase', () => {
+      expect(normalizeString('TEST')).toBe('test');
+      expect(normalizeString('Test')).toBe('test');
+      expect(normalizeString('TeSt')).toBe('test');
+    });
+
+    test('handles empty string', () => {
+      expect(normalizeString('')).toBe('');
+      expect(normalizeString('   ')).toBe('');
+    });
+  });
+
+  describe('isDuplicate', () => {
+    test('detects exact duplicates (case-insensitive)', () => {
+      const items = ['Footwear', 'Apparel', 'Accessories'];
+      
+      expect(isDuplicate(items, 'Footwear')).toBe(true);
+      expect(isDuplicate(items, 'footwear')).toBe(true);
+      expect(isDuplicate(items, 'FOOTWEAR')).toBe(true);
+      expect(isDuplicate(items, 'FoOtWeAr')).toBe(true);
+    });
+
+    test('handles whitespace differences', () => {
+      const items = ['Footwear', 'Apparel'];
+      
+      expect(isDuplicate(items, '  Footwear  ')).toBe(true);
+      expect(isDuplicate(items, ' apparel ')).toBe(true);
+    });
+
+    test('returns false for non-duplicates', () => {
+      const items = ['Footwear', 'Apparel'];
+      
+      expect(isDuplicate(items, 'Accessories')).toBe(false);
+      expect(isDuplicate(items, 'accessories')).toBe(false);
+    });
+
+    test('handles empty array', () => {
+      expect(isDuplicate([], 'test')).toBe(false);
+    });
+
+    test('handles empty string', () => {
+      const items = ['Footwear'];
+      expect(isDuplicate(items, '')).toBe(false);
+      expect(isDuplicate(items, '   ')).toBe(false);
+    });
+  });
+
+  describe('deduplicateArray', () => {
+    test('removes case-insensitive duplicates', () => {
+      const items = ['Footwear', 'footwear', 'FOOTWEAR', 'Apparel', 'apparel'];
+      const result = deduplicateArray(items);
+      
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe('Footwear'); // Keeps first occurrence
+      expect(result[1]).toBe('Apparel');
+    });
+
+    test('keeps first occurrence of duplicates', () => {
+      const items = ['Nike', 'NIKE', 'nike', 'Adidas'];
+      const result = deduplicateArray(items);
+      
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe('Nike'); // Original casing preserved
+      expect(result[1]).toBe('Adidas');
+    });
+
+    test('handles array with no duplicates', () => {
+      const items = ['Footwear', 'Apparel', 'Accessories'];
+      const result = deduplicateArray(items);
+      
+      expect(result).toEqual(items);
+    });
+
+    test('handles empty array', () => {
+      expect(deduplicateArray([])).toEqual([]);
+    });
+
+    test('trims whitespace during comparison', () => {
+      const items = ['Footwear', '  Footwear  ', ' footwear ', 'Apparel'];
+      const result = deduplicateArray(items);
+      
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe('Footwear');
+      expect(result[1]).toBe('Apparel');
+    });
+  });
+
+  describe('validateItem', () => {
+    test('accepts valid strings', () => {
+      const result = validateItem('Footwear');
+      expect(result.valid).toBe(true);
+      expect(result.cleaned).toBe('Footwear');
+      expect(result.error).toBeUndefined();
+    });
+
+    test('trims whitespace', () => {
+      const result = validateItem('  Footwear  ');
+      expect(result.valid).toBe(true);
+      expect(result.cleaned).toBe('Footwear');
+    });
+
+    test('rejects empty strings', () => {
+      const result = validateItem('');
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Value cannot be empty');
+    });
+
+    test('rejects whitespace-only strings', () => {
+      const result = validateItem('   ');
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Value cannot be empty');
+    });
+
+    test('truncates strings over 80 characters', () => {
+      const longString = 'A'.repeat(100);
+      const result = validateItem(longString);
+      
+      expect(result.valid).toBe(true);
+      expect(result.cleaned).toHaveLength(80);
+      expect(result.cleaned).toBe('A'.repeat(80));
+      expect(result.error).toBeUndefined();
+    });
+
+    test('accepts strings exactly 80 characters', () => {
+      const maxString = 'A'.repeat(80);
+      const result = validateItem(maxString);
+      
+      expect(result.valid).toBe(true);
+      expect(result.cleaned).toBe(maxString);
+      expect(result.cleaned).toHaveLength(80);
+    });
+  });
+});

--- a/src/hooks/useAttributesSettings.ts
+++ b/src/hooks/useAttributesSettings.ts
@@ -1,0 +1,269 @@
+/**
+ * Hook for managing product attributes in Firestore
+ * Handles CRUD operations for /settings/attributes
+ */
+
+import { useState, useEffect } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export type AttributeKey = 
+  | 'departments' 
+  | 'classes' 
+  | 'categories' 
+  | 'ageGroups' 
+  | 'genders' 
+  | 'statuses' 
+  | 'websites' 
+  | 'sportsTeams' 
+  | 'leagues';
+
+export type AttributesData = Record<AttributeKey, string[]>;
+
+const INITIAL_ATTRIBUTES: AttributesData = {
+  departments: [],
+  classes: [],
+  categories: [],
+  ageGroups: [],
+  genders: [],
+  statuses: [],
+  websites: [],
+  sportsTeams: [],
+  leagues: [],
+};
+
+const MAX_ITEM_LENGTH = 80;
+
+/**
+ * Normalize string for case-insensitive comparison
+ */
+export function normalizeString(str: string): string {
+  return str.trim().toLowerCase();
+}
+
+/**
+ * Check if an item already exists (case-insensitive)
+ */
+export function isDuplicate(items: string[], newItem: string): boolean {
+  const normalized = normalizeString(newItem);
+  return items.some(item => normalizeString(item) === normalized);
+}
+
+/**
+ * Deduplicate array (case-insensitive, keeps first occurrence)
+ */
+export function deduplicateArray(items: string[]): string[] {
+  const seen = new Set<string>();
+  return items.filter(item => {
+    const normalized = normalizeString(item);
+    if (seen.has(normalized)) {
+      return false;
+    }
+    seen.add(normalized);
+    return true;
+  });
+}
+
+/**
+ * Validate and clean an item value
+ */
+export function validateItem(value: string): { valid: boolean; cleaned: string; error?: string } {
+  const trimmed = value.trim();
+  
+  if (!trimmed) {
+    return { valid: false, cleaned: '', error: 'Value cannot be empty' };
+  }
+  
+  if (trimmed.length > MAX_ITEM_LENGTH) {
+    // Silently truncate
+    return { valid: true, cleaned: trimmed.substring(0, MAX_ITEM_LENGTH) };
+  }
+  
+  return { valid: true, cleaned: trimmed };
+}
+
+export function useAttributesSettings() {
+  const [data, setData] = useState<AttributesData>(INITIAL_ATTRIBUTES);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const docRef = doc(db, 'settings', 'attributes');
+
+  // Load data on mount
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const docSnap = await getDoc(docRef);
+      
+      if (docSnap.exists()) {
+        const loadedData = docSnap.data() as AttributesData;
+        // Ensure all keys exist and deduplicate on load
+        const cleanedData: AttributesData = { ...INITIAL_ATTRIBUTES };
+        Object.keys(INITIAL_ATTRIBUTES).forEach((key) => {
+          const attrKey = key as AttributeKey;
+          cleanedData[attrKey] = deduplicateArray(loadedData[attrKey] || []);
+        });
+        setData(cleanedData);
+      } else {
+        // Document doesn't exist, create it with empty arrays
+        await setDoc(docRef, INITIAL_ATTRIBUTES);
+        setData(INITIAL_ATTRIBUTES);
+      }
+    } catch (err) {
+      console.error('Error loading attributes:', err);
+      setError('Failed to load attributes');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveData = async (newData: AttributesData): Promise<boolean> => {
+    try {
+      setSaving(true);
+      setError(null);
+      
+      // Deduplicate all arrays before saving
+      const cleanedData: AttributesData = { ...INITIAL_ATTRIBUTES };
+      Object.keys(newData).forEach((key) => {
+        const attrKey = key as AttributeKey;
+        cleanedData[attrKey] = deduplicateArray(newData[attrKey]);
+      });
+      
+      await setDoc(docRef, cleanedData);
+      setData(cleanedData);
+      return true;
+    } catch (err) {
+      console.error('Error saving attributes:', err);
+      setError('Failed to save attributes');
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const addItem = async (key: AttributeKey, value: string): Promise<{ success: boolean; error?: string }> => {
+    const validation = validateItem(value);
+    
+    if (!validation.valid) {
+      return { success: false, error: validation.error };
+    }
+    
+    const currentItems = data[key];
+    
+    if (isDuplicate(currentItems, validation.cleaned)) {
+      return { success: false, error: 'Item already exists' };
+    }
+    
+    // Optimistic update
+    const newData = {
+      ...data,
+      [key]: [...currentItems, validation.cleaned],
+    };
+    
+    setData(newData);
+    
+    // Save to Firestore
+    const success = await saveData(newData);
+    
+    if (!success) {
+      // Rollback on failure
+      setData(data);
+      return { success: false, error: 'Failed to save' };
+    }
+    
+    return { success: true };
+  };
+
+  const editItem = async (
+    key: AttributeKey, 
+    index: number, 
+    newValue: string
+  ): Promise<{ success: boolean; error?: string }> => {
+    const validation = validateItem(newValue);
+    
+    if (!validation.valid) {
+      return { success: false, error: validation.error };
+    }
+    
+    const currentItems = data[key];
+    
+    if (index < 0 || index >= currentItems.length) {
+      return { success: false, error: 'Invalid index' };
+    }
+    
+    // Check if the new value duplicates another item (excluding the current index)
+    const otherItems = currentItems.filter((_, i) => i !== index);
+    if (isDuplicate(otherItems, validation.cleaned)) {
+      return { success: false, error: 'Item already exists' };
+    }
+    
+    // Optimistic update
+    const newItems = [...currentItems];
+    newItems[index] = validation.cleaned;
+    
+    const newData = {
+      ...data,
+      [key]: newItems,
+    };
+    
+    setData(newData);
+    
+    // Save to Firestore
+    const success = await saveData(newData);
+    
+    if (!success) {
+      // Rollback on failure
+      setData(data);
+      return { success: false, error: 'Failed to save' };
+    }
+    
+    return { success: true };
+  };
+
+  const deleteItem = async (key: AttributeKey, index: number): Promise<{ success: boolean; error?: string }> => {
+    const currentItems = data[key];
+    
+    if (index < 0 || index >= currentItems.length) {
+      return { success: false, error: 'Invalid index' };
+    }
+    
+    // Optimistic update
+    const newItems = currentItems.filter((_, i) => i !== index);
+    
+    const newData = {
+      ...data,
+      [key]: newItems,
+    };
+    
+    setData(newData);
+    
+    // Save to Firestore
+    const success = await saveData(newData);
+    
+    if (!success) {
+      // Rollback on failure
+      setData(data);
+      return { success: false, error: 'Failed to save' };
+    }
+    
+    return { success: true };
+  };
+
+  return {
+    data,
+    loading,
+    saving,
+    error,
+    addItem,
+    editItem,
+    deleteItem,
+    reload: loadData,
+  };
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, ChangeEvent } from 'react';
-import { mockVocabulary } from '../mockData';
 import AISettingsTab from './settings/AISettingsTab';
 import VocabSettingsTab from './settings/VocabSettingsTab';
 import Toast from '../components/Toast';
+import { useAttributesSettings, type AttributeKey } from '../hooks/useAttributesSettings';
+import { useAuth } from '../contexts/AuthContext';
 
 // Define the types for the keys we'll be managing
 type VocabKey = keyof typeof editableVocabs;
@@ -42,7 +43,8 @@ type ToastState = {
 
 const SettingsPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<ActiveTab>('ai');
-  const [vocabulary, setVocabulary] = useState(mockVocabulary);
+  const { user } = useAuth();
+  const attributes = useAttributesSettings();
   const [toast, setToast] = useState<ToastState>({ show: false, message: '', type: 'success' });
   const [newItems, setNewItems] = useState({
     departments: '',
@@ -55,6 +57,8 @@ const SettingsPage: React.FC = () => {
     sportsTeams: '',
     leagues: '',
   });
+  const [editingItem, setEditingItem] = useState<{ key: AttributeKey; index: number } | null>(null);
+  const [editValue, setEditValue] = useState('');
 
   const showToast = (message: string, type: 'success' | 'error') => {
     setToast({ show: true, message, type });
@@ -69,18 +73,67 @@ const SettingsPage: React.FC = () => {
     setNewItems(prev => ({ ...prev, [key]: value }));
   };
 
-  const handleAddItem = (key: VocabKey) => {
+  const handleAddItem = async (key: VocabKey) => {
+    if (!user) {
+      showToast('Please sign in to edit settings', 'error');
+      return;
+    }
+
     const newItem = newItems[key].trim();
-    if (newItem) {
-      // Ensure readonly arrays from mock data are treated as mutable string arrays
-      const currentList = Array.from(vocabulary[key]);
-      if (!currentList.includes(newItem)) {
-        setVocabulary(prev => ({
-          ...prev,
-          [key]: [...currentList, newItem],
-        }));
-        setNewItems(prev => ({ ...prev, [key]: '' })); // Clear input after adding
-      }
+    if (!newItem) return;
+
+    const result = await attributes.addItem(key as AttributeKey, newItem);
+    
+    if (result.success) {
+      setNewItems(prev => ({ ...prev, [key]: '' }));
+      showToast('Saved', 'success');
+    } else {
+      showToast(result.error || 'Couldn\'t save — try again', 'error');
+    }
+  };
+
+  const startEdit = (key: AttributeKey, index: number, currentValue: string) => {
+    setEditingItem({ key, index });
+    setEditValue(currentValue);
+  };
+
+  const cancelEdit = () => {
+    setEditingItem(null);
+    setEditValue('');
+  };
+
+  const saveEdit = async () => {
+    if (!editingItem || !user) {
+      cancelEdit();
+      return;
+    }
+
+    const result = await attributes.editItem(editingItem.key, editingItem.index, editValue);
+    
+    if (result.success) {
+      showToast('Saved', 'success');
+      cancelEdit();
+    } else {
+      showToast(result.error || 'Couldn\'t save — try again', 'error');
+    }
+  };
+
+  const handleDelete = async (key: AttributeKey, index: number) => {
+    if (!user) {
+      showToast('Please sign in to edit settings', 'error');
+      return;
+    }
+
+    if (!confirm('Are you sure you want to delete this item?')) {
+      return;
+    }
+
+    const result = await attributes.deleteItem(key, index);
+    
+    if (result.success) {
+      showToast('Deleted', 'success');
+    } else {
+      showToast(result.error || 'Couldn\'t delete — try again', 'error');
     }
   };
   
@@ -88,7 +141,15 @@ const SettingsPage: React.FC = () => {
     if (e.key === 'Enter') {
       handleAddItem(key);
     }
-  }
+  };
+
+  const handleEditKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      saveEdit();
+    } else if (e.key === 'Escape') {
+      cancelEdit();
+    }
+  };
 
   const TabButton: React.FC<{ tabName: ActiveTab; label: string }> = ({ tabName, label }) => (
     <button
@@ -103,32 +164,86 @@ const SettingsPage: React.FC = () => {
     </button>
   );
 
-  const VocabEditor: React.FC<{ vocabKey: VocabKey; title: string }> = ({ vocabKey, title }) => (
-    <div className="bg-white p-6 rounded-lg shadow">
-      <h3 className="text-lg font-semibold text-gray-800 mb-4">{title}</h3>
-      <ul className="space-y-2 h-48 overflow-y-auto border rounded-md p-3 bg-gray-50 mb-4">
-        {vocabulary[vocabKey].map((item, index) => (
-          <li key={index} className="text-gray-700">{item}</li>
-        ))}
-      </ul>
-      <div className="flex space-x-2">
-        <input
-          type="text"
-          value={newItems[vocabKey]}
-          onChange={(e) => handleInputChange(e, vocabKey)}
-          onKeyPress={(e) => handleKeyPress(e, vocabKey)}
-          placeholder="Add new..."
-          className="flex-grow block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
-        />
-        <button
-          onClick={() => handleAddItem(vocabKey)}
-          className="px-4 py-2 bg-indigo-600 text-white font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
-          Add
-        </button>
+  const VocabEditor: React.FC<{ vocabKey: VocabKey; title: string }> = ({ vocabKey, title }) => {
+    const items = attributes.data[vocabKey as AttributeKey] || [];
+    const isEditing = (index: number) => editingItem?.key === vocabKey && editingItem?.index === index;
+
+    return (
+      <div className="bg-white p-6 rounded-lg shadow">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">{title}</h3>
+        
+        {attributes.loading ? (
+          <div className="h-48 flex items-center justify-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+          </div>
+        ) : (
+          <>
+            <ul className="space-y-2 h-48 overflow-y-auto border rounded-md p-3 bg-gray-50 mb-4">
+              {items.length === 0 ? (
+                <li className="text-gray-400 text-sm italic">No items yet</li>
+              ) : (
+                items.map((item, index) => (
+                  <li 
+                    key={index} 
+                    className="flex items-center justify-between group hover:bg-white px-2 py-1 rounded transition-colors"
+                  >
+                    {isEditing(index) ? (
+                      <input
+                        type="text"
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={handleEditKeyPress}
+                        onBlur={cancelEdit}
+                        autoFocus
+                        className="flex-grow border-indigo-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+                      />
+                    ) : (
+                      <>
+                        <span 
+                          className="text-gray-700 flex-grow cursor-pointer"
+                          onClick={() => user && startEdit(vocabKey as AttributeKey, index, item)}
+                          title="Click to edit"
+                        >
+                          {item}
+                        </span>
+                        <button
+                          onClick={() => handleDelete(vocabKey as AttributeKey, index)}
+                          className="opacity-0 group-hover:opacity-100 text-red-500 hover:text-red-700 transition-opacity ml-2"
+                          disabled={attributes.saving}
+                          title="Delete"
+                        >
+                          ×
+                        </button>
+                      </>
+                    )}
+                  </li>
+                ))
+              )}
+            </ul>
+            
+            <div className="flex space-x-2">
+              <input
+                type="text"
+                value={newItems[vocabKey]}
+                onChange={(e) => handleInputChange(e, vocabKey)}
+                onKeyPress={(e) => handleKeyPress(e, vocabKey)}
+                placeholder="Add new..."
+                disabled={attributes.saving}
+                className="flex-grow block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+              />
+              <button
+                onClick={() => handleAddItem(vocabKey)}
+                disabled={attributes.saving || !newItems[vocabKey].trim()}
+                className="px-4 py-2 bg-indigo-600 text-white font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {attributes.saving ? 'Saving...' : 'Add'}
+              </button>
+            </div>
+          </>
+        )}
       </div>
-    </div>
-  );
+    );
+  };
 
   const PlaceholderTab: React.FC<{ title: string }> = ({ title }) => (
     <div className="bg-white p-6 rounded-lg shadow">


### PR DESCRIPTION
Replace mockVocabulary with Firestore-backed product attributes, enabling full CRUD operations through the Settings → Vocab/Dropdowns tab.

## Changes

### useAttributesSettings Hook
- **Firestore integration:** Reads/writes to `/settings/attributes`
- **CRUD operations:**
  - `addItem()`: Add new items with validation
  - `editItem()`: Update existing items by index
  - `deleteItem()`: Remove items with confirmation
- **Optimistic updates:** Immediate UI response with rollback on error
- **Smart deduplication:** Case-insensitive duplicate detection
- **Validation:**
  - Trim whitespace
  - Max length: 80 characters (silently truncate)
  - Reject empty values
  - Case-insensitive equality checks

### Enhanced UI (SettingsPage.tsx)
- **Inline editing:**
  - Click any item to edit in place
  - Enter key saves changes
  - Escape key cancels
  - Auto-focus on edit input
- **Delete functionality:**
  - Hover over item shows × button
  - Confirmation dialog before deletion
- **Loading states:** Spinner while fetching data
- **Disabled states:** Controls disabled during save operations
- **Auth guard:** Requires sign-in to edit (shows error toast if not authenticated)
- **Toast notifications:**
  - "Saved" on successful add/edit
  - "Deleted" on successful deletion
  - Error messages with retry prompts

### Firestore Schema
Document: `/settings/attributes`


All arrays maintain case-insensitive uniqueness.

### Seed Script
- **File:** `scripts/seed-attributes.ts`
- **Command:** `npm run seed:attributes`
- **Data:** Starter values for all 9 attribute types
- **Usage:** Run once to initialize Firestore

### Testing
- **Comprehensive unit tests** in `src/hooks/__tests__/useAttributesSettings.test.ts`
- Test coverage:
  - `normalizeString()`: Whitespace trim + lowercase
  - `isDuplicate()`: Case-insensitive comparison
  - `deduplicateArray()`: Remove duplicates, keep first
  - `validateItem()`: Length limits, empty checks
- Tests require Jest setup (not yet installed)

### Documentation
- Updated README with:
  - `/settings/attributes` Firestore structure
  - Seed script usage
  - List of default attribute values

## Breaking Changes
None - mockVocabulary still exists for other components that may reference it.

## Testing Instructions
1. Run `npm run seed:attributes` to initialize Firestore
2. Navigate to Settings → Vocab/Dropdowns tab
3. Test add: Type a value, click Add or press Enter
4. Test edit: Click an existing item, modify text, press Enter
5. Test delete: Hover over item, click ×, confirm deletion
6. Verify case-insensitive duplicates are prevented
7. Verify toast notifications appear for all operations
8. Test while signed out (should show auth error)

## Quality Checklist
✅ No TypeScript errors  
✅ Optimistic updates with rollback  
✅ Case-insensitive deduplication  
✅ Comprehensive validation  
✅ Accessibility: keyboard navigation (Enter/Esc)  
✅ Auth guard enforced  
✅ Unit tests for validation logic  
✅ Documentation updated  

## Future Enhancements
- Jest setup for running unit tests
- Drag-and-drop reordering
- Bulk import/export
- Search/filter for long lists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new seeding capability for product attributes including departments, classes, categories, age groups, genders, statuses, websites, sports teams, and leagues.
  * Introduced attribute management in Settings (Vocab/Dropdowns) enabling users to add, edit, and delete dropdown values.
  * Real-time feedback with loading and saving indicators for all operations.
  * Authentication required for managing settings.

* **Chores**
  * Added new seed script for initializing attribute data in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->