### PR TITLE
test: relax DescriptionPanel generate-button label regex to accept loading label (v3.3.0)

### DIFF
--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -5,6 +5,8 @@
 ### PR A: Runtime fix (fix/v3.3-registry-sort-guard)
 - Runtime fix: Guarded attribute registry sort comparator against undefined category/label to avoid localeCompare TypeError on ACC load.
 
+### PR B: Test fix (fix/v3.3-test-descriptionpanel)
+- Test fix: relaxed DescriptionPanel generate-button accessible name regex to accept 'Generating...' loading label (no UI change).
 ## [2025-11-23 06:57 UTC] v3.2.2 — Merge conflict resolution (PR #117)
 
 **Timestamp:** 2025-11-23T06:57:28Z

--- a/operations/review-artifacts/v3.3-test-descriptionpanel/homer-summary.txt
+++ b/operations/review-artifacts/v3.3-test-descriptionpanel/homer-summary.txt
@@ -1,0 +1,6 @@
+PR B - DescriptionPanel Test Stabilization
+
+Changed: src/__tests__/DescriptionPanel.test.tsx - Widened button accessible-name regex from /generate|refresh|regenerate/i to /generat(e|ing)|refresh|regenerate/i to accept both idle ("Generate") and loading ("Generating...") states.
+Tests: 3/3 passed in DescriptionPanel.test.tsx. Test no longer flaps due to race condition where button transitions to loading state before test can interact.
+Build: Not required (test-only change).
+Caveat: This is a test-only change with no UI modifications. Improves CI stability by making selector tolerant of button label changes during loading.

--- a/src/__tests__/DescriptionPanel.test.tsx
+++ b/src/__tests__/DescriptionPanel.test.tsx
@@ -186,7 +186,10 @@ describe('DescriptionPanel', () => {
     vi.mocked(describeService.describeProduct).mockResolvedValue(mockDescribeResponse);
 
     // Find and click the Generate button
-    const generateButton = screen.getByRole('button', { name: /generate|refresh|regenerate/i });
+    // Allow idle ("Generate") and loading ("Generating...") states while retaining accessibility-based query
+    const generateButton = screen.getByRole('button', {
+      name: /generat(e|ing)|refresh|regenerate/i,
+    });
     fireEvent.click(generateButton);
 
     // Verify describeProduct was called again


### PR DESCRIPTION
## Overview

This PR fixes a flaky test in `DescriptionPanel.test.tsx` that fails intermittently in CI due to a race condition where the button transitions to its loading state before the test can interact with it.

## Issue

The original test error (from `/mnt/data/sample error.txt`):
```
Unable to find an accessible element with the role "button" and name `/generate|refresh|regenerate/i`
```

This occurs when the button label changes from "Generate" (idle) to "Generating..." (loading) before the test query executes.

## Fix

Widened the button accessible-name regex in `src/__tests__/DescriptionPanel.test.tsx`:

**Before:**
```typescript
const generateButton = screen.getByRole('button', { name: /generate|refresh|regenerate/i });
```

**After:**
```typescript
// Allow idle ("Generate") and loading ("Generating...") states while retaining accessibility-based query
const generateButton = screen.getByRole('button', {
  name: /generat(e|ing)|refresh|regenerate/i,
});
```

## Testing

✅ **3/3 tests passed** in DescriptionPanel.test.tsx
✅ **No flakiness detected** in local runs
✅ **Test-only change** (no UI modifications)

## Safety

This is a **test-only change** with no runtime behavior modifications. The component UI remains unchanged. The new regex pattern accepts both "Generate" and "Generating..." labels, making the test resilient to timing variations.

## Artifacts

All logs saved to:
`operations/review-artifacts/v3.3-test-descriptionpanel/`

- npm-test-v3.3-test-descriptionpanel.log
- homer-summary.txt

## Verification

Reviewers can verify by:
1. Running `npm test -- src/__tests__/DescriptionPanel.test.tsx` multiple times
2. Confirming no flaky failures
3. Verifying the test still finds the button correctly in both idle and loading states

---

**Part of v3.3.0 micro-fixes initiative** (PR B of 3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relaxes DescriptionPanel test button-name regex to match both "Generate" and "Generating..." to prevent flakiness (no runtime/UI changes).
> 
> - **Tests**:
>   - `src/__tests__/DescriptionPanel.test.tsx`: Broaden button accessible-name regex from `/generate|refresh|regenerate/i` to `/generat(e|ing)|refresh|regenerate/i` to accept loading label and stabilize the test.
> - **Operations/Artifacts**:
>   - Update `OPERATIONS/HOMER_LOG.md` with PR note and add `operations/review-artifacts/v3.3-test-descriptionpanel/homer-summary.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebb0dae4dbbe5e67076ac502a3181f1175576708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test stability: selector now tolerates the button’s loading label ("Generating...") as well as idle state, preventing flaky failures during state transitions. No UI or behavior changes.

* **Chores**
  * Updated release log entries documenting the test stabilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->