### PR TITLE
Queues: read products from Firestore instead of mock

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,0 +1,57 @@
+/**
+ * Hook for reading products from Firestore
+ * Fetches products from /products collection
+ */
+
+import { useState, useEffect } from 'react';
+import { collection, getDocs, query } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { Product } from '../types';
+
+export type UseProductsResult = {
+  products: Product[];
+  loading: boolean;
+  error: string | null;
+};
+
+export function useProducts(): UseProductsResult {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const loadProducts = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const productsCollection = collection(db, 'products');
+      const productsQuery = query(productsCollection);
+      const querySnapshot = await getDocs(productsQuery);
+
+      const loadedProducts: Product[] = [];
+      querySnapshot.forEach((doc) => {
+        loadedProducts.push({
+          id: doc.id,
+          ...doc.data(),
+        } as Product);
+      });
+
+      setProducts(loadedProducts);
+    } catch (err) {
+      console.error('Error loading products:', err);
+      setError('Failed to load products from Firestore');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    products,
+    loading,
+    error,
+  };
+}

--- a/src/pages/CompleteQueuePage.tsx
+++ b/src/pages/CompleteQueuePage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useMockProductData, mockVocabulary } from '../mockData';
+import { mockVocabulary } from '../mockData';
 import { Product } from '../types';
 import Toast from '../components/Toast';
 import { exportProductsToCSV } from '../utils/csvExport';
+import { useProducts } from '../hooks/useProducts';
 
 type ToastState = {
   show: boolean;
@@ -11,7 +12,7 @@ type ToastState = {
 };
 
 const CompleteQueuePage: React.FC = () => {
-  const products = useMockProductData();
+  const { products, loading, error } = useProducts();
   const [selectedIds, setSelectedIds] = useState(new Set<string>());
   const [toast, setToast] = useState<ToastState>({ show: false, message: '', type: 'success' });
 
@@ -29,6 +30,12 @@ const CompleteQueuePage: React.FC = () => {
   const hideToast = () => {
     setToast({ ...toast, show: false });
   };
+
+  useEffect(() => {
+    if (error) {
+      showToast(error, 'error');
+    }
+  }, [error]);
 
   useEffect(() => {
     if (headerCheckboxRef.current) {
@@ -92,7 +99,7 @@ const CompleteQueuePage: React.FC = () => {
         <div>
           <h1 className="text-3xl font-bold text-gray-800">Complete Queue</h1>
           <p className="text-gray-600 mt-1">
-            {products.length} products ready for export.
+            {loading ? 'Loading...' : `${products.length} products ready for export.`}
           </p>
         </div>
         <button
@@ -128,54 +135,60 @@ const CompleteQueuePage: React.FC = () => {
           </select>
         </div>
       </div>
-      
-      <div className="overflow-x-auto bg-white rounded-lg shadow">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th scope="col" className="px-6 py-3">
-                <input
-                  ref={headerCheckboxRef}
-                  type="checkbox"
-                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
-                  onChange={handleSelectAll}
-                  checked={products.length > 0 && selectedIds.size === products.length}
-                />
-              </th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brand</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN / Style</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {products.map((product) => (
-              <tr key={product.id} className={`hover:bg-gray-50 ${selectedIds.has(product.id) ? 'bg-indigo-50' : ''}`}>
-                <td className="px-6 py-4">
-                   <input
+
+      {loading ? (
+        <div className="flex justify-center items-center py-12">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+        </div>
+      ) : (
+        <div className="overflow-x-auto bg-white rounded-lg shadow">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  <input
+                    ref={headerCheckboxRef}
                     type="checkbox"
                     className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
-                    checked={selectedIds.has(product.id)}
-                    onChange={(e) => handleSelectOne(e, product.id)}
-                   />
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{product.brand}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{product.name}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{product.mpn}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                      product.status === 'intake' ? 'bg-blue-100 text-blue-800' : 
-                      product.status === 'in-progress' ? 'bg-yellow-100 text-yellow-800' :
-                      product.status === 'validated' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
-                  }`}>
-                    {product.status}
-                  </span>
-                </td>
+                    onChange={handleSelectAll}
+                    checked={products.length > 0 && selectedIds.size === products.length}
+                  />
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brand</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN / Style</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {products.map((product) => (
+                <tr key={product.id} className={`hover:bg-gray-50 ${selectedIds.has(product.id) ? 'bg-indigo-50' : ''}`}>
+                  <td className="px-6 py-4">
+                     <input
+                      type="checkbox"
+                      className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+                      checked={selectedIds.has(product.id)}
+                      onChange={(e) => handleSelectOne(e, product.id)}
+                     />
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{product.brand}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{product.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{product.mpn}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                        product.status === 'intake' ? 'bg-blue-100 text-blue-800' : 
+                        product.status === 'in-progress' ? 'bg-yellow-100 text-yellow-800' :
+                        product.status === 'validated' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+                    }`}>
+                      {product.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {toast.show && (
         <Toast message={toast.message} type={toast.type} onClose={hideToast} />

--- a/src/pages/IntakeQueuePage.tsx
+++ b/src/pages/IntakeQueuePage.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
-import { useMockProductData, mockVocabulary } from '../mockData';
+import { mockVocabulary } from '../mockData';
 import { Product } from '../types';
 import ProductEditorDrawer from '../components/ProductEditorDrawer';
+import { useProducts } from '../hooks/useProducts';
+import Toast from '../components/Toast';
 
 const IntakeQueuePage: React.FC = () => {
-  const products = useMockProductData();
+  const { products, loading, error } = useProducts();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [showErrorToast, setShowErrorToast] = useState(false);
 
   // State for the new filters
   const [statusFilter, setStatusFilter] = useState('all');
@@ -23,6 +26,13 @@ const IntakeQueuePage: React.FC = () => {
     setSelectedProduct(null); // Clear selection on close
   };
 
+  // Show error toast if there's an error
+  React.useEffect(() => {
+    if (error) {
+      setShowErrorToast(true);
+    }
+  }, [error]);
+
   // Prepare data for the filter dropdowns
   const uniqueBrands = [...new Set(products.map(p => p.brand))];
   const departments = mockVocabulary.departments;
@@ -33,7 +43,7 @@ const IntakeQueuePage: React.FC = () => {
       <header className="mb-6">
         <h1 className="text-3xl font-bold text-gray-800">Intake Queue</h1>
         <p className="text-gray-600 mt-1">
-          {products.length} products waiting for processing.
+          {loading ? 'Loading...' : `${products.length} products waiting for processing.`}
         </p>
       </header>
 
@@ -94,8 +104,16 @@ const IntakeQueuePage: React.FC = () => {
         </div>
       </div>
       
-      <div className="overflow-x-auto bg-white rounded-lg shadow">
-        <table className="min-w-full divide-y divide-gray-200">
+      {loading ? (
+        <div className="bg-white rounded-lg shadow p-12">
+          <div className="flex items-center justify-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+          </div>
+          <p className="text-center text-gray-600 mt-4">Loading products...</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto bg-white rounded-lg shadow">
+          <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brand</th>
@@ -134,13 +152,22 @@ const IntakeQueuePage: React.FC = () => {
             ))}
           </tbody>
         </table>
-      </div>
+        </div>
+      )}
 
       <ProductEditorDrawer 
         isOpen={isDrawerOpen}
         onClose={handleCloseDrawer}
         product={selectedProduct}
       />
+
+      {showErrorToast && error && (
+        <Toast 
+          message={error} 
+          type="error" 
+          onClose={() => setShowErrorToast(false)} 
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product queue pages now load live data from the database, replacing static mock data
  * Loading spinners and status text provide feedback while data is being retrieved
  * Error toast notifications automatically appear if data loading encounters issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->