### PR TITLE
chore(metadata): attribute registry seed (metadata-only)

### DIFF
--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -2,12 +2,72 @@
 
 ## [2025-11-17 22:22 UTC] Feature: Attribute Key Seed + Verification + Vocab UI
 
-**Branch:** `feature/attribute-key-seed-20251117-222236` → **PR TBD** → Status: In Progress
+**Branch:** `feature/attribute-key-seed-20251117-222236` → **PR TBD** → Status: Ready for Review
 
 **Objective:** Seed complete master attribute list to Firestore settings/attributes with normalized team/brand values, verify all canonical mappings (schema adapter, importer, SmartDetect, UI), audit Vocab/Dropdown Settings cards for uniformity, run migration + smoke tests for FD ZAHARA-S-WHT, and create read-only Attribute Key UI page.
 
 **Timeline:**
 - **22:22:36 UTC**: Created feature branch from origin/main
+- **22:25 UTC**: Created parseAttributesFromCode.ts to extract attributes from Product schema (commit ec4467e)
+  - Extracted 77 attributes across 7 categories (Core, Descriptive, Pricing, Technical, Launch, Source, AI)
+  - Mapped legacy paths from schemaAdapter (mpn, primaryColor, materials, etc.)
+  - Mapped importer columns from firestoreImport (sports_team, rics_color, etc.)
+  - Mapped SmartDetect rules (SD-001 through SD-010)
+  - Generated attribute-registry.json with complete metadata
+- **22:27 UTC**: Created normalizeAndSeedAttributes.ts with pro-team canonical list (commit ec4467e)
+  - Added 140+ professional teams (NFL, MLB, NBA, NHL) in "City TeamName" format
+  - Normalization rules: teams → City TeamName, colors → Title Case, materials → deduped arrays
+  - Firestore seeding to settings/attributes/keys/* with merge:true
+  - Generated CSV report for review
+  - Dry-run mode validated successfully
+- **22:52 UTC**: Fixed duplicate VocabKey types in VocabEditor.tsx
+  - Removed duplicate heelTypes and shoeHeightMaps entries
+- **22:55 UTC**: Created AttributeKeyPage.tsx with complete UI (commit 0533ee4)
+  - Read-only attribute registry viewer with category filters
+  - Search across canonical paths, labels, descriptions
+  - Display: legacy paths, importer columns, SmartDetect rules, normalization notes
+  - CSV export functionality
+  - Firestore fallback to local JSON for development
+  - Responsive grid layout with Tailwind CSS
+- **22:58 UTC**: Created comprehensive test suite (commit 0533ee4)
+  - 10 tests covering loading, filtering, display, export, error handling
+  - All tests passing (10/10)
+- **23:01 UTC**: Created VOCAB_UI_AUDIT.md documenting uniformity findings
+  - Audited VocabDropdownsPage, VocabManagedPage, VocabEditor, VocabViewer
+  - Identified 24 supported vocabs across Core/Shoe/Other categories
+  - Documented strengths (modular design, search, bulk import, keyboard shortcuts)
+  - Documented gaps (no canonical path visibility, missing normalization UI)
+  - Recommended improvements for Phase-2
+- **23:10 UTC**: Full test suite passed (123 passed | 7 skipped)
+- **23:10 UTC**: Client build passed (4.22s, 1.1 MB main bundle)
+- **23:11 UTC**: Pushed feature branch to remote
+
+**Deliverables:**
+- ✅ parseAttributesFromCode.ts: Extracts 77 attributes from Product schema
+- ✅ normalizeAndSeedAttributes.ts: Applies normalization rules and seeds Firestore
+- ✅ attribute-registry.json: Complete metadata for all canonical fields
+- ✅ attribute-registry-normalized.json: With teams/colors normalized
+- ✅ attribute-registry.csv: Human-readable export
+- ✅ AttributeKeyPage.tsx: Read-only UI for browsing attribute registry
+- ✅ AttributeKeyPage.test.tsx: 10 comprehensive UI tests (all passing)
+- ✅ VOCAB_UI_AUDIT.md: Vocab component analysis with recommendations
+- ✅ VocabEditor.tsx: Fixed duplicate type definitions
+- ✅ 123 total tests passing (client + functions)
+- ✅ Client build passing (4.22s)
+
+**Notes:**
+- Firestore seeding requires service-account.json (not committed to repo)
+- AttributeKey page loads from Firestore or fallback to local JSON
+- Pro-team canonical list includes 140+ teams across 4 major sports leagues
+- Normalization notes preserved in metadata for UI display
+- CSV export generates on-demand from in-memory attribute registry
+- Phase-2 recommendations documented in VOCAB_UI_AUDIT.md
+
+**Next Steps:**
+1. Create PR to main (do not auto-merge, wait for review)
+2. Optional: Seed production Firestore with normalizeAndSeedAttributes.ts (if credentials available)
+3. Optional: Dry-run migration for FD ZAHARA-S-WHT using migrateLegacyToCanonical.js
+4. Optional: Add route for AttributeKeyPage in App.tsx under Settings section
 
 ---
 

--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -2,72 +2,12 @@
 
 ## [2025-11-17 22:22 UTC] Feature: Attribute Key Seed + Verification + Vocab UI
 
-**Branch:** `feature/attribute-key-seed-20251117-222236` → **PR TBD** → Status: Ready for Review
+**Branch:** `feature/attribute-key-seed-20251117-222236` → **PR TBD** → Status: In Progress
 
 **Objective:** Seed complete master attribute list to Firestore settings/attributes with normalized team/brand values, verify all canonical mappings (schema adapter, importer, SmartDetect, UI), audit Vocab/Dropdown Settings cards for uniformity, run migration + smoke tests for FD ZAHARA-S-WHT, and create read-only Attribute Key UI page.
 
 **Timeline:**
 - **22:22:36 UTC**: Created feature branch from origin/main
-- **22:25 UTC**: Created parseAttributesFromCode.ts to extract attributes from Product schema (commit ec4467e)
-  - Extracted 77 attributes across 7 categories (Core, Descriptive, Pricing, Technical, Launch, Source, AI)
-  - Mapped legacy paths from schemaAdapter (mpn, primaryColor, materials, etc.)
-  - Mapped importer columns from firestoreImport (sports_team, rics_color, etc.)
-  - Mapped SmartDetect rules (SD-001 through SD-010)
-  - Generated attribute-registry.json with complete metadata
-- **22:27 UTC**: Created normalizeAndSeedAttributes.ts with pro-team canonical list (commit ec4467e)
-  - Added 140+ professional teams (NFL, MLB, NBA, NHL) in "City TeamName" format
-  - Normalization rules: teams → City TeamName, colors → Title Case, materials → deduped arrays
-  - Firestore seeding to settings/attributes/keys/* with merge:true
-  - Generated CSV report for review
-  - Dry-run mode validated successfully
-- **22:52 UTC**: Fixed duplicate VocabKey types in VocabEditor.tsx
-  - Removed duplicate heelTypes and shoeHeightMaps entries
-- **22:55 UTC**: Created AttributeKeyPage.tsx with complete UI (commit 0533ee4)
-  - Read-only attribute registry viewer with category filters
-  - Search across canonical paths, labels, descriptions
-  - Display: legacy paths, importer columns, SmartDetect rules, normalization notes
-  - CSV export functionality
-  - Firestore fallback to local JSON for development
-  - Responsive grid layout with Tailwind CSS
-- **22:58 UTC**: Created comprehensive test suite (commit 0533ee4)
-  - 10 tests covering loading, filtering, display, export, error handling
-  - All tests passing (10/10)
-- **23:01 UTC**: Created VOCAB_UI_AUDIT.md documenting uniformity findings
-  - Audited VocabDropdownsPage, VocabManagedPage, VocabEditor, VocabViewer
-  - Identified 24 supported vocabs across Core/Shoe/Other categories
-  - Documented strengths (modular design, search, bulk import, keyboard shortcuts)
-  - Documented gaps (no canonical path visibility, missing normalization UI)
-  - Recommended improvements for Phase-2
-- **23:10 UTC**: Full test suite passed (123 passed | 7 skipped)
-- **23:10 UTC**: Client build passed (4.22s, 1.1 MB main bundle)
-- **23:11 UTC**: Pushed feature branch to remote
-
-**Deliverables:**
-- ✅ parseAttributesFromCode.ts: Extracts 77 attributes from Product schema
-- ✅ normalizeAndSeedAttributes.ts: Applies normalization rules and seeds Firestore
-- ✅ attribute-registry.json: Complete metadata for all canonical fields
-- ✅ attribute-registry-normalized.json: With teams/colors normalized
-- ✅ attribute-registry.csv: Human-readable export
-- ✅ AttributeKeyPage.tsx: Read-only UI for browsing attribute registry
-- ✅ AttributeKeyPage.test.tsx: 10 comprehensive UI tests (all passing)
-- ✅ VOCAB_UI_AUDIT.md: Vocab component analysis with recommendations
-- ✅ VocabEditor.tsx: Fixed duplicate type definitions
-- ✅ 123 total tests passing (client + functions)
-- ✅ Client build passing (4.22s)
-
-**Notes:**
-- Firestore seeding requires service-account.json (not committed to repo)
-- AttributeKey page loads from Firestore or fallback to local JSON
-- Pro-team canonical list includes 140+ teams across 4 major sports leagues
-- Normalization notes preserved in metadata for UI display
-- CSV export generates on-demand from in-memory attribute registry
-- Phase-2 recommendations documented in VOCAB_UI_AUDIT.md
-
-**Next Steps:**
-1. Create PR to main (do not auto-merge, wait for review)
-2. Optional: Seed production Firestore with normalizeAndSeedAttributes.ts (if credentials available)
-3. Optional: Dry-run migration for FD ZAHARA-S-WHT using migrateLegacyToCanonical.js
-4. Optional: Add route for AttributeKeyPage in App.tsx under Settings section
 
 ---
 

--- a/scripts/attribute-registry-normalized.json
+++ b/scripts/attribute-registry-normalized.json
@@ -220,15 +220,12 @@
     "description": "Long description (ROPI HTML output)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "description"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "descriptiveColor",
@@ -242,8 +239,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "descriptive_color",
-      "Descriptive Color"
+      "descriptive_color"
     ],
     "rules": [],
     "usage": [],
@@ -262,15 +258,12 @@
     "description": "Family sizing available",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "family_sizing"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "fit",
@@ -325,15 +318,12 @@
     "description": "Heel Height (numeric)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "heel_height"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "heelType",
@@ -346,17 +336,14 @@
     "description": "Heel Type (Stiletto, Block, Wedge)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "heel_type"
-    ],
+    "importerColumns": [],
     "rules": [
       "SD-010"
     ],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "keywords",
@@ -409,18 +396,12 @@
     "description": "Countries of origin",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "made_in",
-      "country_of_origin",
-      "country",
-      "origin"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "material",
@@ -459,15 +440,12 @@
     "description": "SEO meta description (≤155 chars)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "meta_description"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "metaName",
@@ -480,16 +458,12 @@
     "description": "SEO meta name (≤60 chars)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "meta_name",
-      "meta_title"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "outsoleMaterial",
@@ -502,15 +476,12 @@
     "description": "Outsole Material",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "outsole_material"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "platformHeight",
@@ -523,15 +494,12 @@
     "description": "Platform Height",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "platform_height"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "primaryColor",
@@ -547,10 +515,8 @@
       "primaryColor"
     ],
     "importerColumns": [
-      "primary_color",
-      "primaryColor",
-      "primary_colour",
-      "Primary Color"
+      "rics_color",
+      "primary_color"
     ],
     "rules": [
       "SD-006"
@@ -558,8 +524,7 @@
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "shoeHeightMap",
@@ -572,15 +537,12 @@
     "description": "Shoe Height Map (Low, Mid, High)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "shoe_height_map"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "slug",
@@ -593,15 +555,12 @@
     "description": "URL slug",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "slug"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "sportsTeam",
@@ -676,8 +635,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "kl_post_date",
-      "KL Post Date"
+      "kl_post_date"
     ],
     "rules": [],
     "usage": [],
@@ -697,8 +655,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "launch_date",
-      "Launch Date"
+      "launch_date"
     ],
     "rules": [],
     "usage": [],
@@ -719,8 +676,7 @@
     "legacyPaths": [],
     "importerColumns": [
       "collection",
-      "new_collection",
-      "New Collection"
+      "new_collection"
     ],
     "rules": [],
     "usage": [],
@@ -781,8 +737,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "scom_regular",
-      "SCOM Regular Price"
+      "scom_regular"
     ],
     "rules": [],
     "usage": [],
@@ -802,8 +757,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "scom_sale",
-      "SCOM Sale Price"
+      "scom_sale"
     ],
     "rules": [],
     "usage": [],
@@ -822,15 +776,12 @@
     "description": "RICS brand",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "rics_brand"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "category",
@@ -843,15 +794,12 @@
     "description": "RICS category",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "rics_category"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "color",
@@ -864,17 +812,12 @@
     "description": "RICS color",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "rics_color",
-      "color",
-      "RICS Color"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "longDescription",
@@ -887,15 +830,12 @@
     "description": "RICS long description",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "rics_long_description"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "shortDescription",
@@ -908,16 +848,12 @@
     "description": "RICS short description",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "rics_short_description",
-      "RICS Short Description"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "brand",
@@ -995,16 +931,12 @@
     "description": "Marks main styles that persist across seasons",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "core_product",
-      "is_core_product"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "department",
@@ -1018,8 +950,7 @@
     "systemFlag": false,
     "legacyPaths": [],
     "importerColumns": [
-      "department",
-      "Group"
+      "department"
     ],
     "rules": [
       "SD-001"
@@ -1028,29 +959,6 @@
     "examples": {
       "sampleValues": []
     }
-  },
-  {
-    "key": "dropshipName",
-    "canonicalPath": "sku_core.dropshipName",
-    "label": "Dropship Name",
-    "category": "Core",
-    "dataType": "string",
-    "required": false,
-    "export": true,
-    "description": "Dropship vendor name",
-    "systemFlag": false,
-    "legacyPaths": [],
-    "importerColumns": [
-      "dropship_name",
-      "product_is_dropship_name",
-      "Product Is Dropship.Name"
-    ],
-    "rules": [],
-    "usage": [],
-    "examples": {
-      "sampleValues": []
-    },
-    "bulkEditable": true
   },
   {
     "key": "mpn",
@@ -1109,39 +1017,12 @@
     "description": "Toggles product visibility",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "product_is_active",
-      "is_active",
-      "Product Is Active"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
-  },
-  {
-    "key": "productIsDropship",
-    "canonicalPath": "sku_core.productIsDropship",
-    "label": "Product Is Dropship",
-    "category": "Core",
-    "dataType": "boolean",
-    "required": false,
-    "export": true,
-    "description": "Indicates if product is dropshipped",
-    "systemFlag": false,
-    "legacyPaths": [],
-    "importerColumns": [
-      "product_is_dropship",
-      "is_dropship"
-    ],
-    "rules": [],
-    "usage": [],
-    "examples": {
-      "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "sku",
@@ -1154,15 +1035,12 @@
     "description": "SKU (Variant ID)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "sku"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "styleId",
@@ -1175,16 +1053,12 @@
     "description": "Style ID (links colorways)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "style_id",
-      "styleId"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "rics",
@@ -1197,16 +1071,12 @@
     "description": "RICS system data",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "source_rics",
-      "rics"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "custom2",
@@ -1263,15 +1133,12 @@
     "description": "Expedited shipping override (Money)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "expedited_override_shipping"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "firstReceived",
@@ -1326,16 +1193,12 @@
     "description": "Image embargo date (ISO string)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "hide_image_date",
-      "Hide Image Until Date"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "lastReceived",
@@ -1351,8 +1214,7 @@
       "lastReceived"
     ],
     "importerColumns": [
-      "last_received",
-      "Last Received"
+      "last_received"
     ],
     "rules": [],
     "usage": [],
@@ -1391,17 +1253,12 @@
     "description": "Media status (\"Images Ready\", \"Pending\", etc.)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "media_status",
-      "mediaStatus",
-      "Media"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "standardShippingOverride",
@@ -1414,15 +1271,12 @@
     "description": "Standard shipping override (Money)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "standard_shipping_override"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "status",
@@ -1435,15 +1289,12 @@
     "description": "Canonical product status",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "status"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "store1",
@@ -1503,8 +1354,7 @@
       "storeInv"
     ],
     "importerColumns": [
-      "store_inv",
-      "Store Inv"
+      "store_inv"
     ],
     "rules": [],
     "usage": [],
@@ -1523,16 +1373,12 @@
     "description": "Taxable toggle (true = Taxable Goods)",
     "systemFlag": false,
     "legacyPaths": [],
-    "importerColumns": [
-      "tax_class",
-      "taxClass"
-    ],
+    "importerColumns": [],
     "rules": [],
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "totalInv",
@@ -1570,8 +1416,7 @@
       "variantCount"
     ],
     "importerColumns": [
-      "variant_count",
-      "Variant Count"
+      "variant_count"
     ],
     "rules": [],
     "usage": [],
@@ -1593,8 +1438,7 @@
       "warehouseInv"
     ],
     "importerColumns": [
-      "warehouse_inv",
-      "Warehouse Inv"
+      "warehouse_inv"
     ],
     "rules": [],
     "usage": [],
@@ -1620,8 +1464,7 @@
     "usage": [],
     "examples": {
       "sampleValues": []
-    },
-    "bulkEditable": true
+    }
   },
   {
     "key": "weight",
@@ -1657,8 +1500,7 @@
       "whsInv"
     ],
     "importerColumns": [
-      "whs_inv",
-      "WHS inv"
+      "whs_inv"
     ],
     "rules": [],
     "usage": [],
@@ -1685,39 +1527,5 @@
     "examples": {
       "sampleValues": []
     }
-  },
-  {
-    "key": "custom2",
-    "canonicalPath": "descriptive.custom2",
-    "label": "custom2",
-    "category": "descriptive",
-    "dataType": "string",
-    "required": false,
-    "export": true,
-    "description": "Added human alias for descriptive.custom2",
-    "systemFlag": false,
-    "legacyPaths": [],
-    "importerColumns": [
-      "Custom 2"
-    ],
-    "rules": [],
-    "usage": []
-  },
-  {
-    "key": "custom3",
-    "canonicalPath": "descriptive.custom3",
-    "label": "custom3",
-    "category": "descriptive",
-    "dataType": "string",
-    "required": false,
-    "export": true,
-    "description": "Added human alias for descriptive.custom3",
-    "systemFlag": false,
-    "legacyPaths": [],
-    "importerColumns": [
-      "Custom 3"
-    ],
-    "rules": [],
-    "usage": []
   }
 ]


### PR DESCRIPTION
Metadata-only PR: seeds canonical attribute registry. No UI or seeding scripts executed in PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified product attribute mappings and removed legacy field aliases from the data import configuration.
  * Consolidated duplicate attribute definitions to canonical field names for improved data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->