### PR TITLE
chore: Fix firebase hosting public path for staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,96 +32,20 @@ jobs:
             echo "No package.json found, skipping dependency installation"
           fi
 
-      - name: Build (if web exists)
-        run: |
-          if [ -f packages/web/package.json ]; then
-            pnpm --filter @ropi-aoss/web build || echo "Web build failed (not implemented)"
-          else
-            echo "No packages/web found, will create placeholder in prepare step"
-          fi
-
-      - name: Prepare public directory
+      - name: Build packages/web
         run: |
           set -euo pipefail
-          echo "Preparing public/ for hosting..."
-          # Ensure public exists
-          rm -rf public || true
-          mkdir -p public
-
-          # If packages/web exists and has a build output, try common locations and copy into public
-          if [ -f packages/web/package.json ]; then
-            echo "packages/web detected — attempting build output copy..."
-            # try to build (non-fatal fallback handled by earlier steps)
-            if pnpm --filter @ropi-aoss/web build; then
-              echo "packages/web build completed (attempting to find output)..."
-            else
-              echo "packages/web build command returned non-zero (proceeding to look for output)."
-            fi
-
-            # Common output directories
-            CANDIDATES=(
-              "packages/web/dist"
-              "packages/web/build"
-              "packages/web/out"
-              "packages/web/.next"
-            )
-
-            COPIED=false
-            for d in "${CANDIDATES[@]}"; do
-              if [ -d "$d" ]; then
-                echo "Copying build output from $d to public/"
-                rsync -a --delete "$d"/ public/
-                COPIED=true
-                break
-              fi
-            done
-
-            # Special handling for Next.js (.next)
-            if [ "$COPIED" = false ] && [ -d "packages/web/.next" ]; then
-              # If there is static export directory out/, use it
-              if [ -d "packages/web/out" ]; then
-                rsync -a --delete "packages/web/out"/ public/
-                COPIED=true
-              fi
-            fi
-          fi
-
-          # If nothing copied, create a placeholder index.html
-          if [ ! -f public/index.html ]; then
-            echo "No build output found — creating placeholder public/index.html"
-            cat > public/index.html <<'HTML'
-          <!doctype html>
-          <html>
-          <head>
-            <meta charset="utf-8">
-            <title>Ropi AOSS — Staging</title>
-            <style>
-              body { font-family: system-ui, -apple-system, sans-serif; color:#111; background:#f6f7fb; display:flex; align-items:center; justify-content:center; height:100vh; }
-              .card { background: white; border-radius:12px; padding:32px; box-shadow:0 6px 30px rgba(0,0,0,0.08); max-width:880px; text-align:center;}
-              h1 { margin-top:0; color:#2b2f6b;}
-              code { background:#f2f4ff; padding:4px 8px; border-radius:6px; display:inline-block; }
-            </style>
-          </head>
-          <body>
-            <div class="card">
-              <h1>🚀 Ropi AOSS — Staging</h1>
-              <p>This is the <strong>aoss-main</strong> staging environment.</p>
-              <p>Stable staging URL: <strong>https://ropi-aoss-staging.web.app</strong></p>
-              <hr>
-              <p><small>Note: The web app build did not create a public site yet. This placeholder exists so the deploy does not fail.</small></p>
-            </div>
-          </body>
-          </html>
-          HTML
-          fi
-
-          # Final sanity check
-          if [ ! -f public/index.html ]; then
-            echo "::error::public/index.html still missing after prepare step"
+          echo "Building packages/web with Vite..."
+          pnpm --filter @ropi-aoss/web build
+          
+          # Verify build output
+          if [ ! -f packages/web/dist/index.html ]; then
+            echo "::error::packages/web/dist/index.html not found after build"
             exit 1
           fi
-
-          echo "public/ is ready (contains index.html and possible build output)."
+          
+          echo "✅ Build complete: packages/web/dist ready for deployment"
+          ls -lh packages/web/dist/
 
       - name: Setup gcloud authentication
         env:

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "hosting": [
     {
       "target": "aoss-staging",
-      "public": "public",
+      "public": "packages/web/dist",
       "ignore": [
         "firebase.json",
         "**/.*",


### PR DESCRIPTION
## Issue

Staging site () was showing a placeholder message instead of the real AOSS web app.

## Root Cause

`firebase.json` was configured with:
```json
{
  "hosting": [{
    "public": "public"  // ❌ Wrong directory
  }]
}
```

But Vite builds the app to `packages/web/dist` (default output directory).

The deploy workflow had complex placeholder logic that would create a fallback page when the build output wasn't found, resulting in the placeholder being deployed instead of the real app.

## Solution

1. **Updated `firebase.json`**: Point hosting.public directly to `packages/web/dist`
2. **Simplified `deploy-staging.yml`**: Remove placeholder logic, build packages/web directly

## Changes

### firebase.json
```diff
- "public": "public",
+ "public": "packages/web/dist",
```

### .github/workflows/deploy-staging.yml
- Removed 90+ lines of placeholder/fallback logic
- Replaced with simple build step that fails if output not found
- Build now properly validated before deployment

## Testing

✅ Local build successful:
```
pnpm --filter @ropi-aoss/web build
✓ 56 modules transformed
dist/index.html (0.46 kB)
dist/assets/*.css (10.19 kB)
dist/assets/*.js (182.93 kB)
```

✅ Build output verified:
- packages/web/dist/index.html contains real app HTML
- Contains React app root div and bundled assets
- No placeholder text

## Deploy Plan

After merge:
1. Deploy workflow will trigger automatically on push to aoss-main
2. packages/web will build successfully
3. Firebase will deploy packages/web/dist to staging
4. Real AOSS app will load at https://ropi-aoss-staging.web.app

## References

- Related: PROMPT_011 (Diagnose & Fix Staging Deploy)
- Depends on: PR #154 (merged - contains packages/web frontend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to streamline the build process with explicit verification of build artifacts.
  * Updated hosting configuration to serve from the updated build output directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->