### PR TITLE
feat(editor): draft — Save (Draft), Publish, autosave; collections/madeIn wiring

### DIFF
--- a/VOCAB_UI_VERIFICATION.md
+++ b/VOCAB_UI_VERIFICATION.md
@@ -1,0 +1,239 @@
+# Settings Vocab UI Verification Report
+
+## Commit SHA
+**b3d3007** - fix(settings): subscribe to heelTypes/shoeHeightMaps/soleMaterials in useAttributesSettings; initialize in state
+
+## Firestore Verification (AUTOMATED - ✅ PASS)
+
+### Seeded Document Counts
+Verified via Cloud Function endpoint: `POST https://us-central1-ropi-bccee.cloudfunctions.net/seedSettingsVocab`
+
+```
+heelTypes: 7 items
+shoeHeightMaps: 3 items
+soleMaterials: 8 items
+```
+
+### Expected Firestore Paths
+Documents exist at:
+- `settings/heelTypes/items/{autoId}` - 7 documents
+- `settings/shoeHeightMaps/items/{autoId}` - 3 documents  
+- `settings/soleMaterials/items/{autoId}` - 8 documents
+
+### Sample Document Structure
+Each document has the shape:
+```json
+{
+  "value": "Wedge",
+  "label": "Wedge"
+}
+```
+
+### Seeded Values
+
+**heelTypes (7):**
+- Stiletto
+- Block
+- Wedge
+- Kitten
+- Cone
+- Platform
+- Chunky
+
+**shoeHeightMaps (3):**
+- Low
+- Mid
+- High
+
+**soleMaterials (8):**
+- Rubber
+- TPU
+- Vibram
+- Cork
+- Crepe
+- Leather
+- EVA
+- Manmade
+
+## Manual UI Smoke Test (REQUIRED - User Action)
+
+### Prerequisites
+1. Dev server running: `npm run dev`
+2. Browser open: http://localhost:3000/settings/vocab-managed
+3. DevTools Console and Network tabs open
+4. User authenticated with appropriate permissions
+
+### Test Steps for Each Vocab
+
+#### heelTypes
+1. **Verify List Display**
+   - Navigate to "Shoe Attributes" section
+   - Find "Heel Types" card
+   - **Expected:** 7 items visible (Stiletto, Block, Wedge, Kitten, Cone, Platform, Chunky)
+   - **Actual:** _____ items visible
+
+2. **Test Add**
+   - Type in input: `TEMP_TEST_<timestamp>`
+   - Click "Add" button
+   - **Expected:** Item appears in list, no console errors
+   - **Result:** PASS / FAIL
+   - **Console errors:** (paste if any, or "none")
+
+3. **Test Edit**
+   - Hover over temporary item
+   - Click edit icon (✎)
+   - Change to: `TEMP_EDITED`
+   - Save
+   - **Expected:** Item updated in list, no console errors
+   - **Result:** PASS / FAIL
+   - **Console errors:** (paste if any, or "none")
+
+4. **Test Delete**
+   - Hover over temporary item
+   - Click delete icon (×)
+   - Confirm deletion
+   - **Expected:** Item removed from list, no console errors
+   - **Result:** PASS / FAIL
+   - **Console errors:** (paste if any, or "none")
+
+#### shoeHeightMaps
+1. **Verify List Display**
+   - Find "Shoe Height Maps" card
+   - **Expected:** 3 items visible (Low, Mid, High)
+   - **Actual:** _____ items visible
+
+2. **Test CRUD**
+   - Follow same steps as heelTypes
+   - **Add Result:** PASS / FAIL
+   - **Edit Result:** PASS / FAIL
+   - **Delete Result:** PASS / FAIL
+   - **Console errors:** (paste if any, or "none")
+
+#### soleMaterials
+1. **Verify List Display**
+   - Find "Sole Materials" card
+   - **Expected:** 8 items visible (Rubber, TPU, Vibram, Cork, Crepe, Leather, EVA, Manmade)
+   - **Actual:** _____ items visible
+
+2. **Test CRUD**
+   - Follow same steps as heelTypes
+   - **Add Result:** PASS / FAIL
+   - **Edit Result:** PASS / FAIL
+   - **Delete Result:** PASS / FAIL
+   - **Console errors:** (paste if any, or "none")
+
+## Network Tab Inspection
+
+### Expected Firestore Requests
+When page loads, DevTools Network should show:
+- WebSocket connection to Firestore
+- `listen` requests for `settings/{vocab}/items` collections
+- Real-time updates on CRUD operations
+
+### What to Check
+1. Filter Network by "firestore" or "listen"
+2. Verify subscription requests for:
+   - settings/heelTypes/items
+   - settings/shoeHeightMaps/items
+   - settings/soleMaterials/items
+3. On Add/Edit/Delete, verify:
+   - Request sent to Firestore
+   - Response status 200 OK
+   - UI updates immediately (via onSnapshot)
+
+**Network errors:** (paste if any, or "none")
+
+## Code Changes Summary
+
+### File: `src/hooks/useAttributesSettings.ts`
+**Changes:**
+1. Extended `AttributeKey` union type:
+   - Added: `heelTypes`, `shoeHeightMaps`, `soleMaterials`
+2. Extended `INITIAL_ATTRIBUTES` state object:
+   - Added: empty arrays for the three new keys
+3. Extended subscription `keys` array:
+   - Added: all three keys to onSnapshot subscription loop
+
+**Before:**
+```typescript
+export type AttributeKey = 
+  | 'departments' 
+  | 'classes' 
+  // ... 
+  | 'heelHeights'
+  | 'platformHeights'
+  | 'collections'
+  | 'madeIn';
+```
+
+**After:**
+```typescript
+export type AttributeKey = 
+  | 'departments' 
+  | 'classes' 
+  // ... 
+  | 'heelTypes'          // NEW
+  | 'heelHeights'
+  | 'platformHeights'
+  | 'shoeHeightMaps'     // NEW
+  | 'soleMaterials'      // NEW
+  | 'collections'
+  | 'madeIn';
+```
+
+### File: `src/pages/settings/components/VocabEditor.tsx`
+**Status:** Already had `heelTypes`, `shoeHeightMaps`, `soleMaterials` in `VocabKey` union (from previous commit bd26731)
+
+### File: `src/pages/settings/VocabDropdownsPage.tsx`
+**Status:** Already included new vocabs in `shoeVocabs` object and `newItems` state (from previous commit bd26731)
+
+## Root Cause Analysis
+
+**Problem:** UI showed empty lists and no CRUD capability for heelTypes, shoeHeightMaps, soleMaterials
+
+**Root Cause:** 
+- The `useAttributesSettings` hook did not subscribe to these three vocabs
+- Missing keys in `AttributeKey` type union
+- Missing keys in `INITIAL_ATTRIBUTES` state
+- Missing keys in `onSnapshot` subscription loop
+
+**Fix Applied:**
+- Added all three keys to the hook's type system and subscription mechanism
+- Hook now listens to Firestore real-time updates for these collections
+- State properly initialized and populated on mount
+
+## Expected Final State
+
+After fix b3d3007:
+- ✅ UI renders all seeded items for the three vocabs
+- ✅ Add button and input always visible
+- ✅ Edit/Delete buttons visible on hover
+- ✅ CRUD operations call proper Firestore methods
+- ✅ Real-time updates via onSnapshot subscriptions
+- ✅ No console errors during normal CRUD flow
+- ✅ Network tab shows successful Firestore requests
+
+## Next Steps
+
+**USER ACTION REQUIRED:**
+1. Open http://localhost:3000/settings/vocab-managed in browser
+2. Complete manual CRUD tests for each vocab (documented above)
+3. Paste console output and results back to this thread
+4. Report any failures with console/network error details
+
+## Automated Verification Completed ✅
+
+- [x] Firestore documents exist (verified via seed endpoint)
+- [x] Document counts match expected values (7, 3, 8)
+- [x] Hook subscription code includes new keys
+- [x] Build compiles without errors
+- [x] Changes committed and pushed (b3d3007)
+
+## Manual Verification Pending ⏳
+
+- [ ] UI displays seeded items
+- [ ] Add operation works
+- [ ] Edit operation works
+- [ ] Delete operation works
+- [ ] No console errors during CRUD
+- [ ] Network tab shows successful Firestore requests

--- a/scripts/dumpVocabs.mjs
+++ b/scripts/dumpVocabs.mjs
@@ -1,0 +1,30 @@
+// scripts/dumpVocabs.mjs
+import admin from 'firebase-admin';
+
+// Initialize with application default credentials (from environment)
+admin.initializeApp({
+  projectId: 'ropi-bccee'
+});
+
+const db = admin.firestore();
+
+async function dump(vocab) {
+  const col = db.collection('settings').doc(vocab).collection('items');
+  const snap = await col.get();
+  console.log(`\n== ${vocab} (${snap.size} items) ==`);
+  snap.forEach(doc => {
+    console.log(`  ${doc.id}:`, doc.data());
+  });
+}
+
+(async () => {
+  try {
+    await dump('heelTypes');
+    await dump('shoeHeightMaps');
+    await dump('soleMaterials');
+    process.exit(0);
+  } catch (err) {
+    console.error('Error:', err);
+    process.exit(1);
+  }
+})();

--- a/scripts/testVocabUI.js
+++ b/scripts/testVocabUI.js
@@ -1,0 +1,42 @@
+// Quick UI test script - paste this into browser DevTools Console at http://localhost:3000/settings/vocab-managed
+
+// Test the three new shoe vocabs
+const testVocabs = async () => {
+  console.log('=== ROPI Vocab UI Test ===');
+  
+  // Check if useAttributesSettings hook data is populated
+  const checkVocab = (vocabKey, expectedMin) => {
+    // Access the hook data from the React component (if exposed via window.__ROPI)
+    const items = window.__ROPI?.vocabData?.[vocabKey] || [];
+    const pass = items.length >= expectedMin;
+    console.log(`${vocabKey}: ${items.length} items (expected >= ${expectedMin}) - ${pass ? 'PASS' : 'FAIL'}`);
+    if (items.length > 0) {
+      console.log(`  Sample: ${items.slice(0, 3).join(', ')}`);
+    }
+    return pass;
+  };
+  
+  const results = {
+    heelTypes: checkVocab('heelTypes', 7),
+    shoeHeightMaps: checkVocab('shoeHeightMaps', 3),
+    soleMaterials: checkVocab('soleMaterials', 8),
+  };
+  
+  console.log('\n=== Summary ===');
+  console.log(results);
+  
+  return results;
+};
+
+// Run test
+testVocabs();
+
+// Instructions for manual CRUD test:
+console.log('\n=== Manual CRUD Test Steps ===');
+console.log('1. Scroll to "Shoe Attributes" section');
+console.log('2. Find "Heel Types" card');
+console.log('3. Add temporary item: type "TEMP_TEST_' + Date.now() + '" and click Add');
+console.log('4. Edit that item: click edit icon, change to "TEMP_EDITED", save');
+console.log('5. Delete that item: click × icon, confirm');
+console.log('6. Repeat for "Shoe Height Maps" and "Sole Materials"');
+console.log('7. Check console for any errors during CRUD operations');

--- a/src/components/ProductEditorDrawer.tsx
+++ b/src/components/ProductEditorDrawer.tsx
@@ -10,6 +10,7 @@ import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage
 import Toast from './Toast';
 import Select from './ui/Select';
 import { useVocab } from '../hooks/useVocab';
+import { useAttributesSettings } from '../hooks/useAttributesSettings';
 
 interface ProductEditorDrawerProps {
   isOpen: boolean;
@@ -85,9 +86,12 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
   const formRef = useRef<HTMLFormElement>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const lastActiveField = useRef<{ name?: string; start?: number; end?: number }>({});
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [madeInSelections, setMadeInSelections] = useState<string[]>([]);
   
   // Live vocabulary from Firestore
   const vocab = useVocab();
+  const attributes = useAttributesSettings();
   
   // AI Descriptions from subcollection
   type AIDescription = { text: string; meta?: { tone: string; length: string; generatedAt: any } };
@@ -550,8 +554,22 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
 
   // Temporarily disable idle autosave for stability
   const debouncedAutosave = useCallback(() => {
-    // disabled for stability
-  }, []);
+    if (!editableProduct) return;
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    setSavingState('saving');
+    saveTimeoutRef.current = setTimeout(async () => {
+      try {
+        await saveFromForm({
+          // Ensure nested descriptive.madeIn is persisted on autosave
+          ...(madeInSelections.length ? { descriptive: { madeIn: madeInSelections } as any } : {}),
+        }, { showToast: 'Draft saved', keepOpen: true });
+        setLastSavedAt(new Date());
+      } finally {
+        // savingState handled in saveFromForm, but ensure idle if anything goes wrong
+        if (!saveTimeoutRef.current) setSavingState('idle');
+      }
+    }, 1500);
+  }, [editableProduct, madeInSelections]);
 
   const saveFromForm = async (extra: Partial<Product> & { validatedAt?: any } = {}, options?: { showToast?: string; keepOpen?: boolean }) => {
     if (!product || !editableProduct) return;
@@ -621,7 +639,17 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
     if (p.mpn && p.mpn !== product.mpn) (base as any).mpn = p.mpn;
 
     // Merge extra fields (like marketing, status from Approve)
-    const payload = cleanForFirestore<any>({ ...base, ...extra });
+    const payload = cleanForFirestore<any>({
+      ...base,
+      // Persist new collection selection
+      launch: {
+        ...base.launch,
+        ...(editableProduct.launch?.newCollection ? { newCollection: editableProduct.launch?.newCollection } : {}),
+      },
+      // Persist Made In selections under descriptive
+      ...(madeInSelections.length ? { descriptive: { madeIn: madeInSelections } as any } : {}),
+      ...extra,
+    });
     console.log('[drawer] payload to Firestore (STATE)', payload);
 
     await setDoc(doc(db, 'products', product.id), payload, { merge: true });
@@ -637,6 +665,7 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
     // Clear changed fields after manual save
     setChangedFields(new Set());
     setSavingState('saved');
+    setLastSavedAt(new Date());
 
     if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
     savedTimeoutRef.current = setTimeout(() => {
@@ -1512,6 +1541,60 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                                         disabled={vocab.loading}
                                     />
                                 </FormField>
+                                {/* Attributes: New Collection & Made In */}
+                                <FormField label="New Collection">
+                                  <Select
+                                    name="launch.newCollection"
+                                    value={editableProduct.launch?.newCollection ?? ''}
+                                    onChange={(val) => {
+                                      setEditableProduct({
+                                        ...editableProduct,
+                                        launch: { ...editableProduct.launch, newCollection: val },
+                                      });
+                                      setChangedFields(prev => new Set(prev).add('launch.newCollection'));
+                                      debouncedAutosave();
+                                    }}
+                                    onBlur={handleBlur}
+                                    options={[
+                                      '',
+                                      ...((attributes.data.collections || []).map(v => v))
+                                    ] as readonly string[]}
+                                    placeholder="Select a collection..."
+                                    disabled={attributes.loading}
+                                  />
+                                </FormField>
+                                <FormField label="Made In (multi-select)">
+                                  <div className="space-y-2 mt-2 p-3 bg-gray-50 rounded-md border border-gray-200">
+                                    {attributes.loading ? (
+                                      <div className="text-sm text-gray-500">Loading...</div>
+                                    ) : (
+                                      <div className="flex flex-wrap gap-2">
+                                        {(attributes.data.madeIn || []).map((country) => {
+                                          const selected = madeInSelections.includes(country);
+                                          return (
+                                            <button
+                                              type="button"
+                                              key={country}
+                                              onClick={() => {
+                                                setMadeInSelections(prev => {
+                                                  const set = new Set(prev);
+                                                  if (set.has(country)) set.delete(country); else set.add(country);
+                                                  return Array.from(set);
+                                                });
+                                                setChangedFields(prev => new Set(prev).add('descriptive.madeIn'));
+                                                debouncedAutosave();
+                                              }}
+                                              className={`px-2 py-1 rounded-full text-xs border ${selected ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300'}`}
+                                              aria-pressed={selected}
+                                            >
+                                              {country}
+                                            </button>
+                                          );
+                                        })}
+                                      </div>
+                                    )}
+                                  </div>
+                                </FormField>
                             </div>
                         </div>
 
@@ -2083,7 +2166,7 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                       <svg className="mr-1 h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd"/>
                       </svg>
-                      Saved ✓
+                      Saved · {lastSavedAt ? Math.max(0, Math.floor((Date.now() - lastSavedAt.getTime()) / 1000)) : 0}s ago
                     </span>
                   )}
                 </div>
@@ -2098,15 +2181,15 @@ const ProductEditorDrawer: React.FC<ProductEditorDrawerProps> = ({ isOpen, onClo
                   
                   <div className="flex space-x-2">
                     <button type="button" className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50" onClick={onClose}>Cancel</button>
-                    <button type="submit" className="inline-flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">Save</button>
+                    <button type="submit" className="inline-flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">Save (Draft)</button>
                     <button 
                       type="button" 
                       onClick={handleApprove}
                       disabled={!canApprove()}
                       className="inline-flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
-                      title={!canApprove() ? `Missing: ${getMissingFields().join(', ')}` : 'Approve & mark validated'}
+                      title={!canApprove() ? `Missing: ${getMissingFields().join(', ')}` : 'Publish (validate and mark ready)'}
                     >
-                      Approve
+                      Publish
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
Draft PR to:

- Wire ProductEditorDrawer to Settings vocabs (collections, madeIn)
- Add Save (Draft) + Publish actions
- Enable 1.5s debounced autosave with toast and saved indicator
- Maintain responsive styling consistent with V2

Notes:
- Uses existing saveFromForm path with merge:true; autosave calls saveFromForm with keepOpen
- Publish reuses existing approve flow; Save renamed to Save (Draft)
- No changes to V2 editor or import/export flows

Label to add after creation: awaiting-homer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for Heel Types, Shoe Height Maps, and Sole Materials now available in vocabulary settings.
  * Added New Collection dropdown in product editor.
  * Added Made In multi-select field in product editor with real-time autosave.

* **Improvements**
  * Draft save status now displays relative time (e.g., "Saved · 5s ago").
  * Button labels updated to "Save (Draft)" and "Publish" for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->