### PR TITLE
Settings: show error on Firestore read failure

### DIFF
--- a/src/hooks/useAttributesSettings.ts
+++ b/src/hooks/useAttributesSettings.ts
@@ -120,9 +120,11 @@ export function useAttributesSettings() {
         await setDoc(docRef, INITIAL_ATTRIBUTES);
         setData(INITIAL_ATTRIBUTES);
       }
-    } catch (err) {
-      console.error('Error loading attributes:', err);
-      setError('Failed to load attributes');
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      const errorMessage = err?.message || 'Unknown error';
+      console.error('[settings] load failed', errorCode, errorMessage);
+      setError(`Could not load settings (${errorCode})`);
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -41,9 +41,11 @@ export function useProducts(): UseProductsResult {
       });
 
       setProducts(loadedProducts);
-    } catch (err) {
-      console.error('Error loading products:', err);
-      setError('Failed to load products from Firestore');
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      const errorMessage = err?.message || 'Unknown error';
+      console.error('[products] load failed', errorCode, errorMessage);
+      setError(`Could not load products (${errorCode})`);
     } finally {
       setLoading(false);
     }

--- a/src/pages/IntakeQueuePage.tsx
+++ b/src/pages/IntakeQueuePage.tsx
@@ -104,7 +104,30 @@ const IntakeQueuePage: React.FC = () => {
         </div>
       </div>
       
-      {loading ? (
+      {error ? (
+        <div className="bg-white rounded-lg shadow p-12">
+          <div className="bg-red-50 border border-red-200 rounded-md p-6 max-w-2xl mx-auto">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <svg className="h-6 w-6 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">
+                  Failed to load products
+                </h3>
+                <p className="text-sm text-red-700 mt-2">
+                  {error}
+                </p>
+                <p className="text-sm text-red-600 mt-2">
+                  Please check your connection and try refreshing the page.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : loading ? (
         <div className="bg-white rounded-lg shadow p-12">
           <div className="flex items-center justify-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -176,7 +176,32 @@ const SettingsPage: React.FC = () => {
       <div className="bg-white p-6 rounded-lg shadow">
         <h3 className="text-lg font-semibold text-gray-800 mb-4">{title}</h3>
         
-        {attributes.loading ? (
+        {attributes.error ? (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">
+                  Failed to load {title}
+                </h3>
+                <p className="text-sm text-red-700 mt-1">
+                  {attributes.error}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => attributes.reload()}
+                  className="mt-2 text-sm font-medium text-red-600 hover:text-red-500"
+                >
+                  Try again
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : attributes.loading ? (
           <div className="h-48 flex items-center justify-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
           </div>

--- a/src/pages/settings/AISettingsTab.tsx
+++ b/src/pages/settings/AISettingsTab.tsx
@@ -36,9 +36,11 @@ const AISettingsTab: React.FC<AISettingsTabProps> = ({ onShowToast }) => {
       if (docSnap.exists()) {
         setSettings(docSnap.data() as AISettings);
       }
-    } catch (error) {
-      console.error('Error loading AI settings:', error);
-      onShowToast('Failed to load AI settings', 'error');
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      const errorMessage = err?.message || 'Unknown error';
+      console.error('[settings] load failed', errorCode, errorMessage);
+      onShowToast(`Could not load AI settings (${errorCode})`, 'error');
     } finally {
       setLoading(false);
     }

--- a/src/pages/settings/VocabSettingsTab.tsx
+++ b/src/pages/settings/VocabSettingsTab.tsx
@@ -35,9 +35,11 @@ const VocabSettingsTab: React.FC<VocabSettingsTabProps> = ({ onShowToast }) => {
       if (docSnap.exists()) {
         setSettings(docSnap.data() as VocabSettings);
       }
-    } catch (error) {
-      console.error('Error loading vocabulary settings:', error);
-      onShowToast('Failed to load vocabulary settings', 'error');
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      const errorMessage = err?.message || 'Unknown error';
+      console.error('[settings] load failed', errorCode, errorMessage);
+      onShowToast(`Could not load vocabulary settings (${errorCode})`, 'error');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Problem
When Firestore read operations fail (network issues, permissions, etc.), the UI shows a loading spinner indefinitely or crashes without helpful feedback to users or developers.

## Solution
1. **Structured console logging**: All Firestore read failures now log with `console.error('[settings] load failed', errorCode, errorMessage)`
2. **Error UI instead of spinners**: Replace infinite loading spinners with clear error states showing:
   - Red alert box with error icon
   - Error message including Firestore error code (e.g., `permission-denied`, `unavailable`)
   - Retry button for Settings vocab editors
   - Helpful guidance text for users
3. **Toast notifications**: Settings tabs show toast messages with error codes

## Changes Made

### Hooks
- **`src/hooks/useAttributesSettings.ts`**: 
  - Changed error logging to `console.error('[settings] load failed', code, message)`
  - Error state now includes Firestore error code: `Could not load settings (code)`
  
- **`src/hooks/useProducts.ts`**:
  - Changed error logging to `console.error('[products] load failed', code, message)`
  - Error state includes code: `Could not load products (code)`

### Pages
- **`src/pages/SettingsPage.tsx`**:
  - Added error UI before loading check in VocabEditor component
  - Shows red alert box with error icon, message, and "Try again" button
  - Empty-state error instead of infinite spinner
  
- **`src/pages/IntakeQueuePage.tsx`**:
  - Added error state check before loading check
  - Displays centered error message with helpful guidance
  - No more infinite spinner on errors
  
- **`src/pages/settings/AISettingsTab.tsx`**:
  - Updated error logging format
  - Toast message includes error code: `Could not load AI settings (code)`
  
- **`src/pages/settings/VocabSettingsTab.tsx`**:
  - Updated error logging format
  - Toast message includes error code: `Could not load vocabulary settings (code)`

## Testing Checklist
- [ ] Test with Firestore offline (disable network in DevTools)
- [ ] Verify console logs show `[settings] load failed` with error code and message
- [ ] Confirm error UI appears instead of spinner
- [ ] Test retry button in Settings vocab editors
- [ ] Verify toast notifications appear with error codes for AI/Vocab tabs
- [ ] Check that error messages are user-friendly
- [ ] Test with permission-denied scenario (if applicable)

## Benefits
- ✅ Better debugging with structured, searchable console logs
- ✅ Clear user feedback when operations fail
- ✅ Actionable retry options for transient failures
- ✅ No more infinite loading spinners on errors
- ✅ Error codes help identify specific Firestore issues (permissions, network, etc.)

## Example Error Logs
```
[settings] load failed permission-denied Missing or insufficient permissions
[products] load failed unavailable Failed to get document because the client is offline
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging throughout the app to include specific error codes for easier troubleshooting.
  * Fixed error state display priority so errors are now shown clearly instead of being masked by loading indicators.
  * Enhanced error visibility in products loading, settings, and queue pages with more descriptive user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->