### PR TITLE
Firebase: long-polling transport + prod guard + DevTools handle

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp, getApp, getApps, type FirebaseOptions } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { initializeFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 
 // Build config from Vite env with sensible defaults for project ropi-bccee
@@ -23,13 +23,31 @@ const firebaseConfig: FirebaseOptions = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
+// Production guard: warn if running prod build with demo credentials
+if (import.meta.env.PROD && (!firebaseConfig.apiKey || firebaseConfig.apiKey === 'demo-api-key')) {
+  console.error('[ROPI] Missing/invalid VITE_FIREBASE_API_KEY at build time.');
+}
+
 // Initialize (idempotent across HMR)
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
 // Modular exports
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
-const db = getFirestore(app);
+const db = initializeFirestore(app, {
+  experimentalForceLongPolling: true,
+  useFetchStreams: false,
+} as any);
 const storage = getStorage(app);
+
+// Expose debug handle for DevTools inspection
+if (typeof window !== 'undefined') {
+  (window as any).__ROPI = {
+    app,
+    auth,
+    db,
+    options: (app as any).options,
+  };
+}
 
 export { app, auth, provider, db, storage };


### PR DESCRIPTION
## Problem
Running Firestore in dev containers or restrictive network environments can fail with WebChannel/gRPC transport errors.

## Solution
1. **Long-polling transport**: Use `initializeFirestore` with `experimentalForceLongPolling: true` and `useFetchStreams: false` for better compatibility
2. **Production guard**: Add console error when running prod builds with demo/missing Firebase API keys
3. **DevTools handle**: Expose `window.__ROPI` with app, auth, db, and options for easier debugging

## Changes
**File**: `src/firebase.ts`
- Replace `getFirestore()` with `initializeFirestore()`
- Add long-polling configuration for Firestore
- Add production credential validation before app initialization
- Expose debug handle on window object for DevTools access

## Testing
- [ ] Verify Firestore reads/writes work in dev container
- [ ] Check that `window.__ROPI` is accessible in browser console
- [ ] Confirm production build shows error if VITE_FIREBASE_API_KEY is missing
- [ ] Test that Firebase operations work correctly with long-polling transport

## Benefits
- ✅ Fixes Firestore connection issues in restrictive environments
- ✅ Better debugging experience with exposed Firebase instances
- ✅ Early warning for production misconfigurations
- ✅ No breaking changes to existing functionality

## DevTools Usage
After this change, you can inspect Firebase state in the browser console:
```javascript
// Check Firebase configuration
window.__ROPI.options

// Access Firebase instances
window.__ROPI.app
window.__ROPI.auth
window.__ROPI.db
```