### PR TITLE
feat: aoss staging hosting channel (v0.2.1)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,104 @@
+name: Deploy AOSS Staging
+# Per AOSS Section 10.3 — GitHub Actions Deploy Staging
+# Deploys aoss-main to Firebase Hosting preview channel (aoss-main-staging)
+
+on:
+  push:
+    branches:
+      - aoss-main
+  workflow_dispatch:
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@8
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: |
+          # TODO (AOSS): Implement web build per Section 7 when web package is ready
+          echo "⚠️  Web build not yet implemented (AOSS Section 7)"
+          echo "Currently exporting placeholder for hosting channel"
+          
+          # Create a minimal placeholder for hosting
+          mkdir -p public
+          cat > public/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Ropi AOSS - Staging</title>
+            <meta charset="utf-8">
+            <style>
+              body { 
+                font-family: system-ui, -apple-system, sans-serif; 
+                max-width: 800px; 
+                margin: 100px auto; 
+                padding: 20px;
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                color: white;
+              }
+              .card { 
+                background: rgba(255,255,255,0.1); 
+                backdrop-filter: blur(10px);
+                padding: 40px; 
+                border-radius: 16px; 
+                box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+              }
+              h1 { margin-top: 0; }
+              code { 
+                background: rgba(0,0,0,0.2); 
+                padding: 2px 8px; 
+                border-radius: 4px; 
+                font-size: 14px;
+              }
+            </style>
+          </head>
+          <body>
+            <div class="card">
+              <h1>🚀 Ropi AOSS Staging</h1>
+              <p>This is the <strong>aoss-main</strong> staging environment.</p>
+              <p>Deployed from branch: <code>aoss-main</code></p>
+              <p>Firebase Hosting preview channel: <code>aoss-main-staging</code></p>
+              <hr style="border: 1px solid rgba(255,255,255,0.2); margin: 30px 0;">
+              <p><small>⚠️ Web app implementation pending (AOSS Section 7)</small></p>
+              <p><small>Single source of truth: Ropi AOSS Notion (Sections 1-14)</small></p>
+            </div>
+          </body>
+          </html>
+          EOF
+          
+          echo "✅ Placeholder created in public/index.html"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@13
+
+      - name: Deploy to Firebase Hosting preview channel
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          # Deploy to preview channel (aoss-main-staging), not live site
+          # Per AOSS Section 10.3 and 10.6
+          firebase hosting:channel:deploy aoss-main-staging \
+            --project ropi-bccee \
+            --token "$FIREBASE_TOKEN" \
+            --json
+
+      - name: Comment preview URL
+        run: |
+          echo "🎉 Staging deployed successfully!"
+          echo "Preview URL: https://ropi-bccee--aoss-main-staging-<random>.web.app"
+          echo "(Exact URL available in Firebase Console or deploy output above)"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # ROPI AOSS — Clean AOSS scaffold
 This repository is the canonical implementation for Ropi AOSS.
 Single source of truth lives in Notion: Section 1..14 (ROPI AOSS).
+
+## Staging Environment (v0.2.1)
+
+AOSS staging uses **Firebase Hosting preview channels** per AOSS Section 10.3.
+
+- **Branch**: `aoss-main`
+- **Preview channel**: `aoss-main-staging`
+- **Project**: `ropi-bccee`
+- **URL**: Firebase preview URL (format: `https://ropi-bccee--aoss-main-staging-<hash>.web.app`)
+
+The staging environment deploys automatically on push to `aoss-main`. This uses a preview channel to avoid affecting the live production site at `https://ropi-bccee.firebaseapp.com/`, which continues to serve the legacy app until the migration plan in Section 12 is executed.
+
+### Manual Deployment
+
+```bash
+# Deploy to staging preview channel
+firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee
+```

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements **Firebase Hosting staging deployment** for the  branch as specified in **AOSS Section 10.3 — GitHub Actions Deploy Staging**.

This setup deploys to a **preview channel** (not the live site) to allow testing without affecting the production app at `https://ropi-bccee.firebaseapp.com/`.

## What This Implements

### Per AOSS Section 10.3 — Deploy Staging

✅ **GitHub Actions workflow** (`.github/workflows/deploy-staging.yml`)
- Triggers on push to `aoss-main` and manual `workflow_dispatch`
- Uses Node 20 (per Section 10.1.1/10.1.2)
- Uses pnpm for monorepo dependency management
- Uses Firebase CLI 13.x (per Section 10.1)
- Deploys to preview channel `aoss-main-staging` (not live hosting)

✅ **Firebase configuration** (`firebase.json`)
- Minimal hosting configuration for preview channel deployments
- Public directory: `public/`
- SPA-style rewrite to `index.html`

✅ **Placeholder build step**
- Creates temporary HTML placeholder since web app (Section 7) not yet implemented
- TODO comment references Section 7 for future implementation
- Does NOT assume or guess web app structure

✅ **README documentation**
- Explains staging environment setup
- Documents preview channel URL format
- Clarifies that production site is unaffected

## Key Details

### Workflow Triggers
```yaml
on:
  push:
    branches:
      - aoss-main
  workflow_dispatch:
```

### Deploy Command
```bash
firebase hosting:channel:deploy aoss-main-staging \
  --project ropi-bccee \
  --token "$FIREBASE_TOKEN"
```

This uses a **preview channel** instead of `firebase deploy --only hosting` to avoid overwriting the live site.

### Preview URL Format
```
https://ropi-bccee--aoss-main-staging-<random-hash>.web.app
```

## What This Does NOT Affect

✅ **Production site remains untouched**
- Live site at `https://ropi-bccee.firebaseapp.com/` continues serving legacy app
- No changes to production deployment workflow (Section 10.4)
- No changes to `main` branch triggers

✅ **Conservative approach**
- Minimal firebase.json (no assumptions about future config)
- Placeholder build step with clear TODOs
- No guessing about web app structure

## Files Changed

**Added:**
- `.github/workflows/deploy-staging.yml` - Staging deployment workflow (NEW)
- `firebase.json` - Minimal Firebase hosting config (NEW)

**Modified:**
- `README.md` - Added staging environment documentation

## Requirements from AOSS Spec

✅ Section 10.1 - Node 20, Firebase CLI 13.x  
✅ Section 10.3 - Deploy staging workflow  
✅ Section 10.6 - Uses `FIREBASE_TOKEN` secret  
✅ Does NOT modify Section 10.4 (production deploy)  
✅ Does NOT affect live hosting at `ropi-bccee.firebaseapp.com`  

## TODOs for Future Versions

- `TODO (AOSS)`: Implement web build per Section 7 when `packages/web` is ready
- `TODO (AOSS)`: Expand firebase.json per Sections 9 and 10 as app grows
- `TODO (AOSS)`: Implement production deploy workflow per Section 10.4

## Verification

To test after merge:
1. Merge this PR to `aoss-main`
2. Workflow will trigger automatically on push
3. Check Actions tab for deployment status
4. Preview URL will be shown in workflow output
5. Verify placeholder page loads at preview URL

Manual deployment:
```bash
firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee
```

## Notes for Lisa & Theo

- This is an **additive** change - no existing behavior affected
- Production site completely isolated from staging channel
- Ready for web app implementation when Section 7 is tackled
- Follows Section 10.3 spec while adapting to current monorepo structure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated staging environment deployment setup on the aoss-main branch
  * Configured Firebase Hosting preview channels for staging deployments

* **Documentation**
  * Added staging environment documentation including deployment instructions and preview URL format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->