### PR TITLE
UX: Controlled inputs + prevent enter submit + optimistic list refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "build:functions": "npm --prefix functions run build"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.21.0",
     "firebase": "^12.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^6.25.1",
-    "@google/generative-ai": "^0.21.0"
+    "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/src/components/ProductEditorDrawer.tsx
+++ b/src/components/ProductEditorDrawer.tsx
@@ -11,6 +11,7 @@ interface ProductEditorDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   product: Product | null;
+  onSaved?: (productId: string, updates: Partial<Product>) => void;
 }
 
 type ActiveTab = 'core' | 'context' | 'generation' | 'variants' | 'history';
@@ -33,19 +34,24 @@ const mockHistory = [
     "Version 1: Product Imported (11/04/2025)"
 ];
 
-const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClose, product }) => {
+const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClose, product, onSaved }) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>('core');
   const [editableProduct, setEditableProduct] = useState<Product | null>(product);
   const [isGenerating, setIsGenerating] = useState(false);
   const [aiScore, setAiScore] = useState<{ overall: number; tone: number; seo: number; } | null>(null);
   const [toastMessage, setToastMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null);
+  const [lastProductId, setLastProductId] = useState<string | null>(product?.id || null);
 
   useEffect(() => {
-    setEditableProduct(product);
-    setActiveTab('core');
-    setAiScore(null); // Reset score when product changes
-    setToastMessage(null); // Reset toast when product changes
-  }, [product]);
+    // Only reset editableProduct when the product ID changes (not when fields update)
+    if (product?.id !== lastProductId) {
+      setEditableProduct(product);
+      setActiveTab('core');
+      setAiScore(null);
+      setToastMessage(null);
+      setLastProductId(product?.id || null);
+    }
+  }, [product, lastProductId]);
 
   const saveFromForm = async (e: React.FormEvent<HTMLFormElement>, extra: Record<string, any> = {}, options: { showToast?: string; keepOpen?: boolean } = {}) => {
     e.preventDefault();
@@ -98,6 +104,12 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
     console.log('[drawer] payload to Firestore', payload);
 
     await setDoc(doc(db, 'products', product.id), payload, { merge: true });
+    
+    // Call onSaved callback for optimistic UI update in parent
+    if (onSaved) {
+      const filtered = Object.fromEntries(Object.entries(payload).filter(([_, v]) => v !== undefined));
+      onSaved(product.id, filtered as Partial<Product>);
+    }
     
     // Update local state optimistically (avoid overwriting with undefined)
     if (editableProduct) {

--- a/src/pages/IntakeQueuePage.tsx
+++ b/src/pages/IntakeQueuePage.tsx
@@ -7,7 +7,8 @@ import Toast from '../components/Toast';
 import { exportAndDownload } from '../utils/exporter';
 
 const IntakeQueuePage: React.FC = () => {
-  const { products, loading, error } = useProducts();
+  const { products: firestoreProducts, loading, error } = useProducts();
+  const [localProducts, setLocalProducts] = useState<Product[]>([]);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [showErrorToast, setShowErrorToast] = useState(false);
@@ -15,6 +16,14 @@ const IntakeQueuePage: React.FC = () => {
   const [exportMessage, setExportMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null);
   const [selectedIds, setSelectedIds] = useState(new Set<string>());
   const headerCheckboxRef = useRef<HTMLInputElement>(null);
+
+  // Sync Firestore products to local state (eventual consistency)
+  useEffect(() => {
+    setLocalProducts(firestoreProducts);
+  }, [firestoreProducts]);
+
+  // Use local products for rendering (allows optimistic updates)
+  const products = localProducts;
 
   // State for the new filters
   const [statusFilter, setStatusFilter] = useState('all');
@@ -29,6 +38,22 @@ const IntakeQueuePage: React.FC = () => {
   const handleCloseDrawer = () => {
     setIsDrawerOpen(false);
     setSelectedProduct(null); // Clear selection on close
+  };
+
+  const handleProductSaved = (productId: string, updates: Partial<Product>) => {
+    // Optimistic update: merge updates into local products list
+    setLocalProducts(prev => 
+      prev.map(p => 
+        p.id === productId 
+          ? { ...p, ...updates } 
+          : p
+      )
+    );
+    
+    // Also update selectedProduct if it's the same one
+    if (selectedProduct?.id === productId) {
+      setSelectedProduct(prev => prev ? { ...prev, ...updates } : null);
+    }
   };
 
   // Count validated products (from all products, not filtered)
@@ -310,6 +335,7 @@ const IntakeQueuePage: React.FC = () => {
         isOpen={isDrawerOpen}
         onClose={handleCloseDrawer}
         product={selectedProduct}
+        onSaved={handleProductSaved}
       />
 
       {showErrorToast && error && (


### PR DESCRIPTION
Improves editor UX by preventing inputs from kicking users out and enabling live updates without page refresh.

**Changes:**

1. **Stricter drawer reset guard**: Only reset editableProduct when product.id changes (not when any field updates from parent)
   - Added lastProductId state to track ID changes
   - Prevents remounting while typing

2. **Enter key prevention**: Already implemented - form onKeyDown prevents Enter from submitting on INPUT/TEXTAREA elements

3. **Optimistic updates**:
   - Added onSaved callback prop to ProductEditorDrawer
   - IntakeQueuePage maintains local state that syncs from Firestore
   - After save, immediately updates local product list without refresh
   - Firestore listener provides eventual consistency

4. **All inputs already controlled**: Every input/select/textarea has value and onChange handlers

**Result**: Users can type freely without being kicked out, and see their changes reflected in the table immediately after saving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product editor improvements: Changes to products now appear instantly when saved, eliminating wait times for server confirmation and providing immediate visual feedback for a more responsive user experience.
  * Added support for generative AI capabilities to enable advanced product insights and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->