### PR TITLE
fix: Remove unused variables in AttributesCommandCenter

### DIFF
--- a/OPERATIONS/HOMER_LOG.md
+++ b/OPERATIONS/HOMER_LOG.md
@@ -2,8 +2,10 @@
 
 ## [2025-11-23] v3.3.0 — Micro-fixes (PRs A, B, C)
 
-### PR A: Runtime fix (fix/v3.3-registry-sort-guard)
+### PR A: Runtime fix (fix/v3.3-registry-sort-guard) - MERGED ✅
 - Runtime fix: Guarded attribute registry sort comparator against undefined category/label to avoid localeCompare TypeError on ACC load.
+- Merged: PR #119, commit 086654b
+- Verified: Local build + tests pass (213/213). Defensive coercion `(a.category || '').toString()` applied to sort comparator.
 
 ## [2025-11-23 06:57 UTC] v3.2.2 — Merge conflict resolution (PR #117)
 

--- a/src/pages/settings/AttributesCommandCenter.tsx
+++ b/src/pages/settings/AttributesCommandCenter.tsx
@@ -54,7 +54,7 @@ interface Attribute {
 }
 
 export default function AttributesCommandCenter() {
-  const { user, role } = useAuth();
+  const { role } = useAuth();
   const [attributes, setAttributes] = useState<Attribute[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
@@ -451,7 +451,7 @@ export default function AttributesCommandCenter() {
             setDrawerOpen(false);
             setSelectedAttribute(null);
           }}
-          onSave={(updated) => {
+          onSave={() => {
             fetchAttributes();
             setDrawerOpen(false);
             setSelectedAttribute(null);


### PR DESCRIPTION
Fixes ESLint warnings by removing unused `user` variable and unused `updated` parameter in onSave callback.

Part of v3.3.0 micro-fixes cleanup.

Changes:
- Removed unused `user` from `useAuth()` destructuring
- Removed unused `updated` parameter from `onSave` callback

No functional changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused variables in AttributesCommandCenter and updates HOMER operations log with PR A merge details.
> 
> - **Frontend**:
>   - `src/pages/settings/AttributesCommandCenter.tsx`:
>     - Remove unused `user` from `useAuth()` destructuring.
>     - Drop unused `updated` parameter from `onSave` callback.
> - **Docs/Operations**:
>   - `OPERATIONS/HOMER_LOG.md`: Mark PR A as merged and add commit/tests verification details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 626a43add4e00601cd2c0c19330e3fcd819462e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication handling in the settings interface to use role-based access
  * Optimized component integration for attribute updates, ensuring proper data refresh and UI state management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->