### PR TITLE
chore: v3.3 Seeder Denormalization for allowedValues

### DIFF
--- a/operations/review-artifacts/INTERIM_REPORT_V3.3_UX_POLISH.md
+++ b/operations/review-artifacts/INTERIM_REPORT_V3.3_UX_POLISH.md
@@ -1,0 +1,324 @@
+# v3.3 UX Polish and Seeder Denormalization - INTERIM REPORT
+
+**Date:** 2024-11-24  
+**Homer Status:** IN PROGRESS - 2 of 4 features completed
+
+---
+
+## Executive Summary
+
+Implementing v3.3 UX polish features as specified. Progress:
+- ✅ **Always-grouping in ACC:** Already complete from PR #118
+- ✅ **SKU Preview Feature:** Complete and committed to `feat/v3.3-sku-preview`
+- ⏸️ **Seeder Denormalization:** Ready to implement
+- ⏸️ **Permissions UX:** Ready to implement
+
+---
+
+## Feature 1: Always-Grouping (Already Complete)
+
+**Status:** ✅ SHIPPED in PR #118 (v3.3.0)
+
+**Implementation:** `src/pages/settings/AttributesCommandCenter.tsx` already uses:
+- `groupAttributesByPath()` from `src/utils/attributeGrouping.ts`
+- `filterGroupedAttributes()` for search filtering
+- Rendering always shows grouped view with variants
+- Expand/collapse chevrons for variant display
+- Source badges (Core/Vendor/Legacy/AI/Deprecated)
+
+**No Changes Needed:** This feature is production-ready.
+
+---
+
+## Feature 2: SKU Preview ("Show sample SKUs")
+
+**Status:** ✅ COMPLETE - Ready for PR
+
+**Branch:** `feat/v3.3-sku-preview`  
+**Commit:** `585b4f7`
+
+### Changes Made
+
+#### Backend (Cloud Functions)
+- **File:** `functions/src/handlers/attributes.ts`
+  - Added `getValuePreview(req, res)` function (70 lines)
+  - Queries products collection with configurable limit (max 50)
+  - Navigates nested product structure via canonical path
+  - Returns: `{ success, canonicalPath, samples[], totalFound }`
+
+- **File:** `functions/src/api/index.ts`
+  - Added route: `GET /api/attributes/value-preview?path=<canonicalPath>&limit=<number>`
+
+#### Frontend
+- **File:** `src/hooks/useAttributeValuePreview.ts` (NEW - 61 lines)
+  - React hook managing value preview state
+  - Interface: `{ samples, loading, error, load }`
+  - TypeScript types: `ValuePreviewSample`, `ValuePreviewResponse`
+
+- **File:** `src/pages/settings/components/AttributeDetailDrawer.tsx`
+  - Import: `useAttributeValuePreview` hook
+  - Hook instantiated with `formData.canonicalPath`
+  - UI section added in Validation tab:
+    - "Show sample SKUs" button
+    - Sample cards (SKU, Value, Raw Path)
+    - Error display
+    - Loading states
+
+### Validation
+
+```
+✅ Lint: 0 errors, 334 warnings (pre-existing)
+✅ Tests: 225 passed, 9 skipped (13.00s)
+✅ Build: Clean build 4.41s → bundle index-i2uahm_-.js (1,169.15 kB)
+```
+
+### Artifacts
+
+**Location:** `operations/review-artifacts/feat-v3.3-sku-preview/`
+- `npm-lint.log`
+- `npm-test.log`
+- `npm-build.log`
+- `homer-summary.txt`
+
+### Next Steps
+
+1. **Create PR** for `feat/v3.3-sku-preview` → `main`
+2. **Deploy to Staging** (after PR #118 merge if not yet done)
+3. **Manual Testing:**
+   - Open Attribute Detail Drawer
+   - Navigate to Validation tab
+   - Click "Show sample SKUs"
+   - Verify samples display correctly
+
+**PR URL:** (To be created)
+
+---
+
+## Feature 3: Seeder Denormalization
+
+**Status:** ⏸️ READY TO IMPLEMENT
+
+**Branch:** `chore/v3.3-seeder-denorm` (to be created)
+
+### Implementation Plan
+
+**File:** `scripts/normalizeAndSeedAttributes.ts`
+
+**Required Changes:**
+1. For each attribute with `validation.allowedValuesRef`:
+   - Parse the ref path (e.g., `settings/lists/colors`)
+   - Query Firestore collection at that path
+   - Build `allowedValues` array from docs
+   - Write both `allowedValuesRef` AND `allowedValues` to attribute doc
+
+2. Add function:
+```typescript
+async function resolveAllowedValuesRef(refPath: string): Promise<string[]> {
+  const db = admin.firestore();
+  // Parse refPath, query collection, map to values
+  const snapshot = await db.collection(refPath).get();
+  return snapshot.docs.map(d => d.data().value || d.id).filter(Boolean);
+}
+```
+
+3. In seeder loop:
+```typescript
+if (data.validation?.allowedValuesRef) {
+  const allowedValues = await resolveAllowedValuesRef(data.validation.allowedValuesRef);
+  data.validation.allowedValues = allowedValues;
+}
+```
+
+### Validation Steps
+
+1. Run dry-run to verify resolution logic
+2. Seed to staging
+3. Query attribute docs and confirm `allowedValues` array exists
+4. Verify ACC Attribute Detail Drawer shows pills correctly
+
+### Artifacts To Collect
+
+- `normalize-dryrun-denorm.log`
+- `normalize-seed-denorm.log`
+- Firestore screenshot showing denormalized `allowedValues`
+
+---
+
+## Feature 4: Permissions UX
+
+**Status:** ⏸️ READY TO IMPLEMENT
+
+**Branch:** `chore/v3.3-permissions-ux` (to be created)
+
+### Implementation Plan
+
+#### 1. Display Current Role
+
+**File:** `src/pages/settings/AttributesCommandCenter.tsx`
+
+**Location:** Hero section header (after "Attribute Command Center" title)
+
+```tsx
+const { role } = useAuth(); // Already exists
+
+// In hero section, add:
+<div className="flex items-center justify-between">
+  <div>
+    <h1 className="text-2xl font-bold mb-2">Attribute Command Center</h1>
+    <p className="text-indigo-100">Manage canonical attributes...</p>
+  </div>
+  <div className="text-right">
+    <span className="text-xs text-indigo-200">Current Role:</span>
+    <div className="text-sm font-medium">{role || 'viewer'}</div>
+  </div>
+</div>
+```
+
+#### 2. Permission Modal
+
+**File:** `src/pages/settings/components/PermissionRequestModal.tsx` (NEW)
+
+```tsx
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  currentRole: string;
+}
+
+export default function PermissionRequestModal({ isOpen, onClose, currentRole }: Props) {
+  return (
+    <div className={...modal overlay...}>
+      <div className="modal-content">
+        <h2>Request Editor Access</h2>
+        <p>Current role: <strong>{currentRole}</strong></p>
+        <p>To request editor or admin access:</p>
+        <ol>
+          <li>Email theo@shiekhshoes.org</li>
+          <li>Include your email and reason</li>
+          <li>Admin will grant access within 24 hours</li>
+        </ol>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}
+```
+
+#### 3. Update Save/Seed Handlers
+
+**File:** `src/pages/settings/components/AttributeDetailDrawer.tsx`
+
+```tsx
+const [showPermissionModal, setShowPermissionModal] = useState(false);
+
+async function handleSave() {
+  if (!isEditable) {
+    // Instead of alert, open modal
+    setShowPermissionModal(true);
+    return;
+  }
+  // ... existing save logic
+}
+```
+
+### Validation
+
+- Verify role display shows correctly for viewer/editor/admin
+- Click Save/Seed as viewer → modal opens with instructions
+- Modal does NOT automatically change role
+- Email link or copy-paste instructions clear
+
+---
+
+## Remaining Work Summary
+
+### To Complete
+
+1. **Feature 3 - Seeder Denormalization:**
+   - Create branch `chore/v3.3-seeder-denorm`
+   - Modify `scripts/normalizeAndSeedAttributes.ts`
+   - Add `resolveAllowedValuesRef()` function
+   - Run tests, lint, build
+   - Dry-run + seed to staging
+   - Collect artifacts
+   - Create PR
+
+2. **Feature 4 - Permissions UX:**
+   - Create branch `chore/v3.3-permissions-ux`
+   - Add role display in ACC header
+   - Create `PermissionRequestModal` component
+   - Update Save/Seed handlers
+   - Run tests, lint, build
+   - Deploy to staging
+   - Manual verification
+   - Collect artifacts
+   - Create PR
+
+3. **Create PRs:**
+   - PR #1: feat/v3.3-sku-preview (READY NOW)
+   - PR #2: chore/v3.3-seeder-denorm (after implementation)
+   - PR #3: chore/v3.3-permissions-ux (after implementation)
+
+4. **Final Artifacts:**
+   - Consolidate all artifacts into `FINAL_REPORT.md`
+   - Update `OPERATIONS/HOMER_LOG.md` with all changes
+   - Deploy all features to staging
+   - Manual testing checklist
+   - Staging screenshots + console logs
+
+---
+
+## Current Token Status
+
+**Token Usage:** ~87K of 1M tokens used  
+**Estimated Remaining Work:** ~100K tokens (within budget)
+
+**Recommendation:** Continue with Feature 3 (Seeder Denormalization) next, as it's a critical backend change that unblocks the full UX polish feature set.
+
+---
+
+## Commands Reference
+
+### For Seeder Denormalization
+```bash
+cd /workspaces/ROPI-V2.1
+git checkout main && git pull origin main
+git checkout -b chore/v3.3-seeder-denorm
+
+# Edit scripts/normalizeAndSeedAttributes.ts
+# Add resolveAllowedValuesRef() function
+
+npm run lint 2>&1 | tee operations/review-artifacts/chore-v3.3-seeder-denorm/npm-lint.log
+npm test -- --run 2>&1 | tee operations/review-artifacts/chore-v3.3-seeder-denorm/npm-test.log
+npm run build 2>&1 | tee operations/review-artifacts/chore-v3.3-seeder-denorm/npm-build.log
+
+npx tsx scripts/normalizeAndSeedAttributes.ts --dry-run | tee operations/review-artifacts/chore-v3.3-seeder-denorm/normalize-dryrun.log
+npx tsx scripts/normalizeAndSeedAttributes.ts --seed | tee operations/review-artifacts/chore-v3.3-seeder-denorm/normalize-seed.log
+
+git add -A
+git commit -m "chore: add seeder denormalization for allowedValues"
+git push origin chore/v3.3-seeder-denorm
+```
+
+### For Permissions UX
+```bash
+cd /workspaces/ROPI-V2.1
+git checkout main && git pull origin main
+git checkout -b chore/v3.3-permissions-ux
+
+# Create PermissionRequestModal.tsx
+# Edit AttributesCommandCenter.tsx (add role display)
+# Edit AttributeDetailDrawer.tsx (add modal trigger)
+
+npm run lint | tee operations/review-artifacts/chore-v3.3-permissions-ux/npm-lint.log
+npm test -- --run | tee operations/review-artifacts/chore-v3.3-permissions-ux/npm-test.log
+npm run build | tee operations/review-artifacts/chore-v3.3-permissions-ux/npm-build.log
+
+git add -A
+git commit -m "chore: add permissions UX (role display + request modal)"
+git push origin chore/v3.3-permissions-ux
+```
+
+---
+
+**Next Action:** Create PR for feat/v3.3-sku-preview, then proceed with Feature 3 implementation.

--- a/operations/review-artifacts/chore-v3.3-seeder-denorm/homer-summary.txt
+++ b/operations/review-artifacts/chore-v3.3-seeder-denorm/homer-summary.txt
@@ -1,0 +1,117 @@
+chore/v3.3-seeder-denorm — Seeder Denormalization for allowedValues
+
+**Branch:** chore/v3.3-seeder-denorm
+**Status:** ✅ Ready for Review
+
+## Summary
+
+Implemented full denormalization of `validation.allowedValuesRef` in the attribute seeder. The seeder now resolves Firestore collection references and writes the `allowedValues` array directly into attribute documents.
+
+## Changes Made
+
+### File: `scripts/normalizeAndSeedAttributes.ts`
+
+**Added Function:** `resolveAllowedValuesRef(db, refPath)`
+- Parses collection reference paths (e.g., `settings/lists/colors`)
+- Dynamically builds Firestore collection reference
+- Fetches all documents from the collection
+- Extracts values from common fields (`value`, `name`, `label`, or doc ID)
+- Returns array of string values
+- Handles errors gracefully with console warnings
+
+**Updated Function:** `seedFirestore(attributes, dryRun)`
+- Now initializes Firebase Admin before dry-run (needed for ref resolution)
+- Loops through attributes and resolves all `allowedValuesRef` references
+- Writes denormalized `allowedValues` array to attribute documents
+- Logs resolution progress (e.g., "Resolved 5 allowedValuesRef references")
+- In dry-run mode, displays sample attribute with denormalized values
+
+**Removed:** TODO comment about vocab resolution (now implemented)
+
+## Benefits
+
+1. **Client Performance:** Attributes now have `allowedValues` array inline, no client-side resolution needed
+2. **Consistency:** All attributes with vocab sets get denormalized values
+3. **ACC UX:** Attribute Detail Drawer can display allowed value pills without fetching external collections
+4. **Idempotent:** Re-running seeder updates denormalized values if vocab collections change
+
+## Validation
+
+### CI Checks
+```
+✅ Lint: 0 errors, 334 warnings (pre-existing)
+✅ Tests: 225 passed, 9 skipped (12.46s)
+✅ Build: Clean build 4.34s
+```
+
+### Seeder Test
+```
+✅ Dry-run: Completed successfully
+✅ Resolution: 0 refs found in current registry (none present yet)
+✅ Logic: Denormalization code ready for when refs exist
+```
+
+### Logs
+- `operations/review-artifacts/chore-v3.3-seeder-denorm/npm-lint.log`
+- `operations/review-artifacts/chore-v3.3-seeder-denorm/npm-test.log`
+- `operations/review-artifacts/chore-v3.3-seeder-denorm/npm-build.log`
+- `operations/review-artifacts/chore-v3.3-seeder-denorm/normalize-dryrun.log`
+
+## Testing Instructions
+
+### To Test with Real Data
+
+1. **Add `allowedValuesRef` to an attribute:**
+   ```json
+   {
+     "canonicalPath": "color",
+     "validation": {
+       "allowedValuesRef": "settings/lists/colors"
+     }
+   }
+   ```
+
+2. **Create vocab collection in Firestore:**
+   ```
+   settings/lists/colors/
+     - red: { value: "Red" }
+     - blue: { value: "Blue" }
+     - green: { value: "Green" }
+   ```
+
+3. **Run seeder:**
+   ```bash
+   npx tsx scripts/normalizeAndSeedAttributes.ts --dry-run
+   # Should show: "Resolving color → settings/lists/colors"
+   # Should show: "✓ Resolved 3 values from settings/lists/colors"
+   
+   npx tsx scripts/normalizeAndSeedAttributes.ts --seed
+   ```
+
+4. **Verify in Firestore:**
+   ```
+   settings/attributes/keys/color
+   {
+     ...
+     "validation": {
+       "allowedValuesRef": "settings/lists/colors",
+       "allowedValues": ["Red", "Blue", "Green"]  // ← DENORMALIZED!
+     }
+   }
+   ```
+
+## What's Next
+
+1. **Staging Deploy:** Seed staging with this version
+2. **Manual Verification:** Check that attributes with vocab refs have `allowedValues` arrays
+3. **ACC Testing:** Verify Attribute Detail Drawer shows allowed value pills correctly
+
+## Files Changed
+
+```
+scripts/normalizeAndSeedAttributes.ts (+80 lines, refactored)
+```
+
+## One-Line Summary
+
+Seeder now resolves `validation.allowedValuesRef` from Firestore collections and writes denormalized `allowedValues` array to attribute docs

--- a/operations/review-artifacts/v3.3-tolower-guards/homer-summary.txt
+++ b/operations/review-artifacts/v3.3-tolower-guards/homer-summary.txt
@@ -1,0 +1,59 @@
+# PR B: toLowerCase Guards Summary
+
+**Branch:** fix/v3.3-tolower-guards  
+**Commit:** 873d293  
+**PR:** #126 - https://github.com/twgallo13/ROPI-V2.1/pull/126  
+**Base Branch:** axs/v3.3-resolve-118 (PR #118)
+
+## Changes Made
+
+**File:** `src/utils/attributeGrouping.ts`
+
+Applied defensive String() coercion to 7 toLowerCase() calls:
+
+1. **Lines 93-95:** Vendor detection - `col.toLowerCase()` → `String(col || '').toLowerCase()`
+2. **Line 217:** Search term - `searchTerm.toLowerCase()` → `String(searchTerm || '').toLowerCase()`
+3. **Line 221:** Canonical path - `group.canonicalPath.toLowerCase()` → `String(group.canonicalPath || '').toLowerCase()`
+4. **Line 226:** Display name - `group.displayName.toLowerCase()` → `String(group.displayName || '').toLowerCase()`
+5. **Line 231:** Variant labels - `v.label.toLowerCase()` → `String(v.label || '').toLowerCase()`
+6. **Line 236:** Description - `description?.toLowerCase()` → `String(description || '').toLowerCase()`
+
+## Validation Results
+
+- ✅ Lint: 0 errors, 334 warnings (pre-existing)
+- ✅ Tests: All 19 tests passing
+- ✅ Build: 4.37s clean (bundle: index-CU8tU5kv.js)
+- ✅ Deploy: Successful to staging
+- ✅ API: Suggest endpoint verified working
+
+## Staging Verification
+
+**URL:** https://ropi-bccee.web.app/settings/attributes
+
+**Expected fixes:**
+- Search box no longer crashes
+- No TypeError in console for toLowerCase
+- Attribute filtering works correctly
+- Details panel still displays Current Product Values and Allowed Values
+
+## Artifacts Collected
+
+Location: `operations/review-artifacts/v3.3-tolower-guards/`
+
+1. toLower-grep.txt (full repo grep)
+2. toLower-grep-acc.txt (ACC-specific grep)
+3. npm-lint-tolower.log (0 errors)
+4. npm-test-tolower.log (all passing)
+5. npm-build-tolower.log (clean build)
+6. firebase-deploy-tolower.log (successful)
+7. suggest-response.json & suggest-response.pretty.json (API test)
+8. homer-summary.txt (this file)
+
+## Manual Verification Needed
+
+Lisa should verify:
+1. Open staging ACC and use search
+2. Confirm no console errors
+3. Verify attribute details still show validation info
+4. Test filtering with various search terms
+

--- a/scripts/normalizeAndSeedAttributes.ts
+++ b/scripts/normalizeAndSeedAttributes.ts
@@ -247,40 +247,71 @@ function normalizeAttributes(attributes: AttributeMetadata[]): AttributeMetadata
       normalized.normalizationNote = 'Canonicalized from legacy "collection" field';
     }
     
-    // v3.3.0: For attributes with allowedValuesRef, attempt to denormalize if we have sample values
-    // TODO v3.4: Extend to actually fetch from settings/lists/* collection
-    if (attr.validation?.allowedValuesRef && attr.examples.sampleValues.length > 0) {
-      if (!normalized.validation) {
-        normalized.validation = { ...attr.validation };
-      }
-      // Use sample values as a fallback until we wire up full vocab resolution
-      normalized.validation.allowedValues = attr.examples.sampleValues;
-      normalized.normalizationNote = (normalized.normalizationNote || '') + 
-        ' | Vocab values denormalized from samples (TODO: wire to settings/lists/*)';
-    }
+    // v3.3.0: allowedValuesRef will be resolved during seeding phase
+    // The seedFirestore function now handles denormalization from Firestore collections
 
     return normalized;
   });
 }
 
 /**
+ * Resolve allowedValuesRef from Firestore collection
+ * v3.3.0: Denormalize vocab values from settings/lists/* collections
+ */
+async function resolveAllowedValuesRef(db: any, refPath: string): Promise<string[]> {
+  try {
+    // Parse the ref path (e.g., "settings/lists/colors" or "settings/vocab/sizes")
+    // Split and build collection reference
+    const pathParts = refPath.split('/');
+    
+    if (pathParts.length < 2) {
+      console.warn(`  ⚠ Invalid allowedValuesRef format: ${refPath}`);
+      return [];
+    }
+    
+    // Build collection ref dynamically
+    let collectionRef: any = db;
+    for (let i = 0; i < pathParts.length; i++) {
+      if (i % 2 === 0) {
+        // Collection
+        collectionRef = collectionRef.collection(pathParts[i]);
+      } else {
+        // Document
+        collectionRef = collectionRef.doc(pathParts[i]);
+      }
+    }
+    
+    // Get documents from the collection
+    const snapshot = await collectionRef.get();
+    
+    if (!snapshot || !snapshot.docs) {
+      console.warn(`  ⚠ No documents found at ${refPath}`);
+      return [];
+    }
+    
+    // Extract values from docs (try common field names: value, name, label, or use doc ID)
+    const values = snapshot.docs
+      .map((doc: any) => {
+        const data = doc.data();
+        return data?.value || data?.name || data?.label || doc.id;
+      })
+      .filter((v: any) => v && typeof v === 'string');
+    
+    console.log(`  ✓ Resolved ${values.length} values from ${refPath}`);
+    return values;
+    
+  } catch (error) {
+    console.error(`  ✗ Error resolving ${refPath}:`, error);
+    return [];
+  }
+}
+
+/**
  * Seed Firestore settings/attributes/* collection
+ * v3.3.0: Now denormalizes allowedValuesRef to allowedValues array
  */
 async function seedFirestore(attributes: AttributeMetadata[], dryRun: boolean): Promise<void> {
-  if (dryRun) {
-    console.log('\n[DRY RUN] Would seed to Firestore settings/attributes/*');
-    console.log(`Total attributes: ${attributes.length}\n`);
-    
-    // Show sample
-    console.log('Sample attribute (descriptive.sportsTeam):');
-    const sample = attributes.find(a => a.canonicalPath === 'descriptive.sportsTeam');
-    if (sample) {
-      console.log(JSON.stringify(sample, null, 2));
-    }
-    return;
-  }
-
-  // Initialize Firebase Admin
+  // Initialize Firebase Admin (needed even for dry-run to resolve refs)
   const serviceAccountPath = path.join(__dirname, '../service-account.json');
   if (!fs.existsSync(serviceAccountPath)) {
     throw new Error('service-account.json not found. Cannot seed Firestore.');
@@ -292,6 +323,47 @@ async function seedFirestore(attributes: AttributeMetadata[], dryRun: boolean): 
   });
 
   const db = getFirestore();
+  
+  // v3.3.0: Resolve all allowedValuesRef before seeding
+  console.log('\n✓ Resolving allowedValuesRef for attributes...');
+  let resolvedCount = 0;
+  
+  for (const attr of attributes) {
+    if (attr.validation?.allowedValuesRef) {
+      const refPath = attr.validation.allowedValuesRef;
+      console.log(`  Resolving ${attr.canonicalPath} → ${refPath}`);
+      
+      const allowedValues = await resolveAllowedValuesRef(db, refPath);
+      
+      if (allowedValues.length > 0) {
+        if (!attr.validation) {
+          attr.validation = {};
+        }
+        attr.validation.allowedValues = allowedValues;
+        resolvedCount++;
+      }
+    }
+  }
+  
+  console.log(`✓ Resolved ${resolvedCount} allowedValuesRef references\n`);
+  
+  if (dryRun) {
+    console.log('[DRY RUN] Would seed to Firestore settings/attributes/*');
+    console.log(`Total attributes: ${attributes.length}\n`);
+    
+    // Show sample with denormalized values
+    const sampleWithVocab = attributes.find(a => 
+      a.validation?.allowedValues && a.validation.allowedValues.length > 0
+    );
+    
+    if (sampleWithVocab) {
+      console.log('Sample attribute with denormalized allowedValues:');
+      console.log(JSON.stringify(sampleWithVocab, null, 2));
+    }
+    
+    return;
+  }
+
   const batch = db.batch();
   let count = 0;
 


### PR DESCRIPTION
## Feature: Seeder Denormalization for allowedValues

Implements full denormalization of `validation.allowedValuesRef` in the attribute seeder. The seeder now resolves Firestore collection references and writes the `allowedValues` array directly into attribute documents.

## Changes

### `scripts/normalizeAndSeedAttributes.ts`

**New Function:** `resolveAllowedValuesRef(db, refPath)`
- Parses collection reference paths (e.g., `settings/lists/colors`)
- Dynamically builds Firestore collection reference
- Fetches all documents and extracts values
- Returns array of strings from `value`, `name`, `label` fields or doc ID

**Updated Function:** `seedFirestore(attributes, dryRun)`
- Initializes Firebase Admin before processing (needed for ref resolution)
- Loops through attributes and resolves all `allowedValuesRef` references
- Writes denormalized `allowedValues` array to attribute documents
- Logs resolution progress

## Benefits

1. **Client Performance:** Attributes have `allowedValues` inline, no client-side resolution needed
2. **Consistency:** All attributes with vocab sets get denormalized values
3. **ACC UX:** Attribute Detail Drawer can display allowed value pills without fetching external collections
4. **Idempotent:** Re-running seeder updates denormalized values if vocab collections change

## CI Validation

```
✅ Lint: 0 errors, 334 warnings (pre-existing)
✅ Tests: 225 passed, 9 skipped (12.46s)  
✅ Build: Clean build 4.34s
✅ Dry-run: Completed successfully
```

## Testing Instructions

### Manual Test with Real Data

1. Add `allowedValuesRef` to an attribute in registry
2. Create vocab collection in Firestore (e.g., `settings/lists/colors`)
3. Run seeder: `npx tsx scripts/normalizeAndSeedAttributes.ts --seed`
4. Verify attribute doc has denormalized `allowedValues` array

### Current Status

- Logic is complete and ready
- Current registry has 0 `allowedValuesRef` entries (none present yet)
- Denormalization will activate when refs are added

## Artifacts

Logs available in: `operations/review-artifacts/chore-v3.3-seeder-denorm/`

## Related

Part of v3.3 UX Polish initiative. Enables efficient display of allowed values in ACC without runtime Firestore queries.

**DO NOT MERGE** - Awaiting Lisa's approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SKU preview functionality for better product visibility
  * Introduced Always-Grouping feature
  * Enhanced Permissions UX with role display in headers and new request workflows

* **Bug Fixes**
  * Fixed crashes in attribute grouping and handling scenarios

* **Chores**
  * Improved data denormalization in seeding process for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->