### PR TITLE
feat(admin): Attributes persistence & API (Lisa v0.2.0-rc)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -212,6 +212,43 @@ service cloud.firestore {
     }
     
     // ========================================
+    // SETTINGS COLLECTION (Lisa v0.2.0-rc)
+    // ========================================
+    // Related Notion docs:
+    // - Admin UI Build Spec — Settings CRUD
+    // - Section 2.2 — Attribute Validation Schema
+    //
+    // Settings store configuration for Attributes, Smart Rules, AI Templates
+    // Admin-only read/write access
+    
+    // Attributes subcollection: settings/attributes/keys/{attributeId}
+    match /settings/attributes/keys/{attributeId} {
+      // Only admins can read attribute definitions
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      
+      // Only admins can write attribute definitions
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    // Smart Rules subcollection: settings/smartRules/rules/{ruleId}
+    match /settings/smartRules/rules/{ruleId} {
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    // AI Templates subcollection: settings/aiTemplates/templates/{templateKey}
+    match /settings/aiTemplates/templates/{templateKey} {
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    // ========================================
     // DEFAULT DENY
     // ========================================
     // Deny access to all other collections by default

--- a/packages/api/src/endpoints/admin/settings.ts
+++ b/packages/api/src/endpoints/admin/settings.ts
@@ -1,38 +1,175 @@
-import { requireAdmin } from '../../middleware/auth';
-import { Request, Response } from 'express';
-import { validateAttribute } from '../schemas/attributeSchema';
-// NOTE: adapt imports to your runtime/export style. This file is an endpoint skeleton.
-// Example handlers: listAttributes, createAttribute, updateAttribute, deleteAttribute
+/**
+ * Admin Settings Endpoints
+ * Per AOSS Section 6 — API Contracts
+ * 
+ * Implements CRUD handlers for Attributes, Smart Rules, and AI Templates.
+ * All endpoints require admin authentication.
+ */
 
+import { requireAdmin, type AuthenticatedRequest } from '../../middleware/auth';
+import type { Request, Response } from 'express';
+import {
+  listAttributes,
+  getAttribute,
+  createAttribute,
+  updateAttribute,
+  deleteAttribute,
+  validateAttributeData,
+  ServiceError,
+} from '../../services/attributesService';
+
+/**
+ * Format service error for HTTP response
+ */
+function handleServiceError(error: unknown, res: Response): void {
+  if (error instanceof ServiceError) {
+    res.status(error.statusCode).json({
+      error: error.code,
+      message: error.message,
+    });
+    return;
+  }
+  
+  console.error('Unexpected error:', error);
+  res.status(500).json({
+    error: 'INTERNAL_ERROR',
+    message: 'An unexpected error occurred',
+  });
+}
+
+/**
+ * GET /admin/settings/attributes
+ * List attributes with optional search and pagination
+ */
 export async function listAttributesHandler(req: Request, res: Response) {
   await requireAdmin(req, res, async () => {
-    // TODO: Implement Firestore list read for settings/attributes/keys
-    res.status(200).json({ message: 'listAttributes not implemented yet' });
+    try {
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+      const pageToken = req.query.pageToken as string | undefined;
+      const q = req.query.q as string | undefined;
+      
+      const result = await listAttributes({ limit, pageToken, q });
+      res.status(200).json(result);
+    } catch (error) {
+      handleServiceError(error, res);
+    }
   });
 }
 
+/**
+ * GET /admin/settings/attributes/:id
+ * Get a single attribute by ID
+ */
+export async function getAttributeHandler(req: Request, res: Response) {
+  await requireAdmin(req, res, async () => {
+    try {
+      const attributeId = req.params.id;
+      if (!attributeId) {
+        res.status(400).json({
+          error: 'INVALID_REQUEST',
+          message: 'Attribute ID is required',
+        });
+        return;
+      }
+      
+      const attribute = await getAttribute(attributeId);
+      res.status(200).json(attribute);
+    } catch (error) {
+      handleServiceError(error, res);
+    }
+  });
+}
+
+/**
+ * POST /admin/settings/attributes
+ * Create a new attribute
+ */
 export async function createAttributeHandler(req: Request, res: Response) {
   await requireAdmin(req, res, async () => {
-    const parsed = validateAttribute(req.body);
-    if (!parsed.success) {
-      res.status(400).json({ error: parsed.error });
-      return;
+    try {
+      // Validate request body
+      const validation = validateAttributeData(req.body);
+      if (!validation.success) {
+        res.status(400).json({
+          error: 'VALIDATION_ERROR',
+          message: 'Invalid attribute data',
+          errors: validation.errors,
+        });
+        return;
+      }
+      
+      // Get actor from auth context
+      const authReq = req as AuthenticatedRequest;
+      const actor = authReq.auth?.uid || 'system';
+      
+      const created = await createAttribute(validation.data!, actor);
+      res.status(201).json(created);
+    } catch (error) {
+      handleServiceError(error, res);
     }
-    // TODO: Persist to Firestore
-    res.status(201).json({ message: 'createAttribute not implemented yet' });
   });
 }
 
+/**
+ * PUT /admin/settings/attributes/:id
+ * Update an existing attribute
+ */
 export async function updateAttributeHandler(req: Request, res: Response) {
   await requireAdmin(req, res, async () => {
-    // TODO: validate & update
-    res.status(200).json({ message: 'updateAttribute not implemented yet' });
+    try {
+      const attributeId = req.params.id;
+      if (!attributeId) {
+        res.status(400).json({
+          error: 'INVALID_REQUEST',
+          message: 'Attribute ID is required',
+        });
+        return;
+      }
+      
+      // Partial validation - allow subset of fields
+      // For updates, we don't require all fields
+      const patch = req.body;
+      if (!patch || typeof patch !== 'object') {
+        res.status(400).json({
+          error: 'VALIDATION_ERROR',
+          message: 'Request body must be an object',
+        });
+        return;
+      }
+      
+      // Get actor from auth context
+      const authReq = req as AuthenticatedRequest;
+      const actor = authReq.auth?.uid || 'system';
+      
+      const updated = await updateAttribute(attributeId, patch, actor);
+      res.status(200).json(updated);
+    } catch (error) {
+      handleServiceError(error, res);
+    }
   });
 }
 
+/**
+ * DELETE /admin/settings/attributes/:id
+ * Delete an attribute
+ */
 export async function deleteAttributeHandler(req: Request, res: Response) {
   await requireAdmin(req, res, async () => {
-    // TODO: delete
-    res.status(200).json({ message: 'deleteAttribute not implemented yet' });
+    try {
+      const attributeId = req.params.id;
+      if (!attributeId) {
+        res.status(400).json({
+          error: 'INVALID_REQUEST',
+          message: 'Attribute ID is required',
+        });
+        return;
+      }
+      
+      await deleteAttribute(attributeId);
+      res.status(204).send();
+    } catch (error) {
+      handleServiceError(error, res);
+    }
   });
 }
+

--- a/packages/api/src/schemas/aiTemplateSchema.ts
+++ b/packages/api/src/schemas/aiTemplateSchema.ts
@@ -1,4 +1,4 @@
-import { AITemplateSchema } from '../../../sdk/src/schema/aiTemplate';
+import { AITemplateSchema } from '@ropi-aoss/sdk';
 import { z } from 'zod';
 export function validateAITemplate(data: unknown) {
   return AITemplateSchema.safeParse(data);

--- a/packages/api/src/schemas/attributeSchema.ts
+++ b/packages/api/src/schemas/attributeSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AttributeSchema } from '../../../sdk/src/schema/attribute';
+import { AttributeSchema } from '@ropi-aoss/sdk';
 
 export function validateAttribute(data: unknown) {
   return AttributeSchema.safeParse(data);

--- a/packages/api/src/schemas/smartRuleSchema.ts
+++ b/packages/api/src/schemas/smartRuleSchema.ts
@@ -1,4 +1,4 @@
-import { SmartRuleSchema } from '../../../sdk/src/schema/smartRule';
+import { SmartRuleSchema } from '@ropi-aoss/sdk';
 import { z } from 'zod';
 export function validateSmartRule(data: unknown) {
   return SmartRuleSchema.safeParse(data);

--- a/packages/api/src/services/attributesService.ts
+++ b/packages/api/src/services/attributesService.ts
@@ -1,0 +1,290 @@
+/**
+ * Attributes Service
+ * Per AOSS Section 2.2 — Attribute Validation Schema
+ * 
+ * Implements CRUD operations for product attributes in Firestore.
+ * Path: settings/attributes/keys/{attributeId}
+ */
+
+import * as admin from 'firebase-admin';
+import { AttributeSchema, type AttributeType } from '@ropi-aoss/sdk';
+
+// Firestore collection paths
+const ATTRIBUTES_COLLECTION = 'settings/attributes/keys';
+
+// Default pagination limit
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+/**
+ * Service error with HTTP status code
+ */
+export class ServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly code: string
+  ) {
+    super(message);
+    this.name = 'ServiceError';
+  }
+}
+
+/**
+ * Pagination result
+ */
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  pageToken?: string;
+  hasMore: boolean;
+}
+
+/**
+ * List attributes query options
+ */
+export interface ListAttributesOptions {
+  limit?: number;
+  pageToken?: string;
+  q?: string; // Search query for label or attribute_id
+}
+
+/**
+ * Get Firestore instance
+ */
+function getDb(): admin.firestore.Firestore {
+  return admin.firestore();
+}
+
+/**
+ * Convert Zod-validated attribute to Firestore payload
+ */
+function toFirestorePayload(
+  attribute: AttributeType,
+  actor: string,
+  isCreate: boolean
+): Record<string, unknown> {
+  const now = new Date().toISOString();
+  const payload: Record<string, unknown> = { ...attribute };
+  
+  if (isCreate) {
+    payload.createdBy = actor;
+    payload.createdAt = now;
+  }
+  payload.updatedBy = actor;
+  payload.updatedAt = now;
+  
+  return payload;
+}
+
+/**
+ * Convert Firestore document to AttributeType
+ */
+function fromFirestore(doc: admin.firestore.DocumentSnapshot): AttributeType | null {
+  if (!doc.exists) return null;
+  const data = doc.data();
+  if (!data) return null;
+  
+  return {
+    attribute_id: doc.id,
+    ...data,
+  } as AttributeType;
+}
+
+/**
+ * List attributes with optional search and pagination
+ */
+export async function listAttributes(
+  options: ListAttributesOptions = {}
+): Promise<PaginatedResult<AttributeType>> {
+  const db = getDb();
+  const limit = Math.min(options.limit || DEFAULT_LIMIT, MAX_LIMIT);
+  
+  let query: admin.firestore.Query = db.collection(ATTRIBUTES_COLLECTION)
+    .orderBy('label')
+    .limit(limit + 1); // Fetch one extra to detect hasMore
+  
+  // Apply pagination token (last document ID)
+  if (options.pageToken) {
+    const lastDoc = await db.collection(ATTRIBUTES_COLLECTION).doc(options.pageToken).get();
+    if (lastDoc.exists) {
+      query = query.startAfter(lastDoc);
+    }
+  }
+  
+  const snapshot = await query.get();
+  const docs = snapshot.docs;
+  
+  // Determine if there are more results
+  const hasMore = docs.length > limit;
+  const resultDocs = hasMore ? docs.slice(0, limit) : docs;
+  
+  let items = resultDocs
+    .map(doc => fromFirestore(doc))
+    .filter((item): item is AttributeType => item !== null);
+  
+  // Apply client-side search filter if query provided
+  // Note: For production, consider using a search service like Algolia or Elastic
+  if (options.q) {
+    const searchTerm = options.q.toLowerCase();
+    items = items.filter(attr =>
+      attr.label.toLowerCase().includes(searchTerm) ||
+      attr.attribute_id.toLowerCase().includes(searchTerm)
+    );
+  }
+  
+  // Get total count (for small collections; optimize for large ones)
+  const totalSnapshot = await db.collection(ATTRIBUTES_COLLECTION).count().get();
+  const total = totalSnapshot.data().count;
+  
+  return {
+    items,
+    total,
+    pageToken: hasMore ? resultDocs[resultDocs.length - 1]?.id : undefined,
+    hasMore,
+  };
+}
+
+/**
+ * Get a single attribute by ID
+ */
+export async function getAttribute(attributeId: string): Promise<AttributeType> {
+  const db = getDb();
+  const doc = await db.collection(ATTRIBUTES_COLLECTION).doc(attributeId).get();
+  
+  const attribute = fromFirestore(doc);
+  if (!attribute) {
+    throw new ServiceError(
+      `Attribute '${attributeId}' not found`,
+      404,
+      'ATTRIBUTE_NOT_FOUND'
+    );
+  }
+  
+  return attribute;
+}
+
+/**
+ * Create a new attribute
+ * Uses Firestore create() to ensure uniqueness (fails if doc exists)
+ */
+export async function createAttribute(
+  attribute: AttributeType,
+  actor: string
+): Promise<AttributeType> {
+  const db = getDb();
+  const docRef = db.collection(ATTRIBUTES_COLLECTION).doc(attribute.attribute_id);
+  
+  const payload = toFirestorePayload(attribute, actor, true);
+  
+  try {
+    // Use create() which fails if document already exists
+    await docRef.create(payload);
+  } catch (error: unknown) {
+    // Check if it's a duplicate error
+    if (error instanceof Error && error.message.includes('already exists')) {
+      throw new ServiceError(
+        `Attribute '${attribute.attribute_id}' already exists`,
+        409,
+        'ATTRIBUTE_EXISTS'
+      );
+    }
+    throw error;
+  }
+  
+  // Return the created attribute
+  return {
+    ...attribute,
+    createdBy: payload.createdBy as string,
+    createdAt: payload.createdAt as string,
+    updatedBy: payload.updatedBy as string,
+    updatedAt: payload.updatedAt as string,
+  };
+}
+
+/**
+ * Update an existing attribute
+ */
+export async function updateAttribute(
+  attributeId: string,
+  patch: Partial<AttributeType>,
+  actor: string
+): Promise<AttributeType> {
+  const db = getDb();
+  const docRef = db.collection(ATTRIBUTES_COLLECTION).doc(attributeId);
+  
+  // Check if document exists
+  const existing = await docRef.get();
+  if (!existing.exists) {
+    throw new ServiceError(
+      `Attribute '${attributeId}' not found`,
+      404,
+      'ATTRIBUTE_NOT_FOUND'
+    );
+  }
+  
+  // Prevent changing attribute_id
+  const { attribute_id: _, ...patchWithoutId } = patch;
+  
+  const now = new Date().toISOString();
+  const updatePayload = {
+    ...patchWithoutId,
+    updatedBy: actor,
+    updatedAt: now,
+  };
+  
+  await docRef.update(updatePayload);
+  
+  // Fetch and return updated document
+  const updatedDoc = await docRef.get();
+  const result = fromFirestore(updatedDoc);
+  if (!result) {
+    throw new ServiceError('Failed to retrieve updated attribute', 500, 'INTERNAL_ERROR');
+  }
+  
+  return result;
+}
+
+/**
+ * Delete an attribute
+ */
+export async function deleteAttribute(attributeId: string): Promise<void> {
+  const db = getDb();
+  const docRef = db.collection(ATTRIBUTES_COLLECTION).doc(attributeId);
+  
+  // Check if document exists
+  const existing = await docRef.get();
+  if (!existing.exists) {
+    throw new ServiceError(
+      `Attribute '${attributeId}' not found`,
+      404,
+      'ATTRIBUTE_NOT_FOUND'
+    );
+  }
+  
+  await docRef.delete();
+}
+
+/**
+ * Validate attribute data using Zod schema
+ * Returns validation result with parsed data or error details
+ */
+export function validateAttributeData(data: unknown): {
+  success: boolean;
+  data?: AttributeType;
+  errors?: Array<{ path: string; message: string }>;
+} {
+  const result = AttributeSchema.safeParse(data);
+  
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  
+  return {
+    success: false,
+    errors: result.error.errors.map(err => ({
+      path: err.path.join('.'),
+      message: err.message,
+    })),
+  };
+}

--- a/packages/api/test/attributes.service.spec.ts
+++ b/packages/api/test/attributes.service.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Attributes Service Tests
+ * Tests for CRUD operations on product attributes
+ * 
+ * Per AOSS Section 2.2 — Attribute Validation Schema
+ * Lisa v0.2.0-rc
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as admin from 'firebase-admin';
+import {
+  listAttributes,
+  getAttribute,
+  createAttribute,
+  updateAttribute,
+  deleteAttribute,
+  validateAttributeData,
+  ServiceError,
+} from '../src/services/attributesService';
+
+// Note: These tests require Firebase Admin SDK initialization
+// and Firestore emulator running
+
+describe('Attributes Service', () => {
+  let db: admin.firestore.Firestore;
+  const testAttributeId = 'test-color-primary';
+  const testActor = 'test-user-123';
+
+  beforeEach(async () => {
+    // Initialize Firebase Admin if not already done
+    if (!admin.apps.length) {
+      admin.initializeApp({
+        projectId: 'demo-test-project',
+      });
+    }
+    
+    db = admin.firestore();
+    
+    // Use emulator for tests
+    if (process.env.FIRESTORE_EMULATOR_HOST) {
+      console.log('Using Firestore emulator');
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    try {
+      const attributesSnapshot = await db.collection('settings/attributes/keys').get();
+      const batch = db.batch();
+      attributesSnapshot.docs.forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+    } catch (error) {
+      console.error('Cleanup error:', error);
+    }
+  });
+
+  describe('validateAttributeData', () => {
+    it('should validate a correct attribute', () => {
+      const validAttribute = {
+        attribute_id: 'color-primary',
+        label: 'Primary Color',
+        data_type: 'string',
+      };
+      
+      const result = validateAttributeData(validAttribute);
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.attribute_id).toBe('color-primary');
+    });
+
+    it('should reject invalid attribute_id format', () => {
+      const invalidAttribute = {
+        attribute_id: 'Invalid ID With Spaces',
+        label: 'Bad Attribute',
+        data_type: 'string',
+      };
+      
+      const result = validateAttributeData(invalidAttribute);
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.length).toBeGreaterThan(0);
+    });
+
+    it('should reject missing required fields', () => {
+      const incompleteAttribute = {
+        attribute_id: 'test-attr',
+      };
+      
+      const result = validateAttributeData(incompleteAttribute);
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+    });
+
+    it('should reject invalid data_type', () => {
+      const invalidAttribute = {
+        attribute_id: 'test-attr',
+        label: 'Test',
+        data_type: 'invalid_type',
+      };
+      
+      const result = validateAttributeData(invalidAttribute);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('createAttribute', () => {
+    it('should create a new attribute', async () => {
+      const newAttribute = {
+        attribute_id: testAttributeId,
+        label: 'Color Primary',
+        data_type: 'string' as const,
+      };
+      
+      const created = await createAttribute(newAttribute, testActor);
+      
+      expect(created.attribute_id).toBe(testAttributeId);
+      expect(created.label).toBe('Color Primary');
+      expect(created.createdBy).toBe(testActor);
+      expect(created.createdAt).toBeDefined();
+      expect(created.updatedBy).toBe(testActor);
+      expect(created.updatedAt).toBeDefined();
+    });
+
+    it('should throw 409 on duplicate attribute_id', async () => {
+      const attribute = {
+        attribute_id: testAttributeId,
+        label: 'Color Primary',
+        data_type: 'string' as const,
+      };
+      
+      // Create first
+      await createAttribute(attribute, testActor);
+      
+      // Try to create duplicate
+      await expect(createAttribute(attribute, testActor))
+        .rejects
+        .toThrow(ServiceError);
+      
+      try {
+        await createAttribute(attribute, testActor);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).statusCode).toBe(409);
+        expect((error as ServiceError).code).toBe('ATTRIBUTE_EXISTS');
+      }
+    });
+  });
+
+  describe('getAttribute', () => {
+    it('should retrieve an existing attribute', async () => {
+      // Create attribute first
+      const attribute = {
+        attribute_id: testAttributeId,
+        label: 'Color Primary',
+        data_type: 'string' as const,
+      };
+      await createAttribute(attribute, testActor);
+      
+      const retrieved = await getAttribute(testAttributeId);
+      
+      expect(retrieved.attribute_id).toBe(testAttributeId);
+      expect(retrieved.label).toBe('Color Primary');
+    });
+
+    it('should throw 404 for non-existent attribute', async () => {
+      await expect(getAttribute('non-existent-id'))
+        .rejects
+        .toThrow(ServiceError);
+      
+      try {
+        await getAttribute('non-existent-id');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).statusCode).toBe(404);
+        expect((error as ServiceError).code).toBe('ATTRIBUTE_NOT_FOUND');
+      }
+    });
+  });
+
+  describe('updateAttribute', () => {
+    it('should update an existing attribute', async () => {
+      // Create attribute first
+      const attribute = {
+        attribute_id: testAttributeId,
+        label: 'Color Primary',
+        data_type: 'string' as const,
+      };
+      await createAttribute(attribute, testActor);
+      
+      // Update
+      const updatedActor = 'another-user-456';
+      const updated = await updateAttribute(testAttributeId, { label: 'Updated Label' }, updatedActor);
+      
+      expect(updated.label).toBe('Updated Label');
+      expect(updated.updatedBy).toBe(updatedActor);
+    });
+
+    it('should throw 404 for non-existent attribute', async () => {
+      await expect(updateAttribute('non-existent-id', { label: 'Test' }, testActor))
+        .rejects
+        .toThrow(ServiceError);
+      
+      try {
+        await updateAttribute('non-existent-id', { label: 'Test' }, testActor);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).statusCode).toBe(404);
+      }
+    });
+  });
+
+  describe('deleteAttribute', () => {
+    it('should delete an existing attribute', async () => {
+      // Create attribute first
+      const attribute = {
+        attribute_id: testAttributeId,
+        label: 'Color Primary',
+        data_type: 'string' as const,
+      };
+      await createAttribute(attribute, testActor);
+      
+      // Delete
+      await deleteAttribute(testAttributeId);
+      
+      // Verify deleted
+      await expect(getAttribute(testAttributeId))
+        .rejects
+        .toThrow(ServiceError);
+    });
+
+    it('should throw 404 for non-existent attribute', async () => {
+      await expect(deleteAttribute('non-existent-id'))
+        .rejects
+        .toThrow(ServiceError);
+      
+      try {
+        await deleteAttribute('non-existent-id');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).statusCode).toBe(404);
+      }
+    });
+  });
+
+  describe('listAttributes', () => {
+    beforeEach(async () => {
+      // Create some test attributes
+      const attributes = [
+        { attribute_id: 'color-primary', label: 'Primary Color', data_type: 'string' as const },
+        { attribute_id: 'size-standard', label: 'Standard Size', data_type: 'enum' as const },
+        { attribute_id: 'price-retail', label: 'Retail Price', data_type: 'currency' as const },
+      ];
+      
+      for (const attr of attributes) {
+        await createAttribute(attr, testActor);
+      }
+    });
+
+    it('should list all attributes', async () => {
+      const result = await listAttributes();
+      
+      expect(result.items.length).toBe(3);
+      expect(result.total).toBe(3);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should respect limit parameter', async () => {
+      const result = await listAttributes({ limit: 2 });
+      
+      expect(result.items.length).toBe(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.pageToken).toBeDefined();
+    });
+
+    it('should filter by search query', async () => {
+      const result = await listAttributes({ q: 'color' });
+      
+      expect(result.items.length).toBe(1);
+      expect(result.items[0].attribute_id).toBe('color-primary');
+    });
+
+    it('should paginate correctly', async () => {
+      const page1 = await listAttributes({ limit: 2 });
+      expect(page1.items.length).toBe(2);
+      expect(page1.hasMore).toBe(true);
+      
+      const page2 = await listAttributes({ limit: 2, pageToken: page1.pageToken });
+      expect(page2.items.length).toBe(1);
+      expect(page2.hasMore).toBe(false);
+    });
+  });
+});

--- a/packages/api/test/integration/attributes.emu.spec.ts
+++ b/packages/api/test/integration/attributes.emu.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * Attributes Emulator Integration Tests
+ * End-to-end tests against Firebase Emulator
+ * 
+ * Per AOSS Section 2.2 — Attribute Validation Schema
+ * Lisa v0.2.0-rc
+ * 
+ * Prerequisites:
+ * - Firebase emulator running: firebase emulators:start --only firestore
+ * - FIRESTORE_EMULATOR_HOST environment variable set (e.g., localhost:8080)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as admin from 'firebase-admin';
+import {
+  listAttributes,
+  getAttribute,
+  createAttribute,
+  updateAttribute,
+  deleteAttribute,
+  ServiceError,
+} from '../../src/services/attributesService';
+
+// Skip integration tests if emulator is not running
+const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST;
+const describeIfEmulator = EMULATOR_HOST ? describe : describe.skip;
+
+describeIfEmulator('Attributes Emulator Integration Tests', () => {
+  let db: admin.firestore.Firestore;
+  const testActor = 'integration-test-user';
+
+  beforeAll(async () => {
+    // Initialize Firebase Admin with emulator
+    if (!admin.apps.length) {
+      admin.initializeApp({
+        projectId: 'demo-integration-test',
+      });
+    }
+    
+    db = admin.firestore();
+    console.log(`Connected to Firestore emulator at ${EMULATOR_HOST}`);
+  });
+
+  afterAll(async () => {
+    // Final cleanup
+    try {
+      const attributesSnapshot = await db.collection('settings/attributes/keys').get();
+      const batch = db.batch();
+      attributesSnapshot.docs.forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+    } catch (error) {
+      console.error('Final cleanup error:', error);
+    }
+  });
+
+  beforeEach(async () => {
+    // Clean up before each test
+    try {
+      const attributesSnapshot = await db.collection('settings/attributes/keys').get();
+      const batch = db.batch();
+      attributesSnapshot.docs.forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('Full CRUD Lifecycle', () => {
+    it('should complete create -> read -> update -> delete flow', async () => {
+      const attributeId = 'lifecycle-test-attr';
+      
+      // CREATE
+      const created = await createAttribute({
+        attribute_id: attributeId,
+        label: 'Lifecycle Test Attribute',
+        data_type: 'string',
+        category: 'test-category',
+      }, testActor);
+      
+      expect(created.attribute_id).toBe(attributeId);
+      expect(created.label).toBe('Lifecycle Test Attribute');
+      expect(created.createdBy).toBe(testActor);
+      expect(created.createdAt).toBeDefined();
+      
+      // READ
+      const read = await getAttribute(attributeId);
+      expect(read.attribute_id).toBe(attributeId);
+      expect(read.label).toBe('Lifecycle Test Attribute');
+      expect(read.category).toBe('test-category');
+      
+      // UPDATE
+      const updateActor = 'another-test-user';
+      const updated = await updateAttribute(attributeId, {
+        label: 'Updated Label',
+        category: 'updated-category',
+      }, updateActor);
+      
+      expect(updated.label).toBe('Updated Label');
+      expect(updated.category).toBe('updated-category');
+      expect(updated.updatedBy).toBe(updateActor);
+      expect(updated.createdBy).toBe(testActor); // Original creator preserved
+      
+      // DELETE
+      await deleteAttribute(attributeId);
+      
+      // Verify deleted
+      await expect(getAttribute(attributeId))
+        .rejects
+        .toThrow(ServiceError);
+    });
+  });
+
+  describe('Uniqueness Constraint', () => {
+    it('should enforce unique attribute_id (409 on duplicate)', async () => {
+      const attributeId = 'unique-test-attr';
+      
+      // Create first attribute
+      await createAttribute({
+        attribute_id: attributeId,
+        label: 'First Attribute',
+        data_type: 'string',
+      }, testActor);
+      
+      // Attempt to create duplicate
+      try {
+        await createAttribute({
+          attribute_id: attributeId,
+          label: 'Duplicate Attribute',
+          data_type: 'number',
+        }, testActor);
+        
+        // Should not reach here
+        expect.fail('Should have thrown ServiceError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        const serviceError = error as ServiceError;
+        expect(serviceError.statusCode).toBe(409);
+        expect(serviceError.code).toBe('ATTRIBUTE_EXISTS');
+        expect(serviceError.message).toContain(attributeId);
+      }
+    });
+  });
+
+  describe('Pagination', () => {
+    beforeEach(async () => {
+      // Create multiple attributes for pagination testing
+      const attributes = [];
+      for (let i = 1; i <= 15; i++) {
+        attributes.push({
+          attribute_id: `pagination-attr-${String(i).padStart(2, '0')}`,
+          label: `Pagination Attribute ${i}`,
+          data_type: 'string' as const,
+        });
+      }
+      
+      for (const attr of attributes) {
+        await createAttribute(attr, testActor);
+      }
+    });
+
+    it('should paginate through all results', async () => {
+      let allItems: any[] = [];
+      let pageToken: string | undefined;
+      let iterations = 0;
+      const maxIterations = 10; // Safety limit
+      
+      do {
+        const result = await listAttributes({ limit: 5, pageToken });
+        allItems = [...allItems, ...result.items];
+        pageToken = result.pageToken;
+        iterations++;
+      } while (pageToken && iterations < maxIterations);
+      
+      expect(allItems.length).toBe(15);
+      expect(iterations).toBe(3); // 15 items / 5 per page = 3 pages
+    });
+
+    it('should return correct hasMore flag', async () => {
+      const page1 = await listAttributes({ limit: 10 });
+      expect(page1.hasMore).toBe(true);
+      expect(page1.items.length).toBe(10);
+      
+      const page2 = await listAttributes({ limit: 10, pageToken: page1.pageToken });
+      expect(page2.hasMore).toBe(false);
+      expect(page2.items.length).toBe(5);
+    });
+  });
+
+  describe('Search Functionality', () => {
+    beforeEach(async () => {
+      const attributes = [
+        { attribute_id: 'color-primary', label: 'Primary Color', data_type: 'string' as const },
+        { attribute_id: 'color-secondary', label: 'Secondary Color', data_type: 'string' as const },
+        { attribute_id: 'size-standard', label: 'Standard Size', data_type: 'enum' as const },
+        { attribute_id: 'price-retail', label: 'Retail Price', data_type: 'currency' as const },
+        { attribute_id: 'price-wholesale', label: 'Wholesale Price', data_type: 'currency' as const },
+      ];
+      
+      for (const attr of attributes) {
+        await createAttribute(attr, testActor);
+      }
+    });
+
+    it('should filter by label (case-insensitive)', async () => {
+      const result = await listAttributes({ q: 'COLOR' });
+      
+      expect(result.items.length).toBe(2);
+      const ids = result.items.map(a => a.attribute_id);
+      expect(ids).toContain('color-primary');
+      expect(ids).toContain('color-secondary');
+    });
+
+    it('should filter by attribute_id', async () => {
+      const result = await listAttributes({ q: 'price' });
+      
+      expect(result.items.length).toBe(2);
+      const ids = result.items.map(a => a.attribute_id);
+      expect(ids).toContain('price-retail');
+      expect(ids).toContain('price-wholesale');
+    });
+
+    it('should return empty for no matches', async () => {
+      const result = await listAttributes({ q: 'nonexistent' });
+      
+      expect(result.items.length).toBe(0);
+    });
+  });
+
+  describe('Data Type Validation', () => {
+    it('should store and retrieve all valid data types', async () => {
+      const dataTypes = ['string', 'number', 'boolean', 'enum', 'currency', 'json'] as const;
+      
+      for (const dataType of dataTypes) {
+        const attributeId = `type-test-${dataType}`;
+        await createAttribute({
+          attribute_id: attributeId,
+          label: `Test ${dataType}`,
+          data_type: dataType,
+        }, testActor);
+        
+        const retrieved = await getAttribute(attributeId);
+        expect(retrieved.data_type).toBe(dataType);
+      }
+    });
+  });
+
+  describe('Metadata Fields', () => {
+    it('should preserve all optional fields', async () => {
+      const fullAttribute = {
+        attribute_id: 'full-attr-test',
+        label: 'Full Attribute',
+        data_type: 'enum' as const,
+        external_header: 'External Header Name',
+        category: 'classification',
+        allowed_values: ['value1', 'value2', 'value3'],
+        synonyms: ['alt1', 'alt2'],
+        required_for_completion: true,
+        required_for_export: false,
+        import_required: true,
+        ai_usage_notes: 'Use for color classification',
+        status: 'active' as const,
+      };
+      
+      const created = await createAttribute(fullAttribute, testActor);
+      const retrieved = await getAttribute(fullAttribute.attribute_id);
+      
+      expect(retrieved.external_header).toBe(fullAttribute.external_header);
+      expect(retrieved.category).toBe(fullAttribute.category);
+      expect(retrieved.allowed_values).toEqual(fullAttribute.allowed_values);
+      expect(retrieved.synonyms).toEqual(fullAttribute.synonyms);
+      expect(retrieved.required_for_completion).toBe(true);
+      expect(retrieved.required_for_export).toBe(false);
+      expect(retrieved.import_required).toBe(true);
+      expect(retrieved.ai_usage_notes).toBe(fullAttribute.ai_usage_notes);
+      expect(retrieved.status).toBe('active');
+    });
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -182,5 +182,14 @@ export type {
   RetailOpsImportResult,
 } from './import/retailOps';
 
+// ============================================================================
+// Settings Schema Validators (Lisa v0.2.0-rc)
+// Zod schemas for Attributes, SmartRules, and AITemplate
+// ============================================================================
+
+export { AttributeSchema, type AttributeType } from './schema/attribute';
+export { SmartRuleSchema, SmartRuleCondition, SmartRuleAction, type SmartRuleType } from './schema/smartRule';
+export { AITemplateSchema, type AITemplateType } from './schema/aiTemplate';
+
 // Version info
 export const SDK_VERSION = '0.6.0';


### PR DESCRIPTION
## Summary back to Lisa

**Prompt-Version: Lisa v0.2.0-rc**

> Note: This PR replaces closed PR #215 (base branch was deleted when #214 merged).

## Description

Implements server-side persistence for Attributes CRUD with Firestore:

- **Service layer:** `packages/api/src/services/attributesService.ts`
  - listAttributes, getAttribute, createAttribute, updateAttribute, deleteAttribute
  - Pagination, search, uniqueness enforcement (409 on duplicate)
  
- **Endpoint handlers:** `packages/api/src/endpoints/admin/settings.ts`
  - GET/POST/PUT/DELETE routes with admin auth guards
  - Zod validation with structured error responses
  
- **Firestore rules:** `firestore.rules`
  - Admin-only access to settings/attributes/keys/*
  
- **Tests:**
  - Unit tests: `packages/api/test/attributes.service.spec.ts`
  - Integration tests: `packages/api/test/integration/attributes.emu.spec.ts`

## Files Changed

- `packages/api/src/services/attributesService.ts` (new)
- `packages/api/src/endpoints/admin/settings.ts` (updated)
- `firestore.rules` (updated)
- `packages/api/test/attributes.service.spec.ts` (new)
- `packages/api/test/integration/attributes.emu.spec.ts` (new)

**Prompt-Version: Lisa v0.2.0-rc**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only settings management for attributes, smart rules, and AI templates with Firestore access rules.
  * Full CRUD for attributes with pagination, search, validation, and standardized error responses.
  * SDK now exposes schemas/types for attributes, smart rules, and AI templates.

* **Tests**
  * Comprehensive unit and integration tests covering attributes CRUD, validation, pagination, search, and uniqueness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->