### PR TITLE
chore: read firebase config from env in upload-prompts.mjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,18 @@ This creates `/settings/attributes` with starter data for:
 Users can add/edit/delete these values through the Settings → Vocab/Dropdowns tab in the UI.
 
 You only need to run this once to initialize your Firestore database with default settings.
+
+### Running upload-prompts Script
+
+To upload AI prompt templates to Firestore manually:
+
+```bash
+# Export your Firebase API key first (using VITE_ prefix for consistency or FIREBASE_API_KEY)
+export VITE_FIREBASE_API_KEY=your_api_key_here
+# Or: export FIREBASE_API_KEY=your_api_key_here
+
+# Run the script
+node scripts/upload-prompts.mjs
+```
+
+**Note:** Never commit API keys to source control. The script reads from environment variables.

--- a/scripts/upload-prompts.mjs
+++ b/scripts/upload-prompts.mjs
@@ -11,15 +11,20 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Firebase config (from your project)
+// Firebase config (read from environment variables)
 const firebaseConfig = {
-  apiKey: "AIzaSyBEk3l0J3YZYq2e8gF_p5LZ8Y3kP4XQ9Zw",
-  authDomain: "ropi-bccee.firebaseapp.com",
-  projectId: "ropi-bccee",
-  storageBucket: "ropi-bccee.firebasestorage.app",
-  messagingSenderId: "544928303856",
-  appId: "1:544928303856:web:b7c8e5d8a1e0f9a3c4d5e6"
+  apiKey: process.env.VITE_FIREBASE_API_KEY || process.env.FIREBASE_API_KEY || 'REPLACE_ME',
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN || 'ropi-bccee.firebaseapp.com',
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID || 'ropi-bccee',
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET || 'ropi-bccee.firebasestorage.app',
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '',
+  appId: process.env.VITE_FIREBASE_APP_ID || ''
 };
+
+if (!firebaseConfig.apiKey || firebaseConfig.apiKey === 'REPLACE_ME') {
+  console.error('Missing Firebase API key. Set VITE_FIREBASE_API_KEY (for local dev) or FIREBASE_API_KEY (for Node) in the environment.');
+  process.exit(1);
+}
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);


### PR DESCRIPTION
Updates `scripts/upload-prompts.mjs` to read Firebase configuration from environment variables instead of hardcoded values.

**Changes:**
- Replaced hardcoded `firebaseConfig` with env-driven version reading from `VITE_FIREBASE_API_KEY` or `FIREBASE_API_KEY`
- Added validation that exits with helpful error if API key is missing
- Updated `README.md` with instructions on running the script locally with environment variables

**Security Note:** The removed API key (`AIzaSyBEk3l0J3YZYq2e8gF_p5LZ8Y3kP4XQ9Zw`) should be rotated in Firebase console.

**Usage:**
```bash
export VITE_FIREBASE_API_KEY=your_key
node scripts/upload-prompts.mjs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for running the upload-prompts script with environment variable configuration setup.
  * Included security reminder about protecting API keys from source control commits.

* **Chores**
  * Enhanced script initialization with environment variable support for configuration and validation logic to ensure required credentials are properly configured before execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->