### PR TITLE
ci: Add Firebase emulator workflow for API integration tests

### DIFF
--- a/.github/workflows/api-integration-emulator.yml
+++ b/.github/workflows/api-integration-emulator.yml
@@ -1,0 +1,110 @@
+name: API Integration Tests (Emulator)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'packages/api/**'
+      - 'packages/sdk/**'
+      - 'firestore.rules'
+      - '.github/workflows/api-integration-emulator.yml'
+  workflow_dispatch:
+
+jobs:
+  api-integration-tests:
+    name: API Tests with Firebase Emulator
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    env:
+      # Firestore emulator host for tests
+      FIRESTORE_EMULATOR_HOST: localhost:8080
+      # Use demo project for emulator (no real GCP project needed)
+      GCLOUD_PROJECT: demo-ropi-test
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@8
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@latest
+
+      - name: Install Java (required for Firestore emulator)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build SDK (dependency for API)
+        run: pnpm --filter @ropi-aoss/sdk build
+
+      - name: Run API tests with Firestore emulator
+        run: |
+          echo "Starting Firestore emulator and running tests..."
+          firebase emulators:exec \
+            --only firestore \
+            --project demo-ropi-test \
+            "pnpm --filter @ropi-aoss/api test"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-test-results
+          path: |
+            packages/api/coverage/
+            packages/api/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Optional: Run SDK tests (don't require emulator)
+  sdk-unit-tests:
+    name: SDK Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@8
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build and test SDK
+        run: |
+          pnpm --filter @ropi-aoss/sdk build
+          pnpm --filter @ropi-aoss/sdk test
+
+      - name: Upload SDK test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-test-results
+          path: |
+            packages/sdk/coverage/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary back to Lisa

**Prompt-Version: Lisa v0.2.0-rc**

**Type:** ci/infra

## Description

Adds a new GitHub Actions workflow `.github/workflows/api-integration-emulator.yml` that:

1. Runs on PRs that modify `packages/api/**`, `packages/sdk/**`, or `firestore.rules`
2. Starts the Firebase Firestore emulator using `firebase emulators:exec`
3. Runs `pnpm --filter @ropi-aoss/api test` with `FIRESTORE_EMULATOR_HOST` set
4. Uses `demo-ropi-test` project (no real GCP credentials needed for emulator)
5. Uploads test artifacts on completion

## Key Features

- **No GCP secrets required** — Uses demo project mode for emulator
- **Java setup included** — Firestore emulator requires Java
- **Path filtering** — Only runs when relevant files change
- **SDK tests included** — Separate job for SDK unit tests (no emulator needed)
- **Artifacts uploaded** — Coverage and test results preserved

## Files Changed

- `.github/workflows/api-integration-emulator.yml` (new)

## Notes

- Integration tests in `packages/api/test/integration/` will now run with emulator
- SDK tests run separately and don't require emulator
- Workflow is also manually triggerable via workflow_dispatch

**Prompt-Version: Lisa v0.2.0-rc**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration workflow that automatically runs API integration tests against a Firestore emulator and SDK unit tests on all pull requests, with test results and coverage reports uploaded for quality assurance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->