### PR TITLE
chore: deploy pre-check use PRODUCTION environment

### DIFF
--- a/.github/workflows/deploy-precheck.yml
+++ b/.github/workflows/deploy-precheck.yml
@@ -1,13 +1,16 @@
 name: Deploy pre-check
-on: [push]
+on:
+  push:
+  pull_request:
 jobs:
   check:
     runs-on: ubuntu-latest
+    environment: PRODUCTION
     steps:
       - name: Validate required env secrets
         run: |
           missing=false
-          for var in VITE_FIREBASE_API_KEY VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_PROJECT_ID VITE_FIREBASE_STORAGE_BUCKET VITE_FIREBASE_APP_ID GEMINI_API_KEY; do
+          for var in VITE_FIREBASE_API_KEY VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_PROJECT_ID VITE_FIREBASE_STORAGE_BUCKET VITE_FIREBASE_MESSAGING_SENDER_ID VITE_FIREBASE_APP_ID GEMINI_API_KEY; do
             if [ -z "${!var}" ]; then
               echo "::error::Required env var $var is not set."
               missing=true


### PR DESCRIPTION
Make the deploy pre-check job run with the PRODUCTION environment so environment secrets (SERVICE_ACCOUNT_JSON and VITE/GEMINI secrets) are available to the job. This avoids false negatives on pushes where only environment secrets are configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved deployment checks and environment variable validation for production builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->