### PR TITLE
fix(editor): restore focus by field name + caret; autosave on blur/id…

### DIFF
--- a/src/components/ProductEditorDrawer.tsx
+++ b/src/components/ProductEditorDrawer.tsx
@@ -48,6 +48,19 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
   const savedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const lastActiveField = useRef<{ name?: string; start?: number; end?: number }>({});
+
+  // Helper to restore focus by field name + caret position
+  const restoreFocus = useCallback(() => {
+    const { name, start, end } = lastActiveField.current || {};
+    if (!name || !formRef.current) return;
+    const el = formRef.current.elements.namedItem(name) as (HTMLInputElement | HTMLTextAreaElement | null);
+    if (!el) return;
+    el.focus();
+    if (typeof start === 'number' && typeof end === 'number' && 'setSelectionRange' in el) {
+      try { (el as HTMLInputElement).setSelectionRange(start, end); } catch {}
+    }
+  }, []);
 
   useEffect(() => {
     // Only reset editableProduct when the product ID changes (not when fields update)
@@ -150,9 +163,6 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
 
       try {
         setSavingState('saving');
-        // Focus guard: capture currently focused element within the form
-        const activeEl = (typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null);
-        const shouldRestoreFocus = !!(activeEl && formRef.current && formRef.current.contains(activeEl));
         
         // Build payload with only changed fields
         const payload = cleanForFirestore({
@@ -204,18 +214,14 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
           setSavingState('idle');
         }, 1000);
 
-        // Restore focus if it was inside the form before save
-        if (shouldRestoreFocus && activeEl) {
-          try {
-            activeEl.focus();
-          } catch {}
-        }
+        // Restore focus by field name + caret position
+        restoreFocus();
       } catch (error) {
         console.error('[drawer] autosave failed', error);
         setSavingState('idle');
       }
     }, 500); // 500ms debounce per requirements
-  }, [product, editableProduct, changedFields, onSaved]);
+  }, [product, editableProduct, changedFields, onSaved, restoreFocus]);
 
   const saveFromForm = async (e: React.FormEvent<HTMLFormElement>, extra: Record<string, any> = {}, options: { showToast?: string; keepOpen?: boolean } = {}) => {
     e.preventDefault();
@@ -303,6 +309,9 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
       setSavingState('idle');
     }, 1000);
     
+    // Restore focus by field name + caret position
+    restoreFocus();
+    
     // Show toast if requested
     if (options.showToast) {
       setToastMessage({ text: options.showToast, type: 'success' });
@@ -317,6 +326,15 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
   const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     if (!editableProduct) return;
     const { name, value, type } = e.target;
+    
+    // Capture field name and caret position for focus restoration
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      lastActiveField.current = {
+        name: e.target.name,
+        start: e.target.selectionStart ?? undefined,
+        end: e.target.selectionEnd ?? undefined,
+      };
+    }
     
     // Track that this field changed
     setChangedFields(prev => new Set(prev).add(name));
@@ -379,6 +397,15 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
   ) => {
     if (!editableProduct) return;
     const { name, value } = e.target;
+
+    // Capture field name and caret position for focus restoration
+    if (e.target instanceof HTMLTextAreaElement) {
+      lastActiveField.current = {
+        name: e.target.name,
+        start: e.target.selectionStart ?? undefined,
+        end: e.target.selectionEnd ?? undefined,
+      };
+    }
 
     // Track that aiContext changed
     setChangedFields(prev => new Set(prev).add('aiContext'));
@@ -551,7 +578,7 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                         <div className="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-2">
                              <FormField label="Name"><input name="name" type="text" value={editableProduct.name} readOnly className="block w-full border-gray-300 rounded-md shadow-sm bg-gray-100 cursor-not-allowed" /></FormField>
                              <FormField label="MPN"><input name="mpn" type="text" value={editableProduct.mpn} readOnly className="block w-full border-gray-300 rounded-md shadow-sm bg-gray-100 cursor-not-allowed" /></FormField>
-                             <FormField label="Brand"><input type="text" name="brand" value={editableProduct.brand} onChange={handleInputChange} onBlur={handleBlur} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
+                             <FormField label="Brand"><input type="text" name="brand" value={editableProduct.brand} onChange={handleInputChange} onFocus={(e) => { lastActiveField.current = { name: e.currentTarget.name }; }} onBlur={handleBlur} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
                              
                              <FormField label="Department">
                                <Select 
@@ -696,9 +723,9 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                 )}
                 {activeTab === 'context' && (
                     <div className="space-y-6">
-                        <FormField label="Keywords (one per line)"><textarea name="keywords" value={editableProduct.aiContext.keywords.join('\n')} onChange={(e) => handleNestedChange(e, 'aiContext')} onBlur={handleBlur} rows={4} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
-                        <FormField label="Feature Bullets (one per line)"><textarea name="featureBullets" value={editableProduct.aiContext.featureBullets.join('\n')} onChange={(e) => handleNestedChange(e, 'aiContext')} onBlur={handleBlur} rows={4} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
-                        <FormField label="Design Notes"><textarea name="designNotes" value={editableProduct.aiContext.designNotes} onChange={(e) => handleNestedChange(e, 'aiContext')} onBlur={handleBlur} rows={6} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
+                        <FormField label="Keywords (one per line)"><textarea name="keywords" value={editableProduct.aiContext.keywords.join('\n')} onChange={(e) => handleNestedChange(e, 'aiContext')} onFocus={(e) => { lastActiveField.current = { name: e.currentTarget.name }; }} onBlur={handleBlur} rows={4} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
+                        <FormField label="Feature Bullets (one per line)"><textarea name="featureBullets" value={editableProduct.aiContext.featureBullets.join('\n')} onChange={(e) => handleNestedChange(e, 'aiContext')} onFocus={(e) => { lastActiveField.current = { name: e.currentTarget.name }; }} onBlur={handleBlur} rows={4} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
+                        <FormField label="Design Notes"><textarea name="designNotes" value={editableProduct.aiContext.designNotes} onChange={(e) => handleNestedChange(e, 'aiContext')} onFocus={(e) => { lastActiveField.current = { name: e.currentTarget.name }; }} onBlur={handleBlur} rows={6} className="block w-full border-gray-300 rounded-md shadow-sm" /></FormField>
                     </div>
                 )}
                 {activeTab === 'generation' && (


### PR DESCRIPTION
…le only

# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->


## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] UX enhancement

## Editor UX Checklist
<!-- If this PR modifies product editor forms (Intake Queue, Settings, etc.), please review: -->

- [ ] **This PR modifies editor/form interfaces** → Complete the [Editor UX Quality Checklist](.github/PULL_REQUEST_TEMPLATE/editor-ux-checklist.md)
  - See [Editor UX Standard v1 Milestone](https://github.com/twgallo13/ROPI-V2.1/milestone/1) for context

## Testing
<!-- Describe the testing you've done -->

- [ ] Manual testing completed
- [ ] Edge cases tested
- [ ] Tested on different screen sizes (if UI change)
- [ ] No console errors

## Screenshots/Videos
<!-- If applicable, add screenshots or screen recordings to help explain your changes -->


## Additional Notes
<!-- Add any other context about the PR here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling in the product editor to preserve cursor position when editing and saving changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->