### PR TITLE
ci: inject VITE_FIREBASE_* secrets into staging build (PROMPT_018B_v1.3)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,10 +32,27 @@ jobs:
             echo "No package.json found, skipping dependency installation"
           fi
 
+      - name: Debug: ensure VITE_FIREBASE_API_KEY present
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+        run: |
+          if [ -z "$VITE_FIREBASE_API_KEY" ]; then
+            echo "::error::VITE_FIREBASE_API_KEY is empty"
+            exit 1
+          fi
+          echo "VITE_FIREBASE_API_KEY present (length: ${#VITE_FIREBASE_API_KEY})"
+
       - name: Build packages/web
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
         run: |
           set -euo pipefail
-          echo "Building packages/web with Vite..."
+          echo "Building packages/web with Vite (with Firebase config from secrets)..."
           pnpm --filter @ropi-aoss/web build
           
           # Verify build output


### PR DESCRIPTION
## Problem
Staging build was not injecting VITE_FIREBASE_* secrets from GitHub, so deployed bundle contained dummy Firebase API key `AIzaSyDummy_ReplaceInProduction` instead of real credentials.

## Solution
- Add debug step to validate `VITE_FIREBASE_API_KEY` exists (fail-fast if missing)
- Inject all 6 `VITE_FIREBASE_*` environment variables from GitHub secrets into the `Build packages/web` step
- Ensures Vite embeds real Firebase config into production bundle at build-time

## Testing
After merge + staging deploy:
- [ ] Verify deployed bundle contains real API key (curl check)
- [ ] Test Google OAuth sign-in
- [ ] Test Email/Password sign-in
- [ ] Verify admin detection
- [ ] Test observations flows

Related: PROMPT_018B_v1.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration and validation checks for staging environment builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->