### PR TITLE
fix: support human-friendly CSV headers for importer

### DIFF
--- a/src/utils/fieldMapping.ts
+++ b/src/utils/fieldMapping.ts
@@ -99,6 +99,17 @@ export const CSV_TO_FIRESTORE_MAP: Record<string, string> = {
   'Store 4': 'technical.store4',
   'Total Inv': 'technical.totalInv',
 
+  // Missing human-friendly headers we must support (Technical additions)
+  'Media': 'technical.mediaStatus', // Some sheets use simplified header
+  'Hide Image Until Date': 'technical.hideImageDate', // Alternate embargo phrasing
+  'Variant Count': 'technical.variantCount', // Variant tally
+  'WHS inv': 'technical.whsInv', // Uppercase variant
+  'WHS Inv': 'technical.whsInv', // Uppercase variant
+  'Custom 2': 'descriptive.custom2', // Custom descriptive field
+  'Custom 3': 'descriptive.custom3', // Custom descriptive field
+  'Group': 'sku_core.department', // John: "Group" = Department
+  'Product Is Dropship.Name': 'sku_core.dropshipName', // Dropship name mapping
+
   // Launch
   'Hype': 'launch.hype',
   'Fast Fashion': 'launch.fastFashion',


### PR DESCRIPTION
Add missing CSV header mappings for Catalog team (metadata/code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CSV import now accepts additional header name variations and alternate naming conventions. Newly supported headers include Media, Hide Image Until Date, Variant Count, WHS Inventory fields, Custom 2 and Custom 3, Department/Group, and Product Dropship Name, providing greater flexibility and reducing import formatting errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->