### PR TITLE
ci(seed): allow main dispatch for Phase B seed

### DIFF
--- a/scripts/seed-phaseb.sh
+++ b/scripts/seed-phaseb.sh
@@ -78,16 +78,17 @@ fi
 echo "✓ Working tree clean (service-account.json ignored if present)"
 
 # 5. Check current branch
+    "
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-REQUIRED_BRANCH="integration/review-attributekey-20251118"
 
-if [[ "$CURRENT_BRANCH" != "$REQUIRED_BRANCH" ]]; then
-  echo "ERROR: Not on required branch"
+# Allow running from either the integration branch used for review OR from main
+if [[ "$CURRENT_BRANCH" != "integration/review-attributekey-20251118" && "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: Not on required branch (allowed: integration/review-attributekey-20251118, main)"
   echo "  Current: $CURRENT_BRANCH"
-  echo "  Required: $REQUIRED_BRANCH"
   exit 1
 fi
-
+"
+  
 echo "✓ On correct branch: $CURRENT_BRANCH"
 
 echo ""


### PR DESCRIPTION
Small fix to allow Phase B seed script to run when workflow dispatches on main. The script still enforces allowed branches (integration/review-attributekey-20251118 or main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch validation logic in development tooling to support expanded workflow options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->