### PR TITLE
ci: Robust decode for GCP_SA_KEY_BASE64 (PROMPT_019A_v1.8)

### DIFF
--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -1,0 +1,51 @@
+name: Ops — Set Admin Custom Claim
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Email to set admin claim for'
+        required: true
+        default: 'theo@shiekhshoes.org'
+
+jobs:
+  set-admin-claim:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Decode service account key
+        env:
+          SA_B64: ${{ secrets.FIREBASE_SA_KEY }}
+        run: |
+          echo "${SA_B64}" | base64 --decode > /tmp/sa.json
+          chmod 600 /tmp/sa.json
+
+      - name: Install Node (if needed) and deps
+        run: |
+          # ensure node present and install any deps necessary for scripts
+          corepack enable
+          cd scripts || exit 0
+          if [ -f package.json ]; then npm ci || true; fi
+        working-directory: .
+
+      - name: Run set-admin script
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node scripts/set-admin-custom-claim.js "${{ github.event.inputs.email }}"
+
+      - name: Verify claim (server-side)
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node -e "const admin=require('firebase-admin');
+          admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId:'ropi-bccee' });
+          (async()=>{
+            const u = await admin.auth().getUserByEmail(process.env.EMAIL || '${{ github.event.inputs.email }}');
+            console.log('customClaims:', u.customClaims || 'none');
+          })().catch(e=>{ console.error(e); process.exit(1); });"

--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -18,11 +18,40 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Decode service account key
+      - name: Decode service account key (robust)
         env:
-          SA_B64: ${{ secrets.FIREBASE_SA_KEY }}
+          GCP_SA_KEY_BASE64: ${{ secrets.GCP_SA_KEY_BASE64 }}
         run: |
-          echo "${SA_B64}" | base64 --decode > /tmp/sa.json
+          # Robust decode: accept either raw JSON or base64, strip CRLFs, validate JSON
+          SA_B64="${GCP_SA_KEY_BASE64:-}"
+          if [ -z "$SA_B64" ]; then
+            echo "::error::GCP_SA_KEY_BASE64 is empty"
+            exit 1
+          fi
+
+          # Detect if it looks like raw JSON (starts with { or [)
+          firstchar="$(printf '%s' "$SA_B64" | head -c 1)"
+          if [ "$firstchar" = "{" ] || [ "$firstchar" = "[" ]; then
+            printf '%s' "$SA_B64" > /tmp/sa.json
+          else
+            # Strip CR/LF then decode base64
+            printf '%s' "$SA_B64" | tr -d '\r\n' | base64 --decode > /tmp/sa.json
+          fi
+
+          # Ensure jq is available to validate JSON; install if missing
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "Installing jq for JSON validation"
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
+          # Validate decoded JSON
+          if ! jq -e . /tmp/sa.json >/dev/null 2>&1; then
+            echo "::error::Decoded /tmp/sa.json is not valid JSON"
+            echo "Preview of decoded contents:"
+            head -c 400 /tmp/sa.json || true
+            exit 1
+          fi
+          
           chmod 600 /tmp/sa.json
 
       - name: Install Node (if needed) and deps


### PR DESCRIPTION
## Problem

The `set-admin-claim` workflow was failing with base64 decode errors due to:
- Windows CRLF line endings in the secret value
- Inconsistent secret naming (`FIREBASE_SA_KEY` vs `GCP_SA_KEY_BASE64`)
- No validation of decoded JSON
- Poor error messages on failure

## Solution

Implemented robust service account key decoding:

### ✅ Auto-Detection
- Detects if input is raw JSON (starts with `{` or `[`)
- If JSON: writes directly to file
- If base64: strips CR/LF then decodes

### ✅ CRLF Handling
```bash
printf '%s' "$SA_B64" | tr -d '\r\n' | base64 --decode
```
Strips carriage returns and line feeds before decoding

### ✅ JSON Validation
- Installs `jq` if not available
- Validates decoded JSON structure
- Shows preview (400 chars) on validation failure

### ✅ Better Error Messages
- Clear error if secret is empty
- Shows decoded content preview on JSON parse failure
- Exit codes for proper CI failure reporting

### ✅ Consistent Naming
- Uses `GCP_SA_KEY_BASE64` secret (matches deploy-preview workflow)
- Previous `FIREBASE_SA_KEY` reference updated

## Testing

To test this workflow:
1. Merge this PR or push to branch
2. Go to Actions → "Ops — Set Admin Custom Claim"
3. Click "Run workflow"
4. Enter email: `theo@shiekhshoes.org`
5. Verify workflow completes successfully

## Related

- PROMPT_019A: Set Admin Custom Claim workflow
- Fixes Windows CRLF issue from copy-paste
- Aligns with deploy-preview.yml decode pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for admin permission management operations, enabling automated user access configuration via manual trigger.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->