### PR TITLE
Export: Add settings + CSV exporter for validated products

### DIFF
--- a/src/components/ProductEditorDrawer.tsx
+++ b/src/components/ProductEditorDrawer.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, ChangeEvent } from 'react';
 import { Product } from '../types';
 import { mockGenerateDescription } from '../services/mockAIService';
 import { mockVocabulary } from '../mockData';
+import { db } from '../firebase';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 
 interface ProductEditorDrawerProps {
   isOpen: boolean;
@@ -10,6 +12,17 @@ interface ProductEditorDrawerProps {
 }
 
 type ActiveTab = 'core' | 'context' | 'generation' | 'variants' | 'history';
+
+// Helper to clean data for Firestore
+function cleanForFirestore<T extends Record<string, any>>(obj: T): Partial<T> {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;                              // omit undefined (Firestore rejects it)
+    if (typeof v === 'string' && v.trim() === '') out[k] = null; // empty -> null
+    else out[k] = v;
+  }
+  return out as Partial<T>;
+}
 
 // Mock history data for the new tab
 const mockHistory = [
@@ -29,6 +42,33 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
     setActiveTab('core');
     setAiScore(null); // Reset score when product changes
   }, [product]);
+
+  const saveFromForm = async (e: React.FormEvent<HTMLFormElement>, extra: Record<string, any> = {}) => {
+    e.preventDefault();
+    if (!product) return;
+    const fd = new FormData(e.currentTarget);
+    const get = (k: string) => (fd.get(k) as string | null) ?? null;
+
+    const payload = cleanForFirestore({
+      name: get('name'),
+      brand: get('brand'),
+      mpn: get('mpn'),
+      status: get('status') || product.status,
+      department: get('department'),
+      class: get('class'),
+      category: get('category'),
+      ageGroup: get('ageGroup'),
+      gender: get('gender'),
+      website: get('website'),
+      league: get('league'),
+      sportsTeam: get('sportsTeam'),
+      updatedAt: serverTimestamp(),
+      ...extra,
+    });
+
+    await setDoc(doc(db, 'products', product.id), payload, { merge: true });
+    onClose(); // close drawer
+  };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     if (!editableProduct) return;
@@ -156,7 +196,7 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
         <div className="absolute inset-0 bg-gray-500 bg-opacity-75" onClick={onClose} aria-hidden="true"></div>
         <section className="absolute inset-y-0 right-0 pl-10 max-w-full flex">
           <div className={`w-screen max-w-3xl ${drawerPanelClasses}`}>
-            <form className="h-full flex flex-col bg-white shadow-xl">
+            <form className="h-full flex flex-col bg-white shadow-xl" onSubmit={(e) => saveFromForm(e)}>
               <header className="p-4 bg-gray-50 border-b border-gray-200">
                 <div className="flex items-start justify-between">
                     <div>
@@ -274,7 +314,21 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                         <FormField label="Generated Bullets"><ul className="p-2 pl-6 bg-gray-100 rounded-md min-h-[80px] list-disc space-y-1">{editableProduct.marketing.bullets.map((bullet, i) => <li key={i}>{bullet}</li>)}</ul></FormField>
                         <FormField label="Generated SEO Description"><div className="p-2 bg-gray-100 rounded-md min-h-[60px]">{editableProduct.marketing.seo}</div></FormField>
                         <FormField label="Generated Paragraph Draft"><div className="p-2 bg-gray-100 rounded-md min-h-[120px] whitespace-pre-wrap">{editableProduct.marketing.paragraphDraft}</div></FormField>
-                        <div className="flex justify-end pt-4"><button type="button" className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700">Approve</button></div>
+                        <div className="flex justify-end pt-4">
+                          <button 
+                            type="button" 
+                            onClick={(e) => {
+                              const form = (e.currentTarget as HTMLButtonElement).closest('form')!;
+                              saveFromForm({ preventDefault(){}, currentTarget: form } as any, {
+                                status: 'validated',
+                                validatedAt: serverTimestamp(),
+                              });
+                            }}
+                            className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700"
+                          >
+                            Approve
+                          </button>
+                        </div>
                     </div>
                 )}
                 {activeTab === 'variants' && (

--- a/src/pages/IntakeQueuePage.tsx
+++ b/src/pages/IntakeQueuePage.tsx
@@ -4,12 +4,15 @@ import { Product } from '../types';
 import ProductEditorDrawer from '../components/ProductEditorDrawer';
 import { useProducts } from '../hooks/useProducts';
 import Toast from '../components/Toast';
+import { exportAndDownload } from '../utils/exporter';
 
 const IntakeQueuePage: React.FC = () => {
   const { products, loading, error } = useProducts();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [showErrorToast, setShowErrorToast] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportMessage, setExportMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null);
 
   // State for the new filters
   const [statusFilter, setStatusFilter] = useState('all');
@@ -33,6 +36,44 @@ const IntakeQueuePage: React.FC = () => {
     }
   }, [error]);
 
+  // Handle CSV export
+  const handleExport = async () => {
+    try {
+      setIsExporting(true);
+      setExportMessage(null);
+      
+      const { successCount, errorCount } = await exportAndDownload();
+      
+      if (successCount > 0 && errorCount === 0) {
+        setExportMessage({
+          text: `Successfully exported ${successCount} row(s)`,
+          type: 'success',
+        });
+      } else if (successCount > 0 && errorCount > 0) {
+        setExportMessage({
+          text: `Exported ${successCount} row(s). ${errorCount} product(s) had errors (see error CSV)`,
+          type: 'success',
+        });
+      } else if (errorCount > 0) {
+        setExportMessage({
+          text: `Export failed: ${errorCount} product(s) missing required fields (see error CSV)`,
+          type: 'error',
+        });
+      }
+    } catch (err: any) {
+      console.error('[intake] export failed', err);
+      setExportMessage({
+        text: err.message || 'Failed to export products',
+        type: 'error',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  // Count validated products
+  const validatedCount = products.filter(p => p.status === 'validated').length;
+
   // Prepare data for the filter dropdowns
   const uniqueBrands = [...new Set(products.map(p => p.brand))];
   const departments = mockVocabulary.departments;
@@ -40,11 +81,31 @@ const IntakeQueuePage: React.FC = () => {
 
   return (
     <div>
-      <header className="mb-6">
-        <h1 className="text-3xl font-bold text-gray-800">Intake Queue</h1>
-        <p className="text-gray-600 mt-1">
-          {loading ? 'Loading...' : `${products.length} products waiting for processing.`}
-        </p>
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-800">Intake Queue</h1>
+          <p className="text-gray-600 mt-1">
+            {loading ? 'Loading...' : `${products.length} products waiting for processing.`}
+          </p>
+        </div>
+        <button
+          onClick={handleExport}
+          disabled={isExporting || loading || validatedCount === 0}
+          className="px-4 py-2 bg-green-600 text-white font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          title={validatedCount === 0 ? 'No validated products to export' : 'Export validated products to CSV'}
+        >
+          {isExporting ? (
+            <>
+              <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Exporting...
+            </>
+          ) : (
+            <>📥 Export CSV ({validatedCount})</>
+          )}
+        </button>
       </header>
 
       {/* Filter Bar */}
@@ -189,6 +250,14 @@ const IntakeQueuePage: React.FC = () => {
           message={error} 
           type="error" 
           onClose={() => setShowErrorToast(false)} 
+        />
+      )}
+
+      {exportMessage && (
+        <Toast 
+          message={exportMessage.text} 
+          type={exportMessage.type} 
+          onClose={() => setExportMessage(null)} 
         />
       )}
     </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ChangeEvent } from 'react';
 import AISettingsTab from './settings/AISettingsTab';
 import VocabSettingsTab from './settings/VocabSettingsTab';
+import ExportSettingsTab from './settings/ExportSettingsTab';
 import Toast from '../components/Toast';
 import { useAttributesSettings, type AttributeKey } from '../hooks/useAttributesSettings';
 import { useAuth } from '../contexts/AuthContext';
@@ -379,7 +380,7 @@ const SettingsPage: React.FC = () => {
         )}
         {activeTab === 'prompts' && <PlaceholderTab title="Manage AI Prompts" />}
         {activeTab === 'brands' && <PlaceholderTab title="Manage Brands" />}
-        {activeTab === 'export' && <PlaceholderTab title="Manage Export Settings" />}
+        {activeTab === 'export' && <ExportSettingsTab onShowToast={showToast} />}
       </main>
 
       {toast.show && (

--- a/src/pages/settings/ExportSettingsTab.tsx
+++ b/src/pages/settings/ExportSettingsTab.tsx
@@ -1,0 +1,285 @@
+import React, { useState, useEffect } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+
+type ColumnMapping = {
+  exportName: string;
+  productField: string;
+  required: boolean;
+};
+
+type ExportSettings = {
+  requiredFields: string[];
+  columnMappings: ColumnMapping[];
+  includeAIEnrichment: boolean;
+};
+
+const DEFAULT_SETTINGS: ExportSettings = {
+  requiredFields: ['mpn', 'name', 'brand', 'department'],
+  columnMappings: [
+    { exportName: 'MPN', productField: 'mpn', required: true },
+    { exportName: 'Product Name', productField: 'name', required: true },
+    { exportName: 'Brand', productField: 'brand', required: true },
+    { exportName: 'Department', productField: 'department', required: true },
+    { exportName: 'Class', productField: 'class', required: false },
+    { exportName: 'Category', productField: 'category', required: false },
+    { exportName: 'Age Group', productField: 'ageGroup', required: false },
+    { exportName: 'Gender', productField: 'gender', required: false },
+    { exportName: 'Material/Fabric', productField: 'materialFabric', required: false },
+    { exportName: 'Fit', productField: 'fit', required: false },
+    { exportName: 'Sports Team', productField: 'sportsTeam', required: false },
+    { exportName: 'League', productField: 'league', required: false },
+    { exportName: 'Websites', productField: 'websites', required: false },
+    { exportName: 'SKU', productField: 'variants[].sku', required: false },
+    { exportName: 'Size', productField: 'variants[].size', required: false },
+    { exportName: 'Color', productField: 'variants[].color', required: false },
+    { exportName: 'Price', productField: 'variants[].price', required: false },
+  ],
+  includeAIEnrichment: true,
+};
+
+type ExportSettingsTabProps = {
+  onShowToast: (message: string, type: 'success' | 'error') => void;
+};
+
+const ExportSettingsTab: React.FC<ExportSettingsTabProps> = ({ onShowToast }) => {
+  const [settings, setSettings] = useState<ExportSettings>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    try {
+      setLoading(true);
+      const docRef = doc(db, 'settings', 'export');
+      const docSnap = await getDoc(docRef);
+      
+      if (docSnap.exists()) {
+        setSettings(docSnap.data() as ExportSettings);
+      } else {
+        // Initialize with defaults if not exists
+        setSettings(DEFAULT_SETTINGS);
+      }
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      const errorMessage = err?.message || 'Unknown error';
+      console.error('[settings] export load failed', errorCode, errorMessage);
+      onShowToast(`Could not load export settings (${errorCode})`, 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      const docRef = doc(db, 'settings', 'export');
+      await setDoc(docRef, settings);
+      onShowToast('Export settings saved successfully', 'success');
+    } catch (err: any) {
+      const errorCode = err?.code || 'unknown';
+      console.error('[settings] export save failed', errorCode, err?.message);
+      onShowToast(`Failed to save export settings (${errorCode})`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleRequired = (index: number) => {
+    const newMappings = [...settings.columnMappings];
+    newMappings[index].required = !newMappings[index].required;
+    
+    // Update requiredFields array
+    const field = newMappings[index].productField;
+    const requiredFields = newMappings[index].required
+      ? [...settings.requiredFields, field]
+      : settings.requiredFields.filter(f => f !== field);
+    
+    setSettings({
+      ...settings,
+      columnMappings: newMappings,
+      requiredFields,
+    });
+  };
+
+  const updateMapping = (index: number, field: 'exportName' | 'productField', value: string) => {
+    const newMappings = [...settings.columnMappings];
+    newMappings[index][field] = value;
+    setSettings({ ...settings, columnMappings: newMappings });
+  };
+
+  const addMapping = () => {
+    setSettings({
+      ...settings,
+      columnMappings: [
+        ...settings.columnMappings,
+        { exportName: '', productField: '', required: false },
+      ],
+    });
+  };
+
+  const removeMapping = (index: number) => {
+    const mapping = settings.columnMappings[index];
+    const newMappings = settings.columnMappings.filter((_, i) => i !== index);
+    const requiredFields = settings.requiredFields.filter(f => f !== mapping.productField);
+    
+    setSettings({
+      ...settings,
+      columnMappings: newMappings,
+      requiredFields,
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white p-6 rounded-lg shadow">
+        <div className="animate-pulse">
+          <div className="h-4 bg-gray-200 rounded w-1/4 mb-4"></div>
+          <div className="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow">
+      <h2 className="text-2xl font-bold text-gray-800 mb-6">Export Settings</h2>
+      
+      <div className="space-y-6">
+        {/* Include AI Enrichment Toggle */}
+        <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+          <div>
+            <label htmlFor="includeAIEnrichment" className="block text-sm font-medium text-gray-700">
+              Include AI Enrichment
+            </label>
+            <p className="text-xs text-gray-500 mt-1">
+              Export AI-generated marketing content (title, bullets, SEO, paragraphs)
+            </p>
+          </div>
+          <input
+            type="checkbox"
+            id="includeAIEnrichment"
+            checked={settings.includeAIEnrichment}
+            onChange={(e) => setSettings({ ...settings, includeAIEnrichment: e.target.checked })}
+            className="h-5 w-5 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+          />
+        </div>
+
+        {/* Column Mappings */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-800">Column Mappings</h3>
+            <button
+              onClick={addMapping}
+              className="px-3 py-1 text-sm bg-indigo-600 text-white font-medium rounded hover:bg-indigo-700"
+            >
+              + Add Column
+            </button>
+          </div>
+
+          <div className="overflow-x-auto border rounded-lg">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Export Column Name
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Product Field
+                  </th>
+                  <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Required
+                  </th>
+                  <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {settings.columnMappings.map((mapping, index) => (
+                  <tr key={index} className="hover:bg-gray-50">
+                    <td className="px-4 py-3">
+                      <input
+                        type="text"
+                        value={mapping.exportName}
+                        onChange={(e) => updateMapping(index, 'exportName', e.target.value)}
+                        className="w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+                        placeholder="Column name in CSV"
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <input
+                        type="text"
+                        value={mapping.productField}
+                        onChange={(e) => updateMapping(index, 'productField', e.target.value)}
+                        className="w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm font-mono"
+                        placeholder="e.g. mpn, brand, variants[].sku"
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <input
+                        type="checkbox"
+                        checked={mapping.required}
+                        onChange={() => toggleRequired(index)}
+                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <button
+                        onClick={() => removeMapping(index)}
+                        className="text-red-600 hover:text-red-800 font-bold text-lg"
+                        title="Remove mapping"
+                      >
+                        ×
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-xs text-gray-500 mt-2">
+            <strong>Tip:</strong> Use <code className="bg-gray-100 px-1 rounded">variants[]</code> notation 
+            to export variant-level fields (e.g., <code className="bg-gray-100 px-1 rounded">variants[].sku</code>). 
+            Each variant will create a separate row in the export.
+          </p>
+        </div>
+
+        {/* Required Fields Summary */}
+        <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+          <h4 className="text-sm font-semibold text-blue-900 mb-2">Required Fields Summary</h4>
+          <p className="text-sm text-blue-800">
+            {settings.requiredFields.length === 0 ? (
+              <span className="italic">No required fields</span>
+            ) : (
+              <span>
+                Products missing these fields will be exported to an error CSV: {' '}
+                <code className="bg-blue-100 px-1 rounded font-mono text-xs">
+                  {settings.requiredFields.join(', ')}
+                </code>
+              </span>
+            )}
+          </p>
+        </div>
+
+        {/* Save Button */}
+        <div className="pt-4">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-6 py-2 bg-indigo-600 text-white font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving...' : 'Save Export Settings'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportSettingsTab;

--- a/src/utils/exporter.ts
+++ b/src/utils/exporter.ts
@@ -1,0 +1,274 @@
+import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { Product, Variant } from '../types';
+
+type ColumnMapping = {
+  exportName: string;
+  productField: string;
+  required: boolean;
+};
+
+type ExportSettings = {
+  requiredFields: string[];
+  columnMappings: ColumnMapping[];
+  includeAIEnrichment: boolean;
+};
+
+type ExportResult = {
+  successCsv: string;
+  errorCsv: string;
+  successCount: number;
+  errorCount: number;
+};
+
+/**
+ * Get a nested field value from an object using dot notation
+ * e.g., getNestedValue(product, 'brand') or getNestedValue(product, 'marketing.title')
+ */
+function getNestedValue(obj: any, path: string): any {
+  const keys = path.split('.');
+  let value = obj;
+  
+  for (const key of keys) {
+    if (value === null || value === undefined) return null;
+    value = value[key];
+  }
+  
+  return value ?? null;
+}
+
+/**
+ * Escape CSV value - wrap in quotes if contains comma, quote, or newline
+ */
+function escapeCsvValue(value: any): string {
+  if (value === null || value === undefined) return '';
+  
+  const str = String(value);
+  
+  // If contains comma, quote, or newline, wrap in quotes and escape internal quotes
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  
+  return str;
+}
+
+/**
+ * Check if a product has all required fields
+ */
+function hasRequiredFields(product: Product, requiredFields: string[]): { valid: boolean; missing: string[] } {
+  const missing: string[] = [];
+  
+  for (const field of requiredFields) {
+    // Handle variant fields specially
+    if (field.startsWith('variants[].')) {
+      const variantField = field.replace('variants[].', '');
+      const hasField = product.variants.every(v => {
+        const val = getNestedValue(v, variantField);
+        return val !== null && val !== undefined && val !== '';
+      });
+      if (!hasField) missing.push(field);
+    } else {
+      const value = getNestedValue(product, field);
+      if (value === null || value === undefined || value === '') {
+        missing.push(field);
+      }
+    }
+  }
+  
+  return { valid: missing.length === 0, missing };
+}
+
+/**
+ * Expand a product with variants into multiple rows (one per variant)
+ */
+function expandProductRows(product: Product, mappings: ColumnMapping[], includeAI: boolean): Record<string, any>[] {
+  if (!product.variants || product.variants.length === 0) {
+    // No variants - return single row with product data
+    return [buildRow(product, null, mappings, includeAI)];
+  }
+  
+  // Multiple variants - return one row per variant
+  return product.variants.map(variant => buildRow(product, variant, mappings, includeAI));
+}
+
+/**
+ * Build a single row from product + optional variant
+ */
+function buildRow(
+  product: Product,
+  variant: Variant | null,
+  mappings: ColumnMapping[],
+  includeAI: boolean
+): Record<string, any> {
+  const row: Record<string, any> = {};
+  
+  for (const mapping of mappings) {
+    let value: any = null;
+    
+    // Handle variant fields
+    if (mapping.productField.startsWith('variants[].')) {
+      if (variant) {
+        const variantField = mapping.productField.replace('variants[].', '');
+        value = getNestedValue(variant, variantField);
+      }
+    } else {
+      // Regular product field
+      value = getNestedValue(product, mapping.productField);
+    }
+    
+    // Handle arrays (e.g., websites, keywords)
+    if (Array.isArray(value)) {
+      value = value.join('; ');
+    }
+    
+    row[mapping.exportName] = value;
+  }
+  
+  // Add AI enrichment fields if enabled
+  if (includeAI && product.marketing) {
+    row['AI Title'] = product.marketing.title || '';
+    row['AI Bullets'] = Array.isArray(product.marketing.bullets) 
+      ? product.marketing.bullets.join(' | ') 
+      : '';
+    row['AI SEO'] = product.marketing.seo || '';
+    row['AI Paragraph Draft'] = product.marketing.paragraphDraft || '';
+    row['AI Paragraph Final'] = product.marketing.paragraphFinal || '';
+  }
+  
+  return row;
+}
+
+/**
+ * Convert rows to CSV string
+ */
+function rowsToCsv(rows: Record<string, any>[]): string {
+  if (rows.length === 0) return '';
+  
+  // Get all unique column names
+  const columns = Array.from(new Set(rows.flatMap(r => Object.keys(r))));
+  
+  // Build CSV
+  const lines: string[] = [];
+  
+  // Header
+  lines.push(columns.map(escapeCsvValue).join(','));
+  
+  // Data rows
+  for (const row of rows) {
+    const values = columns.map(col => escapeCsvValue(row[col]));
+    lines.push(values.join(','));
+  }
+  
+  return lines.join('\n');
+}
+
+/**
+ * Fetch validated products and export to CSV based on settings
+ */
+export async function exportValidatedProducts(): Promise<ExportResult> {
+  try {
+    // Load export settings
+    const settingsRef = doc(db, 'settings', 'export');
+    const settingsSnap = await getDoc(settingsRef);
+    
+    if (!settingsSnap.exists()) {
+      throw new Error('Export settings not found. Please configure export settings first.');
+    }
+    
+    const settings = settingsSnap.data() as ExportSettings;
+    
+    // Fetch all validated products
+    const productsRef = collection(db, 'products');
+    const q = query(productsRef, where('status', '==', 'validated'));
+    const snapshot = await getDocs(q);
+    
+    if (snapshot.empty) {
+      throw new Error('No validated products found to export.');
+    }
+    
+    const products = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Product));
+    
+    // Separate products into success and error buckets
+    const successRows: Record<string, any>[] = [];
+    const errorRows: Record<string, any>[] = [];
+    
+    for (const product of products) {
+      const { valid, missing } = hasRequiredFields(product, settings.requiredFields);
+      
+      if (valid) {
+        // Expand product into rows (one per variant)
+        const rows = expandProductRows(product, settings.columnMappings, settings.includeAIEnrichment);
+        successRows.push(...rows);
+      } else {
+        // Add to error CSV with missing fields info
+        const errorRow = {
+          'Product ID': product.id,
+          'MPN': product.mpn || '',
+          'Name': product.name || '',
+          'Brand': product.brand || '',
+          'Missing Fields': missing.join(', '),
+          'Status': product.status,
+        };
+        errorRows.push(errorRow);
+      }
+    }
+    
+    // Generate CSV strings
+    const successCsv = rowsToCsv(successRows);
+    const errorCsv = rowsToCsv(errorRows);
+    
+    return {
+      successCsv,
+      errorCsv,
+      successCount: successRows.length,
+      errorCount: errorRows.length,
+    };
+  } catch (error) {
+    console.error('[exporter] export failed', error);
+    throw error;
+  }
+}
+
+/**
+ * Download CSV file to browser
+ */
+export function downloadCsv(csvContent: string, filename: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+  
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+  
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Main export function - exports validated products and triggers downloads
+ */
+export async function exportAndDownload(): Promise<{ successCount: number; errorCount: number }> {
+  const result = await exportValidatedProducts();
+  
+  // Download success CSV if any
+  if (result.successCount > 0) {
+    const timestamp = new Date().toISOString().split('T')[0];
+    downloadCsv(result.successCsv, `validated-products-${timestamp}.csv`);
+  }
+  
+  // Download error CSV if any
+  if (result.errorCount > 0) {
+    const timestamp = new Date().toISOString().split('T')[0];
+    downloadCsv(result.errorCsv, `export-errors-${timestamp}.csv`);
+  }
+  
+  return {
+    successCount: result.successCount,
+    errorCount: result.errorCount,
+  };
+}


### PR DESCRIPTION
Adds comprehensive export functionality for validated products:

**Export Settings Tab** (Settings page):
- Configure required fields for export validation
- Define column mappings (export column name → product field)
- Toggle AI enrichment inclusion (marketing content)
- Saves settings to Firestore (settings/export)

**CSV Exporter** (src/utils/exporter.ts):
- Fetches all products with status='validated'
- Validates products have required fields
- Expands variants into separate rows
- Generates RetailOps-compatible CSV
- Creates error CSV for products missing required fields
- Handles nested fields and arrays

**Export Button** (Intake Queue page):
- Shows count of validated products
- Disabled when no validated products exist
- Disabled while exporting (shows spinner)
- Downloads success CSV and error CSV (if applicable)
- Shows toast notifications with export results

Column mapping supports variant expansion using `variants[].fieldName` notation (e.g., `variants[].sku` creates one row per variant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product changes now auto-save to database when form is submitted.
  * Approve button marks products as validated.
  * CSV export for validated products with configurable column mappings and required fields.
  * Export settings tab to customize exports, including AI enrichment toggle.
  * Real-time export status indicators and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->