### PR TITLE
chore(metadata): add human-friendly importer aliases (Last Received, …

### DIFF
--- a/ops/add-human-aliases.cjs
+++ b/ops/add-human-aliases.cjs
@@ -1,0 +1,66 @@
+// Adds human-friendly importer aliases to scripts/attribute-registry-normalized.json
+const fs = require('fs');
+const path = 'scripts/attribute-registry-normalized.json';
+const reg = JSON.parse(fs.readFileSync(path,'utf8'));
+
+const additions = {
+  "technical.lastReceived": ["Last Received"],
+  "sku_core.department": ["Group"],
+  "descriptive.primaryColor": ["Primary Color"],
+  "descriptive.descriptiveColor": ["Descriptive Color"],
+  "sku_core.productIsActive": ["Product Is Active"],
+  "technical.mediaStatus": ["Media"],
+  "launch.newCollection": ["New Collection"],
+  "launch.klPostDate": ["KL Post Date"],
+  "technical.hideImageDate": ["Hide Image Until Date"],
+  "rics_source.color": ["RICS Color"],
+  "rics_source.shortDescription": ["RICS Short Description"],
+  "technical.storeInv": ["Store Inv"],
+  "technical.warehouseInv": ["Warehouse Inv"],
+  "technical.variantCount": ["Variant Count"],
+  "technical.whsInv": ["WHS inv"],
+  "launch.launchDate": ["Launch Date"],
+  "descriptive.custom2": ["Custom 2"],
+  "descriptive.custom3": ["Custom 3"],
+  "pricing.scomRegularPrice": ["SCOM Regular Price"],
+  "pricing.scomSalePrice": ["SCOM Sale Price"],
+  "sku_core.dropshipName": ["Product Is Dropship.Name"]
+};
+
+// Helper: find index by canonicalPath
+const findIndexByCanonical = cp => reg.findIndex(r=>r.canonicalPath === cp);
+
+for (const [canonical, aliases] of Object.entries(additions)) {
+  const idx = findIndexByCanonical(canonical);
+  if (idx >= 0) {
+    const obj = reg[idx];
+    obj.importerColumns = obj.importerColumns || [];
+    for (const a of aliases) {
+      if (!obj.importerColumns.includes(a)) obj.importerColumns.push(a);
+    }
+    if (obj.canonicalPath === 'descriptive.primaryColor') {
+      obj.importerColumns = obj.importerColumns.filter(c => c !== 'rics_color');
+    }
+  } else {
+    const key = canonical.split('.').pop();
+    console.log('CREATING missing attribute for', canonical);
+    reg.push({
+      key: key,
+      canonicalPath: canonical,
+      label: key,
+      category: canonical.split('.')[0] || 'Uncategorized',
+      dataType: 'string',
+      required: false,
+      export: true,
+      description: `Added human alias for ${canonical}`,
+      systemFlag: false,
+      legacyPaths: [],
+      importerColumns: aliases,
+      rules: [],
+      usage: []
+    });
+  }
+}
+
+fs.writeFileSync(path, JSON.stringify(reg, null, 2) + '\n', 'utf8');
+console.log('WROTE', path);

--- a/ops/add-human-aliases.js
+++ b/ops/add-human-aliases.js
@@ -1,0 +1,70 @@
+// Adds human-friendly importer aliases to scripts/attribute-registry-normalized.json
+const fs = require('fs');
+const path = 'scripts/attribute-registry-normalized.json';
+const reg = JSON.parse(fs.readFileSync(path,'utf8'));
+
+const additions = {
+  "technical.lastReceived": ["Last Received"],
+  "sku_core.department": ["Group"],
+  "descriptive.primaryColor": ["Primary Color"],
+  "descriptive.descriptiveColor": ["Descriptive Color"],
+  "sku_core.productIsActive": ["Product Is Active"],
+  "technical.mediaStatus": ["Media"],
+  "launch.newCollection": ["New Collection"],
+  "launch.klPostDate": ["KL Post Date"],
+  "technical.hideImageDate": ["Hide Image Until Date"],
+  "rics_source.color": ["RICS Color"],
+  "rics_source.shortDescription": ["RICS Short Description"],
+  "technical.storeInv": ["Store Inv"],
+  "technical.warehouseInv": ["Warehouse Inv"],
+  "technical.variantCount": ["Variant Count"],
+  "technical.whsInv": ["WHS inv"],
+  "launch.launchDate": ["Launch Date"],
+  "descriptive.custom2": ["Custom 2"],
+  "descriptive.custom3": ["Custom 3"],
+  "pricing.scomRegularPrice": ["SCOM Regular Price"],
+  "pricing.scomSalePrice": ["SCOM Sale Price"],
+  "sku_core.dropshipName": ["Product Is Dropship.Name"]
+};
+
+// Helper: find index by canonicalPath
+const findIndexByCanonical = cp => reg.findIndex(r=>r.canonicalPath === cp);
+
+for(const [canonical, aliases] of Object.entries(additions)){
+  const idx = findIndexByCanonical(canonical);
+  if(idx>=0){
+    const obj = reg[idx];
+    obj.importerColumns = obj.importerColumns || [];
+    // add aliases without duplicates
+    for(const a of aliases){
+      if(!obj.importerColumns.includes(a)) obj.importerColumns.push(a);
+    }
+    // remove accidental rics_color from descriptive.primaryColor (safety)
+    if(obj.canonicalPath === 'descriptive.primaryColor'){
+      obj.importerColumns = obj.importerColumns.filter(c => c !== 'rics_color');
+    }
+  } else {
+    // if canonical attribute doesn't exist, create a lightweight attribute
+    const key = canonical.split('.').pop();
+    console.log('CREATING missing attribute for', canonical);
+    reg.push({
+      key: key,
+      canonicalPath: canonical,
+      label: key,
+      category: canonical.split('.')[0] || 'Uncategorized',
+      dataType: "string",
+      required: false,
+      export: true,
+      description: `Added human alias for ${canonical}`,
+      systemFlag: false,
+      legacyPaths: [],
+      importerColumns: aliases,
+      rules: [],
+      usage: []
+    });
+  }
+}
+
+// Write back file with 2-space indent
+fs.writeFileSync(path, JSON.stringify(reg, null, 2)+'\n', 'utf8');
+console.log('WROTE', path);

--- a/scripts/attribute-registry-normalized.json
+++ b/scripts/attribute-registry-normalized.json
@@ -242,7 +242,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "descriptive_color"
+      "descriptive_color",
+      "Descriptive Color"
     ],
     "rules": [],
     "usage": [],
@@ -548,7 +549,8 @@
     "importerColumns": [
       "primary_color",
       "primaryColor",
-      "primary_colour"
+      "primary_colour",
+      "Primary Color"
     ],
     "rules": [
       "SD-006"
@@ -674,7 +676,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "kl_post_date"
+      "kl_post_date",
+      "KL Post Date"
     ],
     "rules": [],
     "usage": [],
@@ -694,7 +697,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "launch_date"
+      "launch_date",
+      "Launch Date"
     ],
     "rules": [],
     "usage": [],
@@ -715,7 +719,8 @@
     "legacyPaths": [],
     "importerColumns": [
       "collection",
-      "new_collection"
+      "new_collection",
+      "New Collection"
     ],
     "rules": [],
     "usage": [],
@@ -776,7 +781,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "scom_regular"
+      "scom_regular",
+      "SCOM Regular Price"
     ],
     "rules": [],
     "usage": [],
@@ -796,7 +802,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "scom_sale"
+      "scom_sale",
+      "SCOM Sale Price"
     ],
     "rules": [],
     "usage": [],
@@ -859,7 +866,8 @@
     "legacyPaths": [],
     "importerColumns": [
       "rics_color",
-      "color"
+      "color",
+      "RICS Color"
     ],
     "rules": [],
     "usage": [],
@@ -901,7 +909,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "rics_short_description"
+      "rics_short_description",
+      "RICS Short Description"
     ],
     "rules": [],
     "usage": [],
@@ -1009,7 +1018,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "department"
+      "department",
+      "Group"
     ],
     "rules": [
       "SD-001"
@@ -1032,7 +1042,8 @@
     "legacyPaths": [],
     "importerColumns": [
       "dropship_name",
-      "product_is_dropship_name"
+      "product_is_dropship_name",
+      "Product Is Dropship.Name"
     ],
     "rules": [],
     "usage": [],
@@ -1100,7 +1111,8 @@
     "legacyPaths": [],
     "importerColumns": [
       "product_is_active",
-      "is_active"
+      "is_active",
+      "Product Is Active"
     ],
     "rules": [],
     "usage": [],
@@ -1315,7 +1327,8 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "hide_image_date"
+      "hide_image_date",
+      "Hide Image Until Date"
     ],
     "rules": [],
     "usage": [],
@@ -1338,7 +1351,8 @@
       "lastReceived"
     ],
     "importerColumns": [
-      "last_received"
+      "last_received",
+      "Last Received"
     ],
     "rules": [],
     "usage": [],
@@ -1379,7 +1393,8 @@
     "legacyPaths": [],
     "importerColumns": [
       "media_status",
-      "mediaStatus"
+      "mediaStatus",
+      "Media"
     ],
     "rules": [],
     "usage": [],
@@ -1488,7 +1503,8 @@
       "storeInv"
     ],
     "importerColumns": [
-      "store_inv"
+      "store_inv",
+      "Store Inv"
     ],
     "rules": [],
     "usage": [],
@@ -1554,7 +1570,8 @@
       "variantCount"
     ],
     "importerColumns": [
-      "variant_count"
+      "variant_count",
+      "Variant Count"
     ],
     "rules": [],
     "usage": [],
@@ -1576,7 +1593,8 @@
       "warehouseInv"
     ],
     "importerColumns": [
-      "warehouse_inv"
+      "warehouse_inv",
+      "Warehouse Inv"
     ],
     "rules": [],
     "usage": [],
@@ -1639,7 +1657,8 @@
       "whsInv"
     ],
     "importerColumns": [
-      "whs_inv"
+      "whs_inv",
+      "WHS inv"
     ],
     "rules": [],
     "usage": [],
@@ -1666,5 +1685,39 @@
     "examples": {
       "sampleValues": []
     }
+  },
+  {
+    "key": "custom2",
+    "canonicalPath": "descriptive.custom2",
+    "label": "custom2",
+    "category": "descriptive",
+    "dataType": "string",
+    "required": false,
+    "export": true,
+    "description": "Added human alias for descriptive.custom2",
+    "systemFlag": false,
+    "legacyPaths": [],
+    "importerColumns": [
+      "Custom 2"
+    ],
+    "rules": [],
+    "usage": []
+  },
+  {
+    "key": "custom3",
+    "canonicalPath": "descriptive.custom3",
+    "label": "custom3",
+    "category": "descriptive",
+    "dataType": "string",
+    "required": false,
+    "export": true,
+    "description": "Added human alias for descriptive.custom3",
+    "systemFlag": false,
+    "legacyPaths": [],
+    "importerColumns": [
+      "Custom 3"
+    ],
+    "rules": [],
+    "usage": []
   }
 ]


### PR DESCRIPTION
…Group, Primary Color, etc.)

# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->


## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] UX enhancement

## Editor UX Checklist
<!-- If this PR modifies product editor forms (Intake Queue, Settings, etc.), please review: -->

- [ ] **This PR modifies editor/form interfaces** → Complete the [Editor UX Quality Checklist](.github/PULL_REQUEST_TEMPLATE/editor-ux-checklist.md)
  - See [Editor UX Standard v1 Milestone](https://github.com/twgallo13/ROPI-V2.1/milestone/1) for context

## Testing
<!-- Describe the testing you've done -->

- [ ] Manual testing completed
- [ ] Edge cases tested
- [ ] Tested on different screen sizes (if UI change)
- [ ] No console errors

## Screenshots/Videos
<!-- If applicable, add screenshots or screen recordings to help explain your changes -->


## Additional Notes
<!-- Add any other context about the PR here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added human-friendly aliases for multiple attribute fields across descriptive, pricing, technical, and SKU categories, providing alternative names for data import operations
  * Introduced two new custom attribute fields (custom2 and custom3) with complete metadata support and import options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->