### PR TITLE
ci(validate): allow integration branch for staged merges

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,6 +10,9 @@ jobs:
   validate-pr:
     name: Validate PR Compliance
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     
     steps:
       - name: Checkout repository
@@ -192,4 +195,3 @@ jobs:
           fi
           echo ""
           echo "=========================================="
-# Trigger validation Sat Dec  6 23:34:29 UTC 2025

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -192,3 +192,4 @@ jobs:
           fi
           echo ""
           echo "=========================================="
+# Trigger validation Sat Dec  6 23:34:29 UTC 2025

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -41,30 +41,35 @@ jobs:
         id: validate-branch
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
-          
           echo "Checking branch name: $BRANCH_NAME"
-          
-          # Check if branch starts with 'feature/'
-          if [[ ! "$BRANCH_NAME" =~ ^feature/ ]]; then
-            echo "❌ ERROR: Branch name must start with 'feature/'"
+
+          # Allow either feature/<slug> OR the special integration branch
+          if [[ "$BRANCH_NAME" =~ ^feature/ ]]; then
+            # basic feature branch name OK
+            :
+          elif [[ "$BRANCH_NAME" == "aoss-staging-integration" ]]; then
+            # allow our special integration branch for staged merges
+            :
+          else
+            echo "❌ ERROR: Branch name must start with 'feature/' or be 'aoss-staging-integration'"
             echo "   Current branch: $BRANCH_NAME"
-            echo "   Expected pattern: feature/<slug>"
+            echo "   Expected pattern: feature/<slug> OR aoss-staging-integration"
             echo "   Examples: feature/auth-login, feature/infra/new-workflow"
             echo "branch_valid=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
-          # Check for valid characters (lowercase letters, numbers, hyphens, forward slashes)
-          if [[ ! "$BRANCH_NAME" =~ ^feature/[a-z0-9/-]+$ ]]; then
+
+          # Validate characters for feature/ branches or exact integration name
+          if [[ "$BRANCH_NAME" =~ ^feature/[a-z0-9/-]+$ || "$BRANCH_NAME" == "aoss-staging-integration" ]]; then
+            echo "✅ Branch name is valid: $BRANCH_NAME"
+            echo "branch_valid=true" >> $GITHUB_OUTPUT
+          else
             echo "❌ ERROR: Branch name contains invalid characters"
-            echo "   Allowed: lowercase letters, numbers, hyphens, forward slashes"
+            echo "   Allowed: lowercase letters, numbers, hyphens, forward slashes (or exact 'aoss-staging-integration')"
             echo "   Current branch: $BRANCH_NAME"
             echo "branch_valid=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
-          echo "✅ Branch name is valid: $BRANCH_NAME"
-          echo "branch_valid=true" >> $GITHUB_OUTPUT
 
       - name: Validate Target Branch
         id: validate-target


### PR DESCRIPTION
Allow the special integration branch `aoss-staging-integration` in the PR validator while keeping feature/* guard. Enables our integration flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull request validation updated to accept either feature/<slug> branches or the exact aoss-staging-integration name.
  * Validation simplified to a single check, with clearer error messages reflecting accepted patterns.
  * CI validation permissions adjusted and validation now emits an explicit branch_valid status (true/false) and a corresponding success or error message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->