### PR TITLE
Importer Simplification – MPN as Primary ID

### DIFF
--- a/src/components/MappingReview.tsx
+++ b/src/components/MappingReview.tsx
@@ -74,7 +74,6 @@ const MappingReview: React.FC<MappingReviewProps> = ({
                     className="w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
                   >
                     <option value="">-- Ignore this column --</option>
-                    <option value="product_id">Product ID</option>
                     <option value="mpn">MPN</option>
                     <option value="sku">SKU</option>
                     <option value="name">Name</option>

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -164,7 +164,7 @@ const ImportPage: React.FC = () => {
                 </div>
                 <p className="text-xs text-gray-500">CSV up to 10MB</p>
                 <p className="text-xs text-gray-500 mt-2">
-                  <strong>Required:</strong> Product ID (or MPN) and SKU
+                  <strong>Required:</strong> MPN and SKU
                 </p>
                 <p className="text-xs text-gray-500">
                   Optional: name, brand, price, size, color, etc.

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -27,8 +27,7 @@ export type ParseResult = {
 
 // Synonym mappings for auto-detection
 const HEADER_SYNONYMS: Record<string, string[]> = {
-  product_id: ['product_id', 'style', 'style_id', 'styleid', 'parent_sku', 'style_code', 'product.id'],
-  mpn: ['mpn', 'model', 'mpn_code', 'manufacturer_part_number'],
+  mpn: ['mpn', 'model', 'mpn_code', 'manufacturer_part_number', 'product_id', 'style', 'style_id', 'styleid', 'parent_sku', 'style_code', 'product.id'],
   sku: ['sku', 'variant_id', 'child_sku', 'upc', 'variant_sku'],
   name: ['name', 'title', 'product_name', 'product_title', 'description'],
   brand: ['brand', 'manufacturer', 'vendor'],

--- a/src/utils/firestoreImport.ts
+++ b/src/utils/firestoreImport.ts
@@ -26,9 +26,9 @@ export type ImportResult = {
  * Validate required fields for a product row
  */
 function validateProductRow(data: Record<string, any>): string | null {
-  // Require product_id OR mpn
-  if (!data.product_id && !data.mpn) {
-    return 'Missing required field: product_id or MPN';
+  // Require MPN
+  if (!data.mpn) {
+    return 'Missing required field: MPN';
   }
   
   // Require at least one SKU
@@ -50,14 +50,9 @@ function validateProductRow(data: Record<string, any>): string | null {
  * Transform row data into Product structure
  */
 function transformToProduct(data: Record<string, any>): Partial<Product> {
-  // Use product_id if available, otherwise fall back to mpn
-  const productId = data.product_id || data.mpn;
-  // Keep both values on the product record
-  const mpn = data.mpn || data.product_id;
-  
   return {
-    id: productId || '',
-    mpn: mpn || '',
+    id: data.mpn || '',
+    mpn: data.mpn || '',
     name: data.name || '',
     brand: data.brand || '',
     department: data.department || '',
@@ -116,19 +111,19 @@ function transformToVariant(data: Record<string, any>): Partial<Variant> {
 }
 
 /**
- * Group rows by product_id
+ * Group rows by MPN
  */
 function groupRowsByProduct(rows: ImportRow[]): Map<string, ImportRow[]> {
   const grouped = new Map<string, ImportRow[]>();
   
   for (const row of rows) {
-    const productId = row.data.product_id;
-    if (!productId) continue;
+    const mpn = row.data.mpn;
+    if (!mpn) continue;
     
-    if (!grouped.has(productId)) {
-      grouped.set(productId, []);
+    if (!grouped.has(mpn)) {
+      grouped.set(mpn, []);
     }
-    grouped.get(productId)!.push(row);
+    grouped.get(mpn)!.push(row);
   }
   
   return grouped;
@@ -148,7 +143,7 @@ export async function importToFirestore(
   };
   
   const BATCH_SIZE = 400;
-  const validatedRows: Array<{ row: ImportRow; productId: string }> = [];
+  const validatedRows: Array<{ row: ImportRow; mpn: string }> = [];
   
   // Validate all rows first
   for (const row of rows) {
@@ -162,28 +157,27 @@ export async function importToFirestore(
       });
       continue;
     }
-    // Use product_id if available, otherwise mpn
-    const productId = row.data.product_id || row.data.mpn;
-    validatedRows.push({ row, productId });
+    const mpn = row.data.mpn;
+    validatedRows.push({ row, mpn });
   }
   
-  // Group by product_id
+  // Group by MPN
   const groupedRows = new Map<string, ImportRow[]>();
-  for (const { row, productId } of validatedRows) {
-    if (!groupedRows.has(productId)) {
-      groupedRows.set(productId, []);
+  for (const { row, mpn } of validatedRows) {
+    if (!groupedRows.has(mpn)) {
+      groupedRows.set(mpn, []);
     }
-    groupedRows.get(productId)!.push(row);
+    groupedRows.get(mpn)!.push(row);
   }
   
   // Process in batches
   const allWrites: Array<() => Promise<void>> = [];
   
-  for (const [productId, productRows] of groupedRows) {
+  for (const [mpn, productRows] of groupedRows) {
     try {
       const firstRow = productRows[0];
       const productData = transformToProduct(firstRow.data);
-      const productRef = doc(db, 'products', productId);
+      const productRef = doc(db, 'products', mpn);
       
       // Add product write
       allWrites.push(async () => {
@@ -193,14 +187,14 @@ export async function importToFirestore(
       // Add variant writes
       for (const row of productRows) {
         const variant = transformToVariant(row.data);
-        const variantRef = doc(db, 'products', productId, 'variants', variant.sku!);
+        const variantRef = doc(db, 'products', mpn, 'variants', variant.sku!);
         allWrites.push(async () => {
           await setDoc(variantRef, variant);
         });
         result.imported++;
       }
     } catch (error) {
-      console.error(`Error preparing product ${productId}:`, error);
+      console.error(`Error preparing product ${mpn}:`, error);
       result.skipped += productRows.length;
       for (const row of productRows) {
         result.errors.push({


### PR DESCRIPTION
## Summary
**Breaking Change:** Simplifies the import system by making MPN the universal product identifier. Product ID is fully deprecated.

## Rationale
- Eliminates confusion between product_id and MPN fields
- Single source of truth for product identity
- Cleaner validation logic (one required field instead of OR logic)
- All legacy column names (product_id, style, style_id, etc.) now map to MPN

## Changes

### 1. Validation Simplification
**File:** `src/utils/firestoreImport.ts` - `validateProductRow()`
- **Old:** Required `product_id OR mpn`
- **New:** Requires `mpn` only
- Error message: "Missing required field: MPN"
- Still requires `sku` field

### 2. Product Transformation
**File:** `src/utils/firestoreImport.ts` - `transformToProduct()`
- **Old:** `id = data.product_id || data.mpn`
- **New:** `id = data.mpn`
- Simplified logic, no fallback needed
- MPN becomes the Firestore document ID

### 3. Grouping Logic
**File:** `src/utils/firestoreImport.ts` - `groupRowsByProduct()`
- Function now groups by `data.mpn` exclusively
- Renamed internal references from `productId` to `mpn` for clarity
- Updated function documentation

### 4. Import Execution
**File:** `src/utils/firestoreImport.ts` - `importToFirestore()`
- Batch processing uses MPN as product key
- Firestore document paths: `products/{mpn}/variants/{sku}`
- All references to `productId` replaced with `mpn`

### 5. CSV Parser Updates
**File:** `src/utils/csvParser.ts` - `HEADER_SYNONYMS`
- **Removed:** `product_id` key from synonyms
- **Updated:** MPN synonyms now include all legacy product ID terms
- MPN synonyms: `['mpn', 'model', 'mpn_code', 'manufacturer_part_number', 'product_id', 'style', 'style_id', 'styleid', 'parent_sku', 'style_code', 'product.id']`

### 6. Mapping UI
**File:** `src/components/MappingReview.tsx`
- **Removed:** "Product ID" option from Target Field dropdown
- MPN is now the first option after "Ignore"
- Simplified user experience (one less choice)

### 7. User Guidance
**File:** `src/pages/ImportPage.tsx`
- Updated helper text: **"Required: MPN and SKU"**
- Removed "(or MPN)" ambiguity

## Migration Impact

### ✅ **Backward Compatible CSV Columns**
All existing CSV columns auto-map to MPN:
- `product_id` → MPN
- `style` → MPN
- `style_id` / `styleid` → MPN
- `parent_sku` → MPN
- `style_code` → MPN
- `model` → MPN (already worked)
- `mpn` → MPN (of course)

### ⚠️ **Breaking Changes**
1. Manual mappings with "Product ID" target will need to use "MPN" instead
2. Any code expecting `product.id !== product.mpn` will need updates
3. Firestore document IDs will use MPN values going forward

### 📋 **Data Model**
- Product documents: `id` field = MPN value
- Product documents: `mpn` field = MPN value (same as id)
- No separate `product_id` field stored

## Testing Checklist
- ✅ CSV with `mpn` column imports correctly
- ✅ CSV with `product_id` column auto-maps to MPN
- ✅ CSV with `style` column auto-maps to MPN
- ✅ CSV with `model` column auto-maps to MPN
- ✅ Validation rejects rows missing MPN
- ✅ Firestore documents created with MPN as ID
- ✅ No TypeScript errors

## Rollback Plan
If needed, revert this PR and PR #13 to restore original `product_id` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CSV import now recognizes additional MPN field name variations (product_id, style, style_id, styleid, parent_sku, style_code, product.id) for automatic field mapping.
  * Removed Product ID option from the Target Field dropdown in mapping configuration.

* **Bug Fixes**
  * Updated import validation to enforce MPN as a required field with corresponding error messaging and documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->