### PR TITLE
fix: materials subscription in useAttributesSettings (P13.1)

### DIFF
--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -1,0 +1,12 @@
+# HOMER Operations Log
+
+## [P13.1] materials hook fix — 2025-11-13
+
+- Files: src/hooks/useAttributesSettings.ts
+- Summary: added 'materials' to AttributeKey, INITIAL_ATTRIBUTES, and subscribe keys
+- PR: #73
+- Changes:
+  - Added 'materials' to AttributeKey type definition
+  - Added 'materials' to INITIAL_ATTRIBUTES initialization
+  - Added 'materials' to subscription keys array for real-time updates
+- Impact: Settings → Materials CUD operations now work correctly

--- a/src/hooks/useAttributesSettings.ts
+++ b/src/hooks/useAttributesSettings.ts
@@ -24,6 +24,7 @@ export type AttributeKey =
   | 'categories' 
   | 'ageGroups' 
   | 'genders' 
+  | 'materials'
   | 'statuses' 
   | 'websites' 
   | 'sportsTeams' 
@@ -45,6 +46,7 @@ const INITIAL_ATTRIBUTES: AttributesData = {
   categories: [],
   ageGroups: [],
   genders: [],
+  materials: [],
   statuses: [],
   websites: [],
   sportsTeams: [],
@@ -121,7 +123,7 @@ export function useAttributesSettings() {
     setLoading(true);
 
     const keys: AttributeKey[] = [
-      'departments', 'classes', 'categories', 'ageGroups', 'genders',
+      'departments', 'classes', 'categories', 'ageGroups', 'genders', 'materials',
       'statuses', 'websites', 'sportsTeams', 'leagues', 'fits', 'taxClasses',
       'primaryColors', 'descriptiveColors', 'cutTypes', 'closureTypes', 'heelHeights', 'platformHeights'
     ];


### PR DESCRIPTION
Fixes missing materials wiring so Settings → Materials CUD works.

## Changes
- Added 'materials' to  type
- Added 'materials' to  object
- Added 'materials' to subscription keys array

## Testing
1. Go to Settings → Vocab → Materials and Add/Edit/Delete a value
2. Open Product Editor → Materials chip-select should contain the new value
3. Save product and reload — materials should persist
4. Confirm `/settings/materials/items` documents exist in Firestore

Implements P13.1