### PR TITLE
ci: add comprehensive gcloud diagnostics and activation (PROMPT_019A_v1.15)

### DIFF
--- a/.github/workflows/set-admin-claim.yml
+++ b/.github/workflows/set-admin-claim.yml
@@ -75,6 +75,107 @@ jobs:
           echo "Decoded service account JSON present at /tmp/sa.json (validated)"
           chmod 600 /tmp/sa.json
 
+      - name: Diagnose gcloud & sa key (TEMP)
+        env:
+          GCP_SA_KEY_BASE64: ${{ secrets.GCP_SA_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "---- gcloud version ----"
+          if command -v gcloud >/dev/null 2>&1; then
+            gcloud --version || true
+          else
+            echo "gcloud not installed"
+          fi
+
+          echo "---- show /tmp/sa.json presence and client_email (safe) ----"
+          if [ -f /tmp/sa.json ]; then
+            python3 -c "import json; j=json.load(open('/tmp/sa.json')); print('client_email:', j.get('client_email'))" 2>&1 || echo "ERROR reading /tmp/sa.json"
+          else
+            echo "/tmp/sa.json NOT FOUND"
+          fi
+
+          echo "---- Check env var length for GCP_SA_KEY_BASE64 (no value printed) ----"
+          if [ -z "${GCP_SA_KEY_BASE64+x}" ]; then
+            echo "GCP_SA_KEY_BASE64 UNSET"
+          elif [ -z "$GCP_SA_KEY_BASE64" ]; then
+            echo "GCP_SA_KEY_BASE64 SET BUT EMPTY"
+          else
+            LEN=$(printf '%s' "$GCP_SA_KEY_BASE64" | wc -c)
+            echo "GCP_SA_KEY_BASE64 length: $LEN"
+          fi
+
+          echo "---- Test activation commands (dry run) ----"
+          echo "Attempting to activate service account and print active account..."
+          if command -v gcloud >/dev/null 2>&1; then
+            set +e
+            gcloud auth activate-service-account --key-file=/tmp/sa.json --project=ropi-bccee --quiet 2>/tmp/gcloud_activate.err
+            ACT=$?
+            set -e
+            if [ $ACT -ne 0 ]; then
+              echo "gcloud activate failed; preview:"
+              head -n 60 /tmp/gcloud_activate.err || true
+            else
+              echo "gcloud activate returned 0"
+              echo "Active account after activation:"
+              gcloud auth list --filter=status:ACTIVE --format='value(account)' || true
+              echo "Attempting to print access token (preview length)..."
+              TOKEN="$(gcloud auth print-access-token 2>/tmp/gcloud_token.err || true)"
+              if [ -z "$TOKEN" ]; then
+                echo "print-access-token failed; preview:"
+                head -n 40 /tmp/gcloud_token.err || true
+              else
+                echo "access-token length: ${#TOKEN}"
+              fi
+            fi
+          else
+            echo "gcloud not available"
+          fi
+
+      - name: Setup gcloud & activate service account
+        run: |
+          set -euo pipefail
+
+          # Ensure gcloud is present
+          if ! command -v gcloud >/dev/null 2>&1; then
+            echo "Installing google-cloud-cli..."
+            sudo apt-get update -y
+            sudo apt-get install -y google-cloud-cli
+          fi
+
+          # Validate decoded key
+          if [ ! -f /tmp/sa.json ]; then
+            echo "::error::/tmp/sa.json not found; cannot activate service account"
+            exit 1
+          fi
+
+          # Activate the service account and set the account/project explicitly
+          echo "Activating service account..."
+          gcloud auth activate-service-account --key-file=/tmp/sa.json --project=ropi-bccee --quiet
+
+          # Make the newly activated account active in gcloud config
+          SA_EMAIL="$(python3 -c "import json,sys; print(json.load(open('/tmp/sa.json'))['client_email'])")"
+          echo "Setting gcloud account to: $SA_EMAIL"
+          gcloud config set account "$SA_EMAIL"
+
+          echo "Setting project to ropi-bccee"
+          gcloud config set project ropi-bccee
+
+          echo "Verify active account:"
+          gcloud auth list --filter=status:ACTIVE --format="value(account)"
+
+          # Verify we can print an access token
+          echo "Attempting to print access token..."
+          TOKEN="$(gcloud auth print-access-token 2>&1)"
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to produce access token via gcloud auth print-access-token"
+            echo "Error output: $TOKEN"
+            gcloud auth list || true
+            exit 1
+          else
+            echo "access-token length: ${#TOKEN}"
+            echo "gcloud activation OK"
+          fi
+
       - name: Install Node (if needed) and deps
         run: |
           # ensure node present and install any deps necessary for scripts
@@ -86,8 +187,22 @@ jobs:
       - name: Run set-admin script
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+          EMAIL: "${{ github.event.inputs.email }}"
         run: |
-          node scripts/set-admin-custom-claim.js "${{ github.event.inputs.email }}"
+          set -euo pipefail
+          echo "Confirm GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
+          echo "Active gcloud account:"
+          gcloud auth list --filter=status:ACTIVE --format="value(account)" || echo "gcloud not available"
+          echo "Using project:"
+          gcloud config get-value project || echo "gcloud not available"
+
+          # Run the script using applicationDefault()
+          node -e "const admin=require('firebase-admin'); \
+            admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId:'ropi-bccee' }); \
+            (async ()=>{ const u = await admin.auth().getUserByEmail(process.env.EMAIL); \
+              await admin.auth().setCustomUserClaims(u.uid, { admin: true }); \
+              console.log('Set admin claim for', process.env.EMAIL); \
+            })().catch(e=>{ console.error(e); process.exit(1); });"
 
       - name: Verify claim (server-side)
         env:


### PR DESCRIPTION
## Summary
Adds comprehensive diagnostics and proper gcloud activation to troubleshoot and fix the "no active gcloud account" error.

## Changes

### 1. New Step: "Diagnose gcloud & sa key (TEMP)"
**Purpose**: Gather diagnostic information before activation

**Diagnostics included**:
- ✅ gcloud version check
- ✅ Verify `/tmp/sa.json` exists and read `client_email`
- ✅ Check `GCP_SA_KEY_BASE64` secret length (value not printed)
- ✅ Test `gcloud auth activate-service-account` in dry-run mode
- ✅ Check active account after test activation
- ✅ Test `gcloud auth print-access-token` and report token length

**Note**: This step is temporary and will be removed once we confirm the workflow works.

### 2. New Step: "Setup gcloud & activate service account"
**Purpose**: Properly activate the service account

**Steps**:
- Install `google-cloud-cli` if not present
- Validate `/tmp/sa.json` exists
- Activate service account: `gcloud auth activate-service-account`
- Set active account: `gcloud config set account`
- Set project: `gcloud config set project ropi-bccee`
- Verify activation with `gcloud auth list`
- Test token generation with `gcloud auth print-access-token`

### 3. Updated: "Run set-admin script"
**Changes**:
- Added `EMAIL` environment variable
- Pre-flight checks: verify gcloud account and project
- Inline Node script using `applicationDefault()`
- Sets custom claim `{ admin: true }`

## Expected Diagnostic Output

### From "Diagnose" step:
```
gcloud version: X.X.X
client_email: ropi-aoss-deployer@ropi-bccee.iam.gserviceaccount.com
GCP_SA_KEY_BASE64 length: XXXX
gcloud activate returned 0
Active account after activation: ropi-aoss-deployer@...
access-token length: XXX
```

### From "Setup gcloud" step:
```
Activating service account...
Setting gcloud account to: ropi-aoss-deployer@...
Active account: ropi-aoss-deployer@...
access-token length: XXX
gcloud activation OK
```

### From "Run set-admin script":
```
GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
Active gcloud account: ropi-aoss-deployer@...
Using project: ropi-bccee
Set admin claim for theo@shiekhshoes.org
```

## Testing Plan

After merge:
1. Trigger workflow on `aoss-main` with email `theo@shiekhshoes.org`
2. Approve staging environment
3. Capture complete logs from:
   - "Diagnose gcloud & sa key (TEMP)" step
   - "Setup gcloud & activate service account" step
   - "Run set-admin script" step
4. If successful, create follow-up PR to remove TEMP diagnostic step
5. If failure, analyze diagnostic output to identify root cause

## Prerequisites
- [ ] Secret `GCP_SA_KEY_BASE64` configured in staging environment
- [ ] Service account has IAM role: `roles/firebase.admin`

## Related
PROMPT_019A_v1.15

---

**Ready for merge and diagnostic run.** The TEMP diagnostic step will help us understand exactly what's happening with gcloud activation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow diagnostics and validation for admin claim initialization.
  * Improved credential setup verification and error handling in deployment process.
  * Added detailed logging steps for troubleshooting service account configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->