### PR TITLE
fix: remove continue-on-error from preview deploy after IAM fix

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -118,7 +118,6 @@ jobs:
         run: npm install -g firebase-tools@13
 
       - name: Deploy to preview channel
-        continue-on-error: true
         run: |
           set -euo pipefail
           if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
@@ -132,15 +131,18 @@ jobs:
           PR_NUM=${{ github.event.pull_request.number }}
           CHANNEL=pr-${PR_NUM}
           firebase hosting:channel:deploy "${CHANNEL}" --only aoss-staging --project ropi-bccee --json > deploy.json || {
-            echo "::warning::Firebase preview deployment failed (may need additional permissions)"
+            echo "::error::Firebase preview deployment failed"
             cat deploy.json || true
-            exit 0
+            exit 1
           }
           echo "Deploy output:"
           cat deploy.json
-          # Try to extract a URL
-          PREVIEW_URL=$(jq -r '.result[0].site // empty' deploy.json || true)
+          # Extract preview URL from the correct path
+          PREVIEW_URL=$(jq -r '.result["aoss-staging"].url // empty' deploy.json || true)
           echo "PREVIEW_URL=${PREVIEW_URL}"
+          if [ -n "$PREVIEW_URL" ]; then
+            echo "Preview available at: $PREVIEW_URL"
+          fi
           echo "===="
       - name: Post preview URL to PR
         continue-on-error: true


### PR DESCRIPTION
Remove continue-on-error from preview deploy step now that Firebase permissions are working.

Changes:
- Remove continue-on-error from 'Deploy to preview channel' step
- Fix URL extraction jq path: .result["aoss-staging"].url
- Keep continue-on-error on PR comment step (GitHub token permissions)
- Change deployment failure to ::error instead of ::warning

Validation:
- Staging deploy: Run 19855839772 ✅ SUCCESS
- Preview deploy: Run 19855900099 ✅ SUCCESS  
- Preview URL: https://ropi-aoss-staging--pr-152-62dowzew.web.app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability and error handling for preview deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->