### PR TITLE
chore(metadata): add importer aliases for master CSV headers

### DIFF
--- a/scripts/attribute-registry-normalized.json
+++ b/scripts/attribute-registry-normalized.json
@@ -220,12 +220,18 @@
     "description": "Long description (ROPI HTML output)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "description",
+      "product_description",
+      "long_description",
+      "short_description"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "descriptiveColor",
@@ -258,12 +264,15 @@
     "description": "Family sizing available",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "family_sizing"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "fit",
@@ -318,12 +327,15 @@
     "description": "Heel Height (numeric)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "heel_height"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "heelType",
@@ -336,14 +348,17 @@
     "description": "Heel Type (Stiletto, Block, Wedge)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "heel_type"
+    ],
     "rules": [
       "SD-010"
     ],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "keywords",
@@ -396,12 +411,18 @@
     "description": "Countries of origin",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "made_in",
+      "country_of_origin",
+      "country",
+      "origin"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "material",
@@ -437,15 +458,18 @@
     "dataType": "string",
     "required": true,
     "export": true,
-    "description": "SEO meta description (≤155 chars)",
+    "description": "SEO meta description (\u2264155 chars)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "meta_description"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "metaName",
@@ -455,15 +479,19 @@
     "dataType": "string",
     "required": true,
     "export": true,
-    "description": "SEO meta name (≤60 chars)",
+    "description": "SEO meta name (\u226460 chars)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "meta_name",
+      "meta_title"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "outsoleMaterial",
@@ -476,12 +504,15 @@
     "description": "Outsole Material",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "outsole_material"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "platformHeight",
@@ -494,12 +525,15 @@
     "description": "Platform Height",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "platform_height"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "primaryColor",
@@ -516,7 +550,9 @@
     ],
     "importerColumns": [
       "rics_color",
-      "primary_color"
+      "primary_color",
+      "primaryColor",
+      "primary_colour"
     ],
     "rules": [
       "SD-006"
@@ -524,7 +560,8 @@
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "shoeHeightMap",
@@ -537,12 +574,15 @@
     "description": "Shoe Height Map (Low, Mid, High)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "shoe_height_map"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "slug",
@@ -555,12 +595,15 @@
     "description": "URL slug",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "slug"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "sportsTeam",
@@ -776,12 +819,16 @@
     "description": "RICS brand",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "rics_brand",
+      "brand"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "category",
@@ -794,12 +841,16 @@
     "description": "RICS category",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "rics_category",
+      "category"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "color",
@@ -812,12 +863,16 @@
     "description": "RICS color",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "rics_color",
+      "color"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "longDescription",
@@ -830,12 +885,16 @@
     "description": "RICS long description",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "rics_long_description",
+      "long_description"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "shortDescription",
@@ -848,12 +907,16 @@
     "description": "RICS short description",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "rics_short_description",
+      "short_description"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "brand",
@@ -931,12 +994,16 @@
     "description": "Marks main styles that persist across seasons",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "core_product",
+      "is_core_product"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "department",
@@ -1017,12 +1084,16 @@
     "description": "Toggles product visibility",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "product_is_active",
+      "is_active"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "sku",
@@ -1035,12 +1106,15 @@
     "description": "SKU (Variant ID)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "sku"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "styleId",
@@ -1053,12 +1127,16 @@
     "description": "Style ID (links colorways)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "style_id",
+      "styleId"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "rics",
@@ -1071,12 +1149,16 @@
     "description": "RICS system data",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "source_rics",
+      "rics"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "custom2",
@@ -1133,12 +1215,15 @@
     "description": "Expedited shipping override (Money)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "expedited_override_shipping"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "firstReceived",
@@ -1193,12 +1278,15 @@
     "description": "Image embargo date (ISO string)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "hide_image_date"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "lastReceived",
@@ -1253,12 +1341,16 @@
     "description": "Media status (\"Images Ready\", \"Pending\", etc.)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "media_status",
+      "mediaStatus"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "standardShippingOverride",
@@ -1271,12 +1363,15 @@
     "description": "Standard shipping override (Money)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "standard_shipping_override"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "status",
@@ -1289,12 +1384,15 @@
     "description": "Canonical product status",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "status"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "store1",
@@ -1373,12 +1471,16 @@
     "description": "Taxable toggle (true = Taxable Goods)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [],
+    "importerColumns": [
+      "tax_class",
+      "taxClass"
+    ],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "totalInv",
@@ -1464,7 +1566,8 @@
     "usage": [],
     "examples": {
       "sampleValues": []
-    }
+    },
+    "bulkEditable": true
   },
   {
     "key": "weight",

--- a/scripts/attribute-registry-normalized.json
+++ b/scripts/attribute-registry-normalized.json
@@ -221,10 +221,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "description",
-      "product_description",
-      "long_description",
-      "short_description"
+      "description"
     ],
     "rules": [],
     "usage": [],
@@ -458,7 +455,7 @@
     "dataType": "string",
     "required": true,
     "export": true,
-    "description": "SEO meta description (\u2264155 chars)",
+    "description": "SEO meta description (≤155 chars)",
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
@@ -479,7 +476,7 @@
     "dataType": "string",
     "required": true,
     "export": true,
-    "description": "SEO meta name (\u226460 chars)",
+    "description": "SEO meta name (≤60 chars)",
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
@@ -549,7 +546,6 @@
       "primaryColor"
     ],
     "importerColumns": [
-      "rics_color",
       "primary_color",
       "primaryColor",
       "primary_colour"
@@ -820,8 +816,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "rics_brand",
-      "brand"
+      "rics_brand"
     ],
     "rules": [],
     "usage": [],
@@ -842,8 +837,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "rics_category",
-      "category"
+      "rics_category"
     ],
     "rules": [],
     "usage": [],
@@ -886,8 +880,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "rics_long_description",
-      "long_description"
+      "rics_long_description"
     ],
     "rules": [],
     "usage": [],
@@ -908,8 +901,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "rics_short_description",
-      "short_description"
+      "rics_short_description"
     ],
     "rules": [],
     "usage": [],
@@ -1028,6 +1020,28 @@
     }
   },
   {
+    "key": "dropshipName",
+    "canonicalPath": "sku_core.dropshipName",
+    "label": "Dropship Name",
+    "category": "Core",
+    "dataType": "string",
+    "required": false,
+    "export": true,
+    "description": "Dropship vendor name",
+    "systemFlag": false,
+    "legacyPaths": [],
+    "importerColumns": [
+      "dropship_name",
+      "product_is_dropship_name"
+    ],
+    "rules": [],
+    "usage": [],
+    "examples": {
+      "sampleValues": []
+    },
+    "bulkEditable": true
+  },
+  {
     "key": "mpn",
     "canonicalPath": "sku_core.mpn",
     "label": "Mpn",
@@ -1087,6 +1101,28 @@
     "importerColumns": [
       "product_is_active",
       "is_active"
+    ],
+    "rules": [],
+    "usage": [],
+    "examples": {
+      "sampleValues": []
+    },
+    "bulkEditable": true
+  },
+  {
+    "key": "productIsDropship",
+    "canonicalPath": "sku_core.productIsDropship",
+    "label": "Product Is Dropship",
+    "category": "Core",
+    "dataType": "boolean",
+    "required": false,
+    "export": true,
+    "description": "Indicates if product is dropshipped",
+    "systemFlag": false,
+    "legacyPaths": [],
+    "importerColumns": [
+      "product_is_dropship",
+      "is_dropship"
     ],
     "rules": [],
     "usage": [],

--- a/scripts/update-importer-aliases.ts
+++ b/scripts/update-importer-aliases.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Update importer aliases in attribute-registry-normalized.json
+ * Metadata-only changes for CSV import header mapping
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface Attribute {
+  key: string;
+  canonicalPath: string;
+  label: string;
+  category: string;
+  dataType: string;
+  required: boolean;
+  export: boolean;
+  description: string;
+  systemFlag: boolean;
+  legacyPaths: string[];
+  importerColumns: string[];
+  rules: string[];
+  usage: string[];
+  examples: {
+    sampleValues: any[];
+  };
+  bulkEditable?: boolean;
+  normalizationNote?: string;
+}
+
+// Mapping of CSV headers to canonical paths and their importer columns
+const importerMapping: Record<string, { canonicalPath: string; columns: string[] }> = {
+  'descriptive.ageGroup': { canonicalPath: 'descriptive.ageGroup', columns: ['age_group'] },
+  'descriptive.gender': { canonicalPath: 'descriptive.gender', columns: ['gender'] },
+  'sku_core.department': { canonicalPath: 'sku_core.department', columns: ['department'] },
+  'sku_core.class': { canonicalPath: 'sku_core.class', columns: ['class'] },
+  'sku_core.category': { canonicalPath: 'sku_core.category', columns: ['category'] },
+  'technical.website': { canonicalPath: 'technical.website', columns: ['website'] },
+  'descriptive.sportsTeam': { canonicalPath: 'descriptive.sportsTeam', columns: ['sports_team'] },
+  'descriptive.league': { canonicalPath: 'descriptive.league', columns: ['league'] },
+  'descriptive.fit': { canonicalPath: 'descriptive.fit', columns: ['fit'] },
+  'descriptive.material': { canonicalPath: 'descriptive.material', columns: ['material'] },
+  'pricing.map': { canonicalPath: 'pricing.map', columns: ['map'] },
+  'pricing.promo': { canonicalPath: 'pricing.promo', columns: ['promo'] },
+  'launch.hype': { canonicalPath: 'launch.hype', columns: ['hype'] },
+  'launch.fastFashion': { canonicalPath: 'launch.fastFashion', columns: ['fast_fashion', 'fastfashion'] },
+  'descriptive.cutType': { canonicalPath: 'descriptive.cutType', columns: ['cut_type'] },
+  'descriptive.closureType': { canonicalPath: 'descriptive.closureType', columns: ['closure_type'] },
+  'descriptive.platformHeight': { canonicalPath: 'descriptive.platformHeight', columns: ['platform_height'] },
+  'descriptive.heelType': { canonicalPath: 'descriptive.heelType', columns: ['heel_type'] },
+  'technical.height': { canonicalPath: 'technical.height', columns: ['height'] },
+  'technical.length': { canonicalPath: 'technical.length', columns: ['length'] },
+  'technical.width': { canonicalPath: 'technical.width', columns: ['width'] },
+  'technical.weight': { canonicalPath: 'technical.weight', columns: ['weight'] },
+  'technical.standardShippingOverride': { canonicalPath: 'technical.standardShippingOverride', columns: ['standard_shipping_override'] },
+  'technical.expeditedOverrideShipping': { canonicalPath: 'technical.expeditedOverrideShipping', columns: ['expedited_override_shipping'] },
+  'technical.hideImageDate': { canonicalPath: 'technical.hideImageDate', columns: ['hide_image_date'] },
+  'sku_core.styleId': { canonicalPath: 'sku_core.styleId', columns: ['style_id'] },
+  'descriptive.shoeHeightMap': { canonicalPath: 'descriptive.shoeHeightMap', columns: ['shoe_height_map'] },
+  'descriptive.heelHeight': { canonicalPath: 'descriptive.heelHeight', columns: ['heel_height'] },
+  'descriptive.outsoleMaterial': { canonicalPath: 'descriptive.outsoleMaterial', columns: ['outsole_material'] },
+  'pricing.scomRegularPrice': { canonicalPath: 'pricing.scomRegularPrice', columns: ['scom_regular'] },
+  'pricing.scomSalePrice': { canonicalPath: 'pricing.scomSalePrice', columns: ['scom_sale'] },
+  'sku_core.coreProduct': { canonicalPath: 'sku_core.coreProduct', columns: ['core_product'] },
+  'descriptive.primaryColor': { canonicalPath: 'descriptive.primaryColor', columns: ['primary_color', 'primaryColor', 'primary_colour'] }, // rics_color removed
+  'descriptive.descriptiveColor': { canonicalPath: 'descriptive.descriptiveColor', columns: ['descriptive_color'] },
+  'descriptive.keywords': { canonicalPath: 'descriptive.keywords', columns: ['keywords'] },
+  'descriptive.description': { canonicalPath: 'descriptive.description', columns: ['description'] },
+  'technical.taxClass': { canonicalPath: 'technical.taxClass', columns: ['tax_class'] },
+  'launch.newCollection': { canonicalPath: 'launch.newCollection', columns: ['collection'] },
+  'launch.klPostDate': { canonicalPath: 'launch.klPostDate', columns: ['kl_post_date'] },
+  'sku_core.productIsActive': { canonicalPath: 'sku_core.productIsActive', columns: ['product_is_active'] },
+  'launch.launchDate': { canonicalPath: 'launch.launchDate', columns: ['launch_date'] },
+  'technical.mediaStatus': { canonicalPath: 'technical.mediaStatus', columns: ['media_status', 'mediaStatus'] },
+  'rics_source.shortDescription': { canonicalPath: 'rics_source.shortDescription', columns: ['rics_short_description'] },
+  'rics_source.longDescription': { canonicalPath: 'rics_source.longDescription', columns: ['rics_long_description'] },
+  'technical.lastReceived': { canonicalPath: 'technical.lastReceived', columns: ['last_received'] },
+  'technical.firstReceived': { canonicalPath: 'technical.firstReceived', columns: ['first_received'] },
+  'technical.store1': { canonicalPath: 'technical.store1', columns: ['store1'] },
+  'technical.storeInv': { canonicalPath: 'technical.storeInv', columns: ['store_inv'] },
+  'technical.warehouseInv': { canonicalPath: 'technical.warehouseInv', columns: ['warehouse_inv'] },
+  'technical.whsInv': { canonicalPath: 'technical.whsInv', columns: ['whs_inv'] },
+  'technical.store4': { canonicalPath: 'technical.store4', columns: ['store4'] },
+  'technical.totalInv': { canonicalPath: 'technical.totalInv', columns: ['total_inv'] },
+  'rics_source.brand': { canonicalPath: 'rics_source.brand', columns: ['rics_brand'] },
+  'technical.status': { canonicalPath: 'technical.status', columns: ['status'] },
+  'sku_core.mpn': { canonicalPath: 'sku_core.mpn', columns: ['mpn'] },
+  'sku_core.sku': { canonicalPath: 'sku_core.sku', columns: ['sku'] },
+  'sku_core.brand': { canonicalPath: 'sku_core.brand', columns: ['brand'] },
+  'sku_core.name': { canonicalPath: 'sku_core.name', columns: ['name'] },
+  'descriptive.slug': { canonicalPath: 'descriptive.slug', columns: ['slug'] },
+  'rics_source.category': { canonicalPath: 'rics_source.category', columns: ['rics_category'] },
+  'rics_source.color': { canonicalPath: 'rics_source.color', columns: ['rics_color'] },
+  'descriptive.familySizing': { canonicalPath: 'descriptive.familySizing', columns: ['family_sizing'] },
+  'descriptive.madeIn': { canonicalPath: 'descriptive.madeIn', columns: ['made_in'] },
+  'descriptive.metaName': { canonicalPath: 'descriptive.metaName', columns: ['meta_name'] },
+  'descriptive.metaDescription': { canonicalPath: 'descriptive.metaDescription', columns: ['meta_description'] },
+};
+
+// New attributes to add
+const newAttributes: Partial<Attribute>[] = [
+  {
+    key: 'custom2',
+    canonicalPath: 'descriptive.custom2',
+    label: 'Custom2',
+    category: 'Descriptive',
+    dataType: 'string',
+    required: false,
+    export: true,
+    description: 'Custom field 2',
+    systemFlag: false,
+    legacyPaths: [],
+    importerColumns: ['custom2'],
+    rules: [],
+    usage: [],
+    examples: { sampleValues: [] },
+    bulkEditable: true,
+  },
+  {
+    key: 'custom3',
+    canonicalPath: 'descriptive.custom3',
+    label: 'Custom3',
+    category: 'Descriptive',
+    dataType: 'string',
+    required: false,
+    export: true,
+    description: 'Custom field 3',
+    systemFlag: false,
+    legacyPaths: [],
+    importerColumns: ['custom3'],
+    rules: [],
+    usage: [],
+    examples: { sampleValues: [] },
+    bulkEditable: true,
+  },
+  {
+    key: 'productIsDropship',
+    canonicalPath: 'sku_core.productIsDropship',
+    label: 'Product Is Dropship',
+    category: 'Core',
+    dataType: 'boolean',
+    required: false,
+    export: true,
+    description: 'Indicates if product is dropshipped',
+    systemFlag: false,
+    legacyPaths: [],
+    importerColumns: ['product_is_dropship', 'is_dropship'],
+    rules: [],
+    usage: [],
+    examples: { sampleValues: [] },
+    bulkEditable: true,
+  },
+  {
+    key: 'dropshipName',
+    canonicalPath: 'sku_core.dropshipName',
+    label: 'Dropship Name',
+    category: 'Core',
+    dataType: 'string',
+    required: false,
+    export: true,
+    description: 'Dropship vendor name',
+    systemFlag: false,
+    legacyPaths: [],
+    importerColumns: ['dropship_name', 'product_is_dropship_name'],
+    rules: [],
+    usage: [],
+    examples: { sampleValues: [] },
+    bulkEditable: true,
+  },
+];
+
+function main() {
+  const registryPath = path.join(__dirname, 'attribute-registry-normalized.json');
+  
+  // Read the existing registry
+  const registryContent = fs.readFileSync(registryPath, 'utf-8');
+  const attributes: Attribute[] = JSON.parse(registryContent);
+  
+  console.log(`Loaded ${attributes.length} attributes from registry`);
+  
+  // Track changes
+  let updated = 0;
+  let added = 0;
+  
+  // Build a map for quick lookup
+  const attributeMap = new Map<string, Attribute>();
+  attributes.forEach(attr => attributeMap.set(attr.canonicalPath, attr));
+  
+  // Update existing attributes with new importer columns
+  for (const [canonicalPath, mapping] of Object.entries(importerMapping)) {
+    const attr = attributeMap.get(canonicalPath);
+    if (attr) {
+      // Merge columns, preserving existing ones and adding new ones
+      const existingColumns = new Set(attr.importerColumns);
+      let changed = false;
+      
+      for (const col of mapping.columns) {
+        if (!existingColumns.has(col)) {
+          attr.importerColumns.push(col);
+          changed = true;
+        }
+      }
+      
+      // Special case: remove rics_color from descriptive.primaryColor
+      if (canonicalPath === 'descriptive.primaryColor') {
+        const ricsColorIndex = attr.importerColumns.indexOf('rics_color');
+        if (ricsColorIndex !== -1) {
+          attr.importerColumns.splice(ricsColorIndex, 1);
+          changed = true;
+          console.log(`Removed 'rics_color' from descriptive.primaryColor`);
+        }
+      }
+      
+      if (changed) {
+        updated++;
+        console.log(`Updated ${canonicalPath}: ${attr.importerColumns.join(', ')}`);
+      }
+    } else {
+      console.warn(`Warning: ${canonicalPath} not found in registry`);
+    }
+  }
+  
+  // Check if custom2 and custom3 already exist in technical namespace
+  const technicalCustom2 = attributeMap.get('technical.custom2');
+  const technicalCustom3 = attributeMap.get('technical.custom3');
+  
+  if (technicalCustom2) {
+    console.log('technical.custom2 already exists, skipping descriptive.custom2');
+    newAttributes.splice(newAttributes.findIndex(a => a.canonicalPath === 'descriptive.custom2'), 1);
+  }
+  
+  if (technicalCustom3) {
+    console.log('technical.custom3 already exists, skipping descriptive.custom3');
+    newAttributes.splice(newAttributes.findIndex(a => a.canonicalPath === 'descriptive.custom3'), 1);
+  }
+  
+  // Add new attributes if they don't exist
+  for (const newAttr of newAttributes) {
+    if (!attributeMap.has(newAttr.canonicalPath!)) {
+      attributes.push(newAttr as Attribute);
+      attributeMap.set(newAttr.canonicalPath!, newAttr as Attribute);
+      added++;
+      console.log(`Added new attribute: ${newAttr.canonicalPath}`);
+    } else {
+      console.log(`Attribute ${newAttr.canonicalPath} already exists, skipping`);
+    }
+  }
+  
+  // Sort attributes by canonicalPath for consistency
+  attributes.sort((a, b) => a.canonicalPath.localeCompare(b.canonicalPath));
+  
+  // Write back to file
+  fs.writeFileSync(registryPath, JSON.stringify(attributes, null, 2) + '\n', 'utf-8');
+  
+  console.log(`\nSummary:`);
+  console.log(`- Updated: ${updated} attributes`);
+  console.log(`- Added: ${added} new attributes`);
+  console.log(`- Total: ${attributes.length} attributes`);
+  console.log(`\nWrote updated registry to ${registryPath}`);
+}
+
+main();

--- a/scripts/validate-importer-columns.ts
+++ b/scripts/validate-importer-columns.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Validate that no importerColumns are duplicated across attributes
+ * except where intentionally allowed (e.g., rics_color on rics_source.color only)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface Attribute {
+  key: string;
+  canonicalPath: string;
+  importerColumns: string[];
+}
+
+function main() {
+  const registryPath = path.join(__dirname, 'attribute-registry-normalized.json');
+  const registryContent = fs.readFileSync(registryPath, 'utf-8');
+  const attributes: Attribute[] = JSON.parse(registryContent);
+  
+  // Build a map of importer column -> list of canonical paths
+  const columnMap = new Map<string, string[]>();
+  
+  for (const attr of attributes) {
+    for (const col of attr.importerColumns) {
+      if (!columnMap.has(col)) {
+        columnMap.set(col, []);
+      }
+      columnMap.get(col)!.push(attr.canonicalPath);
+    }
+  }
+  
+  // Find duplicates
+  const duplicates: Array<{ column: string; paths: string[] }> = [];
+  
+  for (const [column, paths] of columnMap.entries()) {
+    if (paths.length > 1) {
+      duplicates.push({ column, paths });
+    }
+  }
+  
+  if (duplicates.length === 0) {
+    console.log('✅ No duplicate importerColumns found!');
+    process.exit(0);
+  } else {
+    console.log('❌ Found duplicate importerColumns:');
+    console.log('');
+    
+    for (const dup of duplicates) {
+      console.log(`Column: "${dup.column}"`);
+      console.log(`  Used by: ${dup.paths.join(', ')}`);
+      console.log('');
+    }
+    
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
Metadata-only updates to `attribute-registry-normalized.json` to add/fix importer aliases for all CSV headers used in the master product import.

## Key Changes
- **Removed** `rics_color` from `descriptive.primaryColor.importerColumns`
- `rics_color` now exclusively maps to `rics_source.color`
- **Added 2 new attributes:**
  - `sku_core.productIsDropship` (boolean) with aliases: `product_is_dropship`, `is_dropship`
  - `sku_core.dropshipName` (string) with aliases: `dropship_name`, `product_is_dropship_name`
- Cleaned up duplicate mappings (brand, category, descriptions)
- Updated `technical.whsInv` and `technical.warehouseInv` with correct aliases
- Set `bulkEditable:true` on appropriate fields for catalog editors

## CSV Header → Canonical Path Mappings
```
age_group → descriptive.ageGroup
gender → descriptive.gender
department → sku_core.department
class → sku_core.class
category → sku_core.category
website → technical.website
sports_team → descriptive.sportsTeam
league → descriptive.league
fit → descriptive.fit
material → descriptive.material
map → pricing.map
promo → pricing.promo
hype → launch.hype
fast_fashion, fastfashion → launch.fastFashion
cut_type → descriptive.cutType
closure_type → descriptive.closureType
platform_height → descriptive.platformHeight
heel_type → descriptive.heelType
height → technical.height
length → technical.length
width → technical.width
weight → technical.weight
standard_shipping_override → technical.standardShippingOverride
expedited_override_shipping → technical.expeditedOverrideShipping
hide_image_date → technical.hideImageDate
style_id → sku_core.styleId
shoe_height_map → descriptive.shoeHeightMap
heel_height → descriptive.heelHeight
outsole_material → descriptive.outsoleMaterial
scom_regular → pricing.scomRegularPrice
scom_sale → pricing.scomSalePrice
core_product → sku_core.coreProduct
primary_color → descriptive.primaryColor (rics_color REMOVED)
descriptive_color → descriptive.descriptiveColor
keywords → descriptive.keywords
description → descriptive.description
tax_class → technical.taxClass
collection → launch.newCollection
kl_post_date → launch.klPostDate
product_is_active → sku_core.productIsActive
launch_date → launch.launchDate
media_status, mediaStatus → technical.mediaStatus
rics_short_description → rics_source.shortDescription
rics_long_description → rics_source.longDescription
last_received → technical.lastReceived
first_received → technical.firstReceived
store1 → technical.store1
store_inv → technical.storeInv
warehouse_inv → technical.warehouseInv
whs_inv → technical.whsInv
store4 → technical.store4
total_inv → technical.totalInv
rics_brand → rics_source.brand
status → technical.status
mpn → sku_core.mpn
sku → sku_core.sku
brand → sku_core.brand
name → sku_core.name
slug → descriptive.slug
rics_category → rics_source.category
rics_color → rics_source.color
family_sizing → descriptive.familySizing
made_in → descriptive.madeIn
meta_name → descriptive.metaName
meta_description → descriptive.metaDescription
custom2 → technical.custom2
custom3 → technical.custom3
dropship_name, product_is_dropship_name → sku_core.dropshipName (NEW)
product_is_dropship, is_dropship → sku_core.productIsDropship (NEW)
```

## Validation
✅ No duplicate `importerColumns` across attributes (validated with `validate-importer-columns.ts`)

## Important
**Metadata-only: No seeding, no writes to Firestore.**

This PR only updates the JSON metadata file. No database operations are performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded bulk editing capabilities across product attributes, allowing in-place editing of additional descriptive, pricing, and technical fields.
  * Added support for new product attributes including dropship status and name fields.
  * Improved attribute field mapping to support legacy and alternate naming conventions for better data compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->