### PR TITLE
fix(registry): guard sort comparator against undefined category/label (v3.3.0)

### DIFF
--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -1,5 +1,10 @@
 # HOMER Operations Log
 
+## [2025-11-23] v3.3.0 — Micro-fixes (PRs A, B, C)
+
+### PR A: Runtime fix (fix/v3.3-registry-sort-guard)
+- Runtime fix: Guarded attribute registry sort comparator against undefined category/label to avoid localeCompare TypeError on ACC load.
+
 ## [2025-11-23 06:57 UTC] v3.2.2 — Merge conflict resolution (PR #117)
 
 **Timestamp:** 2025-11-23T06:57:28Z

--- a/operations/review-artifacts/v3.3-registry-sort-guard/homer-summary.txt
+++ b/operations/review-artifacts/v3.3-registry-sort-guard/homer-summary.txt
@@ -1,0 +1,6 @@
+PR A - Registry Sort Guard Fix
+
+Changed: src/utils/attributeRegistry.ts - Added defensive guards in sort comparator to handle undefined category/label values by converting to empty strings before calling localeCompare().
+Tests: 213 passed (25 test files), no new failures introduced.
+Build: Successful (dist/ created, 1.16MB main bundle).
+Caveat: This is a safe runtime-only guard with no behavior changes for valid data. Prevents TypeError when attributes have missing category/label fields.

--- a/src/utils/attributeRegistry.ts
+++ b/src/utils/attributeRegistry.ts
@@ -72,9 +72,14 @@ export async function getAttributeRegistry(options: { forceRefresh?: boolean } =
     });
     
     // Sort by category then label for UI consistency
+    // Guard against undefined category/label to avoid runtime errors (localeCompare on undefined).
     attributes.sort((a, b) => {
-      if (a.category !== b.category) return a.category.localeCompare(b.category);
-      return a.label.localeCompare(b.label);
+      const aCat = (a.category || '').toString();
+      const bCat = (b.category || '').toString();
+      if (aCat !== bCat) return aCat.localeCompare(bCat);
+      const aLabel = (a.label || '').toString();
+      const bLabel = (b.label || '').toString();
+      return aLabel.localeCompare(bLabel);
     });
     
     cachedRegistry = attributes;


### PR DESCRIPTION
## Overview

This PR fixes a runtime TypeError that occurs when the attribute registry sort comparator encounters attributes with undefined `category` or `label` fields.

## Issue

The original error (from `/mnt/data/sample error.txt`):
```
TypeError: Cannot read property 'localeCompare' of undefined
```

This occurs when `a.category` or `a.label` is undefined and the code tries to call `.localeCompare()` on it.

## Fix

Added defensive guards in `src/utils/attributeRegistry.ts` to convert undefined values to empty strings before calling `localeCompare()`:

```typescript
const aCat = (a.category || '').toString();
const bCat = (b.category || '').toString();
if (aCat !== bCat) return aCat.localeCompare(bCat);
const aLabel = (a.label || '').toString();
const bLabel = (b.label || '').toString();
return aLabel.localeCompare(bLabel);
```

## Testing

✅ **213 tests passed** (25 test files)
✅ **Build successful** (1.16MB main bundle)
✅ **No new failures introduced**

## Safety

This is a **runtime-only guard** with no behavior changes for valid data. It prevents crashes when attributes have missing category/label fields, allowing the ACC page to load successfully.

## Artifacts

All logs and artifacts saved to:
`operations/review-artifacts/v3.3-registry-sort-guard/`

- npm-test-v3.3-registry-sort-guard.log
- npm-build-v3.3-registry-sort-guard.log
- homer-summary.txt

## Verification

Reviewers should:
1. Open ACC page (`/settings/attributes`)
2. Confirm no `localeCompare` TypeError in browser console
3. Verify attributes sort correctly by category then label

---

**Part of v3.3.0 micro-fixes initiative** (PR A of 3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guards attribute registry sort comparator against undefined category/label to prevent localeCompare runtime errors; tests/build pass.
> 
> - **Runtime fix**:
>   - In `src/utils/attributeRegistry.ts`, update sort comparator to coerce missing `category`/`label` to empty strings before `localeCompare`, preventing TypeError during ACC load.
> - **Ops/Docs**:
>   - Add v3.3.0 log entry and review artifact summary for the fix; tests (213) and build succeed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 753bcebcbfd20badd804b43c6c86c2e66ea95f72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a runtime error that could occur during application load when certain attribute data contained missing values, ensuring more reliable initialization and preventing crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->