### PR TITLE
ci: fix YAML heredoc and robust decode (PROMPT_019A_v1.11)

### DIFF
--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -1,3 +1,23 @@
+name: Ops — Set Admin Custom Claim
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Email to set admin claim for'
+        required: true
+        default: 'theo@shiekhshoes.org'
+
+jobs:
+  set-admin-claim:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Decode service account key (very robust)
         env:
           GCP_SA_KEY_BASE64: ${{ secrets.GCP_SA_KEY_BASE64 }}
@@ -8,28 +28,26 @@
             exit 1
           fi
 
-          # Trim leading/trailing whitespace
+          # Trim whitespace
           SA_TRIM="$(printf '%s' "$SA_RAW" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 
-          # If it's a quoted JSON string, try to unquote/unescape with python
+          # If quoted JSON string, unquote + unescape via python
           if [ "$(printf '%s' "$SA_TRIM" | head -c 1)" = '"' ] && [ "$(printf '%s' "$SA_TRIM" | tail -c 1)" = '"' ]; then
-            # Use python to unescape JSON string into raw JSON
             printf '%s' "$SA_TRIM" | python3 -c "import sys,json; print(json.loads(sys.stdin.read()))" > /tmp/sa.json 2>/tmp/decode.err || {
-              echo "::warning::python unescape of quoted JSON failed; stripping quotes and falling back"
+              echo "::warning::python unescape of quoted JSON failed; stripping quotes and continuing"
               printf '%s' "${SA_TRIM:1:-1}" > /tmp/sa.json
             }
           else
-            # Decide if it looks like raw JSON or base64
             FIRSTCHAR="$(printf '%s' "$SA_TRIM" | sed -e 's/[[:space:]]//g' | head -c 1 || true)"
             if [ "$FIRSTCHAR" = "{" ] || [ "$FIRSTCHAR" = "[" ]; then
-              # Raw JSON
+              # Looks like raw JSON
               printf '%s' "$SA_TRIM" > /tmp/sa.json
             else
-              # Assume base64; strip CRLFs then decode
+              # Assume base64; strip CRLFs and decode
               printf '%s' "$SA_TRIM" | tr -d '\r\n' | base64 --decode > /tmp/sa.json 2>/tmp/base64.err || {
                 echo "::error::base64 decode failed (invalid input)"
-                echo "Preview of trimmed secret (first 160 chars):"
-                printf '%s' "$SA_TRIM" | head -c 160 || true
+                echo "First 160 chars of trimmed secret:"
+                printf '%s' "$SA_TRIM" | head -c 160
                 echo
                 echo "base64 error output:"
                 cat /tmp/base64.err || true
@@ -38,24 +56,25 @@
             fi
           fi
 
-          # Validate JSON with python3 (fallback to jq if python not present)
+          # Validate JSON using python3 or fallback to jq
           if command -v python3 >/dev/null 2>&1; then
-            python3 - <<'PY' || {
-  echo "::error::python3 JSON validation failed"
-  head -c 400 /tmp/sa.json || true
-  exit 1
-}
+            python3 - <<'PY'
 import sys, json
 try:
   json.load(open('/tmp/sa.json'))
   sys.exit(0)
 except Exception as e:
   print('::error::Decoded /tmp/sa.json is not valid JSON:', e)
-  print(open('/tmp/sa.json').read(400))
+  with open('/tmp/sa.json') as f:
+    print(f.read(400))
   sys.exit(1)
 PY
+            if [ $? -ne 0 ]; then
+              echo "::error::python3 JSON validation failed"
+              head -c 400 /tmp/sa.json || true
+              exit 1
+            fi
           else
-            # Fallback to jq
             if ! command -v jq >/dev/null 2>&1; then
               sudo apt-get update && sudo apt-get install -y jq
             fi
@@ -64,3 +83,28 @@ PY
 
           echo "Decoded service account JSON present at /tmp/sa.json (validated)"
           chmod 600 /tmp/sa.json
+
+      - name: Install Node (if needed) and deps
+        run: |
+          # ensure node present and install any deps necessary for scripts
+          corepack enable
+          cd scripts || exit 0
+          if [ -f package.json ]; then npm ci || true; fi
+        working-directory: .
+
+      - name: Run set-admin script
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node scripts/set-admin-custom-claim.js "${{ github.event.inputs.email }}"
+
+      - name: Verify claim (server-side)
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: |
+          node -e "const admin=require('firebase-admin');
+          admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId:'ropi-bccee' });
+          (async()=>{
+            const u = await admin.auth().getUserByEmail(process.env.EMAIL || '${{ github.event.inputs.email }}');
+            console.log('customClaims:', u.customClaims || 'none');
+          })().catch(e=>{ console.error(e); process.exit(1); });"


### PR DESCRIPTION
## Summary
This PR fixes the YAML syntax error in the `set-admin-claim.yml` workflow that was causing parse failures.

## Changes
- **Fixed Python heredoc syntax**: The heredoc closing `PY` marker is now properly positioned on its own line
- **Fixed error handling**: Moved the conditional error check after the Python script execution instead of using an invalid inline error handler
- **Improved JSON validation**: Uses proper Python file reading with context manager
- **Restored complete workflow**: The previous commit accidentally deleted most of the workflow; this restores all job steps

## Technical Details
The YAML syntax error at line 66 was caused by improper indentation and placement of the bash error handler within the Python heredoc block. The heredoc pattern `<<'PY'` must have its closing `PY` on a dedicated line without any surrounding syntax.

**Before (broken):**
```yaml
python3 - <<'PY' || {
  echo "::error::python3 JSON validation failed"
  ...
}
import sys, json
...
PY
```

**After (fixed):**
```yaml
python3 - <<'PY'
import sys, json
...
PY
if [ $? -ne 0 ]; then
  echo "::error::python3 JSON validation failed"
  ...
fi
```

## Testing
After merge, the workflow should:
1. Successfully parse without YAML errors
2. Decode the `GCP_SA_KEY_BASE64` secret (base64-encoded service account JSON)
3. Validate the JSON structure
4. Run the admin claim script successfully

Related: PROMPT_019A_v1.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced admin account setup automation with improved error handling and server-side verification to ensure reliable claim configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->