### PR TITLE
ci: add staging environment to set-admin workflow (PROMPT_019A_v1.11)

### DIFF
--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   set-admin-claim:
     runs-on: ubuntu-latest
+    environment: staging
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
Adds `environment: staging` to the set-admin-claim workflow to properly scope the `GCP_SA_KEY_BASE64` secret to the staging environment.

## Changes
- Added `environment: staging` to the `set-admin-claim` job
- This ensures the workflow uses environment-scoped secrets and requires environment approval if configured

## Testing Plan
After merge:
1. Ensure `GCP_SA_KEY_BASE64` secret is added to the `staging` environment (base64-encoded service account JSON)
2. Trigger workflow: Actions → "Ops — Set Admin Custom Claim" → Run workflow
   - Branch: `aoss-main`
   - Email: `theo@shiekhshoes.org`
3. Approve staging environment deployment if prompted
4. Verify logs show:
   - "Decoded service account JSON present at /tmp/sa.json (validated)"
   - "Custom claim set for theo@shiekhshoes.org"
   - "customClaims: { role: 'admin' }"

## Related
PROMPT_019A_v1.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for improved operational management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->