### PR TITLE
ci: add workflow to set admin custom claim (ops-runner)

### DIFF
--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -1,0 +1,51 @@
+name: Ops — Set Admin Custom Claim
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Email to set admin claim for'
+        required: true
+        default: 'theo@shiekhshoes.org'
+
+jobs:
+  set-admin-claim:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Decode service account key
+        env:
+          SA_B64: ${{ secrets.FIREBASE_SA_KEY }}
+        run: |
+          echo "${SA_B64}" | base64 --decode > /tmp/sa.json
+          chmod 600 /tmp/sa.json
+
+      - name: Install Node (if needed) and deps
+        run: |
+          # ensure node present and install any deps necessary for scripts
+          corepack enable
+          cd scripts || exit 0
+          if [ -f package.json ]; then npm ci || true; fi
+        working-directory: .
+
+      - name: Run set-admin script
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node scripts/set-admin-custom-claim.js "${{ github.event.inputs.email }}"
+
+      - name: Verify claim (server-side)
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node -e "const admin=require('firebase-admin');
+          admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId:'ropi-bccee' });
+          (async()=>{
+            const u = await admin.auth().getUserByEmail(process.env.EMAIL || '${{ github.event.inputs.email }}');
+            console.log('customClaims:', u.customClaims || 'none');
+          })().catch(e=>{ console.error(e); process.exit(1); });"


### PR DESCRIPTION
## Purpose
This workflow enables Ops to run the repository script `scripts/set-admin-custom-claim.js` to set admin custom claims on users in the staging Firebase project. The workflow uses a GitHub secret `FIREBASE_SA_KEY` (base64-encoded service account JSON).

## Ops Instructions
1. **Add Secret**: In repository Settings → Secrets and variables → Actions, add a secret named `FIREBASE_SA_KEY` containing the base64-encoded service account JSON:
   ```bash
   cat service-account.json | base64 -w 0
   ```

2. **Run Workflow**: 
   - Go to Actions tab → "Ops — Set Admin Custom Claim"
   - Click "Run workflow"
   - Enter the email address (default: `theo@shiekhshoes.org`)
   - Click "Run workflow"

3. **Verify**: The workflow will run the script and verify the custom claim was set correctly.

## Security Note
⚠️ **Do NOT put service account JSON in issue/PR bodies or comments.** Always use GitHub Secrets only. The workflow securely decodes the secret at runtime and stores it temporarily in `/tmp/sa.json` with restricted permissions (600).

## Related
Part of PROMPT_019A_v1.7.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new admin workflow for managing user account permissions and custom claims through an automated, manually-triggered operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->