### PR TITLE
ci: fix preview deploy (Option A) — use firebase_preview.json and hard-fail web build (PROMPT_018B_v1.1)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,10 +25,22 @@ jobs:
           else
             echo "No package.json found, skipping dependency installation"
           fi
-      - name: Build (if web exists)
+      - name: Build (web)
         run: |
           if [ -f packages/web/package.json ]; then
-            pnpm --filter @ropi-aoss/web build || echo "Web build failed (not implemented)"
+            echo "Building @ropi-aoss/web..."
+            # Fail loudly on build error so CI surfaces real issues
+            pnpm --filter @ropi-aoss/web build || { echo "::error::Web build failed"; exit 1; }
+            echo "Build completed. Listing packages/web and common output directories:"
+            ls -la packages/web || true
+            for d in "packages/web/dist" "packages/web/build" "packages/web/out" "packages/web/.next"; do
+              echo "=== $d ==="
+              if [ -d "$d" ]; then
+                ls -la "$d"
+              else
+                echo "$d does not exist"
+              fi
+            done
           else
             echo "No packages/web found — will create placeholder later"
           fi
@@ -124,20 +136,39 @@ jobs:
             echo "::warning::GOOGLE_APPLICATION_CREDENTIALS not set — skipping preview deploy"
             exit 0
           fi
-          
+
           echo "Using GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
-          
-          # Deploy to preview channel on aoss-staging target
+
+          # Create a temporary firebase config that points hosting at the prepared public/ folder.
+          cat > firebase_preview.json <<'JSON'
+          {
+            "hosting": [
+              {
+                "target": "aoss-staging",
+                "public": "public",
+                "ignore": [
+                  "firebase.json",
+                  "**/.*",
+                  "**/node_modules/**"
+                ],
+                "rewrites": [
+                  { "source": "**", "destination": "/index.html" }
+                ]
+              }
+            ]
+          }
+          JSON
+
+          # Deploy to preview channel on aoss-staging target using the temporary config
           PR_NUM=${{ github.event.pull_request.number }}
           CHANNEL=pr-${PR_NUM}
-          firebase hosting:channel:deploy "${CHANNEL}" --only aoss-staging --project ropi-bccee --json > deploy.json || {
+          firebase hosting:channel:deploy "${CHANNEL}" --only aoss-staging --project ropi-bccee --config firebase_preview.json --json > deploy.json || {
             echo "::error::Firebase preview deployment failed"
             cat deploy.json || true
             exit 1
           }
           echo "Deploy output:"
           cat deploy.json
-          # Extract preview URL from the correct path
           PREVIEW_URL=$(jq -r '.result["aoss-staging"].url // empty' deploy.json || true)
           echo "PREVIEW_URL=${PREVIEW_URL}"
           if [ -n "$PREVIEW_URL" ]; then


### PR DESCRIPTION
**PROMPT Version:** PROMPT_018B_v1.1

## Summary:
- Implement Option A preview deploy fix so PR preview channel deploys reliably.
- Fail loudly if @ropi-aoss/web build fails (so we catch build regressions).
- Create a temporary firebase_preview.json that points hosting to the workflow-prepared public/ folder.
- Use firebase CLI with --config firebase_preview.json for preview channel deploys.

## Why:
- CI previously failed with "Directory 'packages/web/dist' for Hosting does not exist." because preview deploy used repository firebase.json (which points to packages/web/dist). The job already prepares public/ (copies build outputs or creates a placeholder) but deploy still expects packages/web/dist. This change makes the preview deploy use the prepared public/ folder.

## Scope & Safety:
- This is intentionally minimal and non-invasive.
- **Does NOT** modify repo firebase.json (production/staging canonical config remains unchanged).
- This is a safe, short-term unblock for PR preview builds.

## Testing & Acceptance:
- After merge, preview workflow should succeed and post a preview URL as a PR comment.
- A follow-up will standardize canonical build output and firebase.json for a permanent fix.

**Related:** PROMPT_018B (original prompt). This is PROMPT_018B_v1.1 for tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened build reliability with enhanced error detection and diagnostic output for faster troubleshooting
  * Improved preview deployment robustness to automatically locate web builds from multiple output paths
  * Optimized Firebase preview hosting configuration for the staging environment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->