### PR TITLE
fix(search): guard toLowerCase usages in ACC render path

### DIFF
--- a/src/utils/attributeGrouping.ts
+++ b/src/utils/attributeGrouping.ts
@@ -90,10 +90,10 @@ function determineSourceKind(attr: AttributeData): SourceKind {
   
   // Check if vendor (has RICS or vendor-specific columns)
   const columns = attr.importerColumns || [];
-  if (columns.some((col: string) => 
-    col.toLowerCase().includes('rics') || 
-    col.toLowerCase().includes('vendor')
-  )) {
+  if (columns.some((col: string) => {
+    const colLower = String(col || '').toLowerCase();
+    return colLower.includes('rics') || colLower.includes('vendor');
+  })) {
     return 'vendor';
   }
   
@@ -214,26 +214,32 @@ export function filterGroupedAttributes(
     return groups;
   }
   
-  const term = searchTerm.toLowerCase().trim();
+  const term = String(searchTerm || '').toLowerCase().trim();
   
   return groups.filter(group => {
     // Search in canonical path
-    if (group.canonicalPath.toLowerCase().includes(term)) {
+    const pathLower = String(group.canonicalPath || '').toLowerCase();
+    if (pathLower.includes(term)) {
       return true;
     }
     
     // Search in display name
-    if (group.displayName.toLowerCase().includes(term)) {
+    const nameLower = String(group.displayName || '').toLowerCase();
+    if (nameLower.includes(term)) {
       return true;
     }
     
     // Search in any variant label
-    if (group.variants.some(v => v.label.toLowerCase().includes(term))) {
+    if (group.variants.some(v => {
+      const labelLower = String(v.label || '').toLowerCase();
+      return labelLower.includes(term);
+    })) {
       return true;
     }
     
     // Search in description
-    if (group.primaryAttribute.description?.toLowerCase().includes(term)) {
+    const descLower = String(group.primaryAttribute.description || '').toLowerCase();
+    if (descLower.includes(term)) {
       return true;
     }
     


### PR DESCRIPTION
## Summary
Guards all `toLowerCase()` calls in ACC render/search path to prevent `TypeError` when attribute fields contain undefined values.

## Problem
The ACC search and filtering logic crashed with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` when attributes had undefined/null values for:
- `canonicalPath`
- `displayName`
- `label`
- `description`
- `importerColumns` entries

## Solution
Applied defensive String coercion pattern: `String(value || '').toLowerCase()`

## Changes
**File:** `src/utils/attributeGrouping.ts`

1. **Line 93-95:** Guard `col.toLowerCase()` in vendor detection
2. **Lines 217-236:** Guard all toLowerCase calls in `filterGroupedAttributes`:
   - searchTerm parameter
   - canonicalPath comparison
   - displayName comparison  
   - variant label comparisons
   - description comparison

## Validation
- ✅ Lint: 0 errors, 334 warnings (pre-existing)
- ✅ Tests: All passing (19 tests)
- ✅ Build: Clean 4.37s
- ✅ Deployed to staging: https://ropi-bccee.web.app/settings/attributes
- ✅ API smoke test: Suggest endpoint working

## Artifacts
Location: `operations/review-artifacts/v3.3-tolower-guards/`
- toLower-grep.txt (all toLowerCase usages)
- toLower-grep-acc.txt (ACC-specific usages)
- npm-lint-tolower.log (0 errors)
- npm-test-tolower.log (all passing)
- npm-build-tolower.log (clean build)
- firebase-deploy-tolower.log (successful deploy)
- suggest-response.pretty.json (API test)

## Testing Instructions
1. Open: https://ropi-bccee.web.app/settings/attributes
2. Use search box to filter attributes
3. Confirm: No console errors, no blank screen
4. Verify: Attribute details still display correctly

## Related
- Fixes toLowerCase crash reported in staging
- Part of v3.3.0 defensive coding improvements
- Base branch: axs/v3.3-resolve-118 (PR #118)