### PR TITLE
chore: remove hardcoded firebase key from seed-templates.html

### DIFF
--- a/public/seed-templates.html
+++ b/public/seed-templates.html
@@ -9,8 +9,11 @@
     import { getAuth, signInWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
     import { getFirestore, collection, doc, setDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
 
+    /* NOTE: Do NOT commit production secrets into source.
+       Set VITE_FIREBASE_API_KEY in GitHub Actions / Environment → PRODUCTION
+       or inject a runtime config file during deployment. */
     const firebaseConfig = {
-      apiKey: "AIzaSyD1aYB4AfqU5n1YfSOtLX5nbEYbnlTfcZ8",
+      apiKey: "REPLACE_WITH_VITE_FIREBASE_API_KEY",
       authDomain: "ropi-bccee.firebaseapp.com",
       projectId: "ropi-bccee",
       storageBucket: "ropi-bccee.firebasestorage.app",


### PR DESCRIPTION
Removes the hardcoded Firebase API key from `public/seed-templates.html` and replaces it with a placeholder.

**Changes:**
- Replaced `apiKey: "AIzaSyD1aYB4AfqU5n1YfSOtLX5nbEYbnlTfcZ8"` with placeholder `"REPLACE_WITH_VITE_FIREBASE_API_KEY"`
- Added comment explaining how to supply the real key via CI (Vite env `VITE_FIREBASE_API_KEY`) or runtime config

**Security Note:** The removed API key should be rotated in Firebase console.

**For deployment:** Ensure `VITE_FIREBASE_API_KEY` is set in GitHub Actions secrets or the PRODUCTION environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firebase configuration to use environment-based API key instead of hard-coded values for improved configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->