### PR TITLE
fix(ci): ensure public/ for deploy-staging (v0.3.6)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,9 +37,91 @@ jobs:
           if [ -f packages/web/package.json ]; then
             pnpm --filter @ropi-aoss/web build || echo "Web build failed (not implemented)"
           else
-            mkdir -p public
-            echo "<!doctype html><html><body><h1>Ropi AOSS Staging</h1><p>Stable staging environment for aoss-main branch</p></body></html>" > public/index.html
+            echo "No packages/web found, will create placeholder in prepare step"
           fi
+
+      - name: Prepare public directory
+        run: |
+          set -euo pipefail
+          echo "Preparing public/ for hosting..."
+          # Ensure public exists
+          rm -rf public || true
+          mkdir -p public
+
+          # If packages/web exists and has a build output, try common locations and copy into public
+          if [ -f packages/web/package.json ]; then
+            echo "packages/web detected — attempting build output copy..."
+            # try to build (non-fatal fallback handled by earlier steps)
+            if pnpm --filter @ropi-aoss/web build; then
+              echo "packages/web build completed (attempting to find output)..."
+            else
+              echo "packages/web build command returned non-zero (proceeding to look for output)."
+            fi
+
+            # Common output directories
+            CANDIDATES=(
+              "packages/web/dist"
+              "packages/web/build"
+              "packages/web/out"
+              "packages/web/.next"
+            )
+
+            COPIED=false
+            for d in "${CANDIDATES[@]}"; do
+              if [ -d "$d" ]; then
+                echo "Copying build output from $d to public/"
+                rsync -a --delete "$d"/ public/
+                COPIED=true
+                break
+              fi
+            done
+
+            # Special handling for Next.js (.next)
+            if [ "$COPIED" = false ] && [ -d "packages/web/.next" ]; then
+              # If there is static export directory out/, use it
+              if [ -d "packages/web/out" ]; then
+                rsync -a --delete "packages/web/out"/ public/
+                COPIED=true
+              fi
+            fi
+          fi
+
+          # If nothing copied, create a placeholder index.html
+          if [ ! -f public/index.html ]; then
+            echo "No build output found — creating placeholder public/index.html"
+            cat > public/index.html <<'HTML'
+          <!doctype html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <title>Ropi AOSS — Staging</title>
+            <style>
+              body { font-family: system-ui, -apple-system, sans-serif; color:#111; background:#f6f7fb; display:flex; align-items:center; justify-content:center; height:100vh; }
+              .card { background: white; border-radius:12px; padding:32px; box-shadow:0 6px 30px rgba(0,0,0,0.08); max-width:880px; text-align:center;}
+              h1 { margin-top:0; color:#2b2f6b;}
+              code { background:#f2f4ff; padding:4px 8px; border-radius:6px; display:inline-block; }
+            </style>
+          </head>
+          <body>
+            <div class="card">
+              <h1>🚀 Ropi AOSS — Staging</h1>
+              <p>This is the <strong>aoss-main</strong> staging environment.</p>
+              <p>Stable staging URL: <strong>https://ropi-aoss-staging.web.app</strong></p>
+              <hr>
+              <p><small>Note: The web app build did not create a public site yet. This placeholder exists so the deploy does not fail.</small></p>
+            </div>
+          </body>
+          </html>
+          HTML
+          fi
+
+          # Final sanity check
+          if [ ! -f public/index.html ]; then
+            echo "::error::public/index.html still missing after prepare step"
+            exit 1
+          fi
+
+          echo "public/ is ready (contains index.html and possible build output)."
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@13
@@ -48,15 +130,25 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
-          # Validate token
           if [ -z "${FIREBASE_TOKEN:-}" ]; then
-            echo "::error::FIREBASE_TOKEN is not set in 'staging' environment"
+            echo "::error::FIREBASE_TOKEN is not set in the 'staging' environment"
             exit 1
           fi
 
-          # Deploy preview channel (keep existing behavior if present)
+          # Deploy preview channel (keep existing behavior)
           firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee --token "$FIREBASE_TOKEN" --json || true
 
-          # Deploy to stable site (aoss-staging)
+          # Deploy to stable aoss-staging target
           firebase deploy --only hosting:aoss-staging --project ropi-bccee --token "$FIREBASE_TOKEN" --json
           echo "Stable staging URL: https://ropi-aoss-staging.web.app"
+
+      - name: Smoke check stable staging
+        run: |
+          set -e
+          echo "Waiting briefly for hosting to warm up..."
+          sleep 3
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' https://ropi-aoss-staging.web.app || true)
+          echo "HTTP status: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "::warning::Staging returned HTTP $STATUS. Check hosting logs and content."
+          fi


### PR DESCRIPTION
## Hotfix v0.3.6 — Deploy Staging Public Directory

### Problem
The `deploy-staging.yml` workflow was failing with `Directory 'public' for Hosting does not exist` because:
- The conditional logic only created `public/` when `packages/web` did NOT exist
- But `packages/web` exists with a non-functional build script
- This caused the firebase deploy to fail

### Solution
This hotfix makes the deployment robust by:

1. **Always ensuring `public/` exists** via a dedicated "Prepare public directory" step
2. **Intelligently copying build output** from common locations:
   - `packages/web/dist`
   - `packages/web/build`
   - `packages/web/out`
   - `packages/web/.next` (Next.js support)
3. **Creating a styled placeholder** `index.html` if no build output is found
4. **Final sanity check** to fail fast if `public/index.html` is still missing
5. **Smoke check** after deployment to verify HTTP 200 response

### Changes
- ✅ Modified `.github/workflows/deploy-staging.yml`
- ✅ No changes to production code, firebase.json, or .firebaserc
- ✅ Preserves all existing workflow behavior (Node 20, pnpm, staging environment)

### Acceptance Criteria
- [x] Branch created: `feature/hotfix-deploy-staging-v0-3-6`
- [x] Draft PR opened against `aoss-main`
- [ ] After merge: `public/index.html` present before deploy
- [ ] After merge: Deploy to `hosting:aoss-staging` succeeds
- [ ] After merge: Workflow prints stable staging URL
- [ ] After merge: Smoke check returns HTTP 200

### Testing
Once merged, the next push to `aoss-main` will:
1. Create `public/` directory
2. Copy any web build output or create placeholder
3. Deploy to https://ropi-aoss-staging.web.app
4. Verify with HTTP smoke check

---
**Homer v0.3.6** — CI hotfix for staging deployment reliability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD deployment workflow with more robust preparation and handling of deployment artifacts.
  * Improved error messaging clarity for the staging environment during deployment.
  * Added automated health check step post-deployment to verify successful deployment to staging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->