### PR TITLE
chore: deploy pre-check fallback to repo secrets + use PRODUCTION env

### DIFF
--- a/.github/workflows/deploy-precheck.yml
+++ b/.github/workflows/deploy-precheck.yml
@@ -1,13 +1,26 @@
 name: Deploy pre-check
-on: [push]
+on:
+  push:
+  pull_request:
 jobs:
   check:
     runs-on: ubuntu-latest
+    # keep PRODUCTION so push/deploy context gets the environment secrets
+    environment: PRODUCTION
+    # also map repository secrets into env for PRs and contexts that don't expose environment secrets
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - name: Validate required env secrets
         run: |
           missing=false
-          for var in VITE_FIREBASE_API_KEY VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_PROJECT_ID VITE_FIREBASE_STORAGE_BUCKET VITE_FIREBASE_APP_ID GEMINI_API_KEY; do
+          for var in VITE_FIREBASE_API_KEY VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_PROJECT_ID VITE_FIREBASE_STORAGE_BUCKET VITE_FIREBASE_MESSAGING_SENDER_ID VITE_FIREBASE_APP_ID GEMINI_API_KEY; do
             if [ -z "${!var}" ]; then
               echo "::error::Required env var $var is not set."
               missing=true


### PR DESCRIPTION
Make deploy pre-check use repo secrets as fallback so PR runs that cannot access environment secrets still validate. Keeps environment: PRODUCTION for push/deploy correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration to enhance environment variable handling and validation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->