### PR TITLE
feat(admin): SmartRules & AITemplate persistence skeleton (Lisa v0.2.0-rc2)

### DIFF
--- a/docs/admin-settings-smartrules.md
+++ b/docs/admin-settings-smartrules.md
@@ -1,0 +1,60 @@
+# Admin Settings: SmartRules & AITemplate Backend
+
+**Prompt-Version:** Lisa v0.2.0-rc2
+
+## Overview
+
+This document describes the backend implementation for SmartRules and AITemplate CRUD operations.
+
+## Firestore Paths
+
+| Entity | Collection Path |
+|--------|-----------------|
+| SmartRules | `settings/smartRules/keys/{ruleId}` |
+| AITemplates | `settings/aiTemplates/keys/{templateKey}` |
+
+## API Endpoints
+
+### SmartRules
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/admin/settings/smartrules` | List all smart rules |
+| GET | `/admin/settings/smartrules/:ruleId` | Get single rule |
+| POST | `/admin/settings/smartrules` | Create new rule |
+| PUT | `/admin/settings/smartrules/:ruleId` | Update rule |
+| DELETE | `/admin/settings/smartrules/:ruleId` | Delete rule |
+
+### AITemplates
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/admin/settings/aitemplates` | List all templates |
+| GET | `/admin/settings/aitemplates/:templateKey` | Get single template |
+| POST | `/admin/settings/aitemplates` | Create new template |
+| PUT | `/admin/settings/aitemplates/:templateKey` | Update template |
+| DELETE | `/admin/settings/aitemplates/:templateKey` | Delete template |
+
+## Schema Validation
+
+All entities are validated using Zod schemas from `@ropi-aoss/sdk`:
+- `SmartRuleSchema` — validates smart rule structure
+- `AITemplateSchema` — validates AI template structure
+
+## Implementation Status
+
+- [x] Service stubs created
+- [x] Endpoint handlers scaffolded
+- [x] Test stubs created
+- [ ] Full service implementation (TODO)
+- [ ] Firestore rules for smartRules and aiTemplates
+- [ ] Integration tests with emulator
+
+## Notion Build Progress Log
+
+See: [ROPI AOSS Build Progress Log](https://www.notion.so/ROPI-AOSS-Build-Progress-Log)
+
+## Related PRs
+
+- PR #218: Attributes persistence & API (Lisa v0.2.0)
+- PR #XXX: SmartRules & AITemplate persistence (this PR)

--- a/packages/api/src/endpoints/admin/settings.smartrules.ts
+++ b/packages/api/src/endpoints/admin/settings.smartrules.ts
@@ -1,0 +1,174 @@
+/**
+ * Admin Settings Endpoints — SmartRules & AITemplate
+ * Per AOSS Section 2.3 & 4.x
+ * 
+ * Express handlers for SmartRules and AITemplate CRUD operations.
+ * All routes require admin authentication via requireAdmin middleware.
+ * 
+ * Lisa v0.2.0-rc2
+ */
+
+import { Request, Response } from 'express';
+import * as smartRulesService from '../../services/smartRulesService';
+import * as aiTemplateService from '../../services/aiTemplateService';
+
+// ============================================================================
+// SmartRules Handlers
+// ============================================================================
+
+/**
+ * GET /admin/settings/smartrules
+ * List all smart rules with pagination
+ */
+export async function listSmartRulesHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { limit, pageToken, q, enabled } = req.query;
+    const result = await smartRulesService.listSmartRules({
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+      pageToken: pageToken as string,
+      q: q as string,
+      enabled: enabled === 'true' ? true : enabled === 'false' ? false : undefined,
+    });
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * GET /admin/settings/smartrules/:ruleId
+ * Get a single smart rule by ID
+ */
+export async function getSmartRuleHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { ruleId } = req.params;
+    const rule = await smartRulesService.getSmartRule(ruleId);
+    res.json(rule);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * POST /admin/settings/smartrules
+ * Create a new smart rule
+ */
+export async function createSmartRuleHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const userId = (req as any).user?.uid || 'anonymous';
+    const rule = await smartRulesService.createSmartRule(req.body, userId);
+    res.status(201).json(rule);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * PUT /admin/settings/smartrules/:ruleId
+ * Update an existing smart rule
+ */
+export async function updateSmartRuleHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { ruleId } = req.params;
+    const userId = (req as any).user?.uid || 'anonymous';
+    const rule = await smartRulesService.updateSmartRule(ruleId, req.body, userId);
+    res.json(rule);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * DELETE /admin/settings/smartrules/:ruleId
+ * Delete a smart rule
+ */
+export async function deleteSmartRuleHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { ruleId } = req.params;
+    await smartRulesService.deleteSmartRule(ruleId);
+    res.status(204).send();
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+// ============================================================================
+// AITemplate Handlers
+// ============================================================================
+
+/**
+ * GET /admin/settings/aitemplates
+ * List all AI templates with pagination
+ */
+export async function listAITemplatesHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { limit, pageToken, q, status, scope } = req.query;
+    const result = await aiTemplateService.listAITemplates({
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+      pageToken: pageToken as string,
+      q: q as string,
+      status: status as 'active' | 'draft' | 'disabled',
+      scope: scope as 'global' | 'store' | 'brand',
+    });
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * GET /admin/settings/aitemplates/:templateKey
+ * Get a single AI template by key
+ */
+export async function getAITemplateHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { templateKey } = req.params;
+    const template = await aiTemplateService.getAITemplate(templateKey);
+    res.json(template);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * POST /admin/settings/aitemplates
+ * Create a new AI template
+ */
+export async function createAITemplateHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const userId = (req as any).user?.uid || 'anonymous';
+    const template = await aiTemplateService.createAITemplate(req.body, userId);
+    res.status(201).json(template);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * PUT /admin/settings/aitemplates/:templateKey
+ * Update an existing AI template
+ */
+export async function updateAITemplateHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { templateKey } = req.params;
+    const userId = (req as any).user?.uid || 'anonymous';
+    const template = await aiTemplateService.updateAITemplate(templateKey, req.body, userId);
+    res.json(template);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}
+
+/**
+ * DELETE /admin/settings/aitemplates/:templateKey
+ * Delete an AI template
+ */
+export async function deleteAITemplateHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const { templateKey } = req.params;
+    await aiTemplateService.deleteAITemplate(templateKey);
+    res.status(204).send();
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  }
+}

--- a/packages/api/src/services/aiTemplateService.ts
+++ b/packages/api/src/services/aiTemplateService.ts
@@ -1,0 +1,114 @@
+/**
+ * AITemplate Service
+ * Per AOSS Section 4.x — AI Content Generation Templates
+ * 
+ * Implements CRUD operations for AI Templates in Firestore.
+ * Path: settings/aiTemplates/keys/{templateKey}
+ * 
+ * Lisa v0.2.0-rc2
+ */
+
+import * as admin from 'firebase-admin';
+import { AITemplateSchema, type AITemplateType } from '@ropi-aoss/sdk';
+
+// Firestore collection paths
+const AITEMPLATES_COLLECTION = 'settings/aiTemplates/keys';
+
+// Default pagination limit
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+/**
+ * Service error with HTTP status code
+ */
+export class ServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly code: string
+  ) {
+    super(message);
+    this.name = 'ServiceError';
+  }
+}
+
+/**
+ * Pagination result
+ */
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  pageToken?: string;
+  hasMore: boolean;
+}
+
+/**
+ * List AI templates query options
+ */
+export interface ListAITemplatesOptions {
+  limit?: number;
+  pageToken?: string;
+  q?: string;
+  status?: 'active' | 'draft' | 'disabled';
+  scope?: 'global' | 'store' | 'brand';
+}
+
+/**
+ * List all AI templates with pagination
+ */
+export async function listAITemplates(
+  options: ListAITemplatesOptions = {}
+): Promise<PaginatedResult<AITemplateType>> {
+  // TODO: Implement Firestore query with pagination
+  throw new Error('Not implemented');
+}
+
+/**
+ * Get a single AI template by key
+ */
+export async function getAITemplate(templateKey: string): Promise<AITemplateType> {
+  // TODO: Implement Firestore get
+  throw new Error('Not implemented');
+}
+
+/**
+ * Create a new AI template
+ */
+export async function createAITemplate(
+  data: Omit<AITemplateType, 'updatedAt'>,
+  userId: string
+): Promise<AITemplateType> {
+  // TODO: Validate with AITemplateSchema.safeParse, write to Firestore
+  throw new Error('Not implemented');
+}
+
+/**
+ * Update an existing AI template
+ */
+export async function updateAITemplate(
+  templateKey: string,
+  data: Partial<AITemplateType>,
+  userId: string
+): Promise<AITemplateType> {
+  // TODO: Merge update with existing doc
+  throw new Error('Not implemented');
+}
+
+/**
+ * Delete an AI template
+ */
+export async function deleteAITemplate(templateKey: string): Promise<void> {
+  // TODO: Delete from Firestore
+  throw new Error('Not implemented');
+}
+
+/**
+ * Validate AI template data against schema
+ */
+export function validateAITemplateData(data: unknown): { success: boolean; error?: string; data?: AITemplateType } {
+  const result = AITemplateSchema.safeParse(data);
+  if (!result.success) {
+    return { success: false, error: result.error.message };
+  }
+  return { success: true, data: result.data };
+}

--- a/packages/api/src/services/smartRulesService.ts
+++ b/packages/api/src/services/smartRulesService.ts
@@ -1,0 +1,113 @@
+/**
+ * SmartRules Service
+ * Per AOSS Section 2.3 — Domain Rules / Smart Rules
+ * 
+ * Implements CRUD operations for SmartRules in Firestore.
+ * Path: settings/smartRules/keys/{ruleId}
+ * 
+ * Lisa v0.2.0-rc2
+ */
+
+import * as admin from 'firebase-admin';
+import { SmartRuleSchema, type SmartRuleType } from '@ropi-aoss/sdk';
+
+// Firestore collection paths
+const SMARTRULES_COLLECTION = 'settings/smartRules/keys';
+
+// Default pagination limit
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+/**
+ * Service error with HTTP status code
+ */
+export class ServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly code: string
+  ) {
+    super(message);
+    this.name = 'ServiceError';
+  }
+}
+
+/**
+ * Pagination result
+ */
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  pageToken?: string;
+  hasMore: boolean;
+}
+
+/**
+ * List smart rules query options
+ */
+export interface ListSmartRulesOptions {
+  limit?: number;
+  pageToken?: string;
+  q?: string;
+  enabled?: boolean;
+}
+
+/**
+ * List all smart rules with pagination
+ */
+export async function listSmartRules(
+  options: ListSmartRulesOptions = {}
+): Promise<PaginatedResult<SmartRuleType>> {
+  // TODO: Implement Firestore query with pagination
+  throw new Error('Not implemented');
+}
+
+/**
+ * Get a single smart rule by ID
+ */
+export async function getSmartRule(ruleId: string): Promise<SmartRuleType> {
+  // TODO: Implement Firestore get
+  throw new Error('Not implemented');
+}
+
+/**
+ * Create a new smart rule
+ */
+export async function createSmartRule(
+  data: Omit<SmartRuleType, 'createdAt' | 'updatedAt'>,
+  userId: string
+): Promise<SmartRuleType> {
+  // TODO: Validate with SmartRuleSchema.safeParse, write to Firestore
+  throw new Error('Not implemented');
+}
+
+/**
+ * Update an existing smart rule
+ */
+export async function updateSmartRule(
+  ruleId: string,
+  data: Partial<SmartRuleType>,
+  userId: string
+): Promise<SmartRuleType> {
+  // TODO: Merge update with existing doc
+  throw new Error('Not implemented');
+}
+
+/**
+ * Delete a smart rule
+ */
+export async function deleteSmartRule(ruleId: string): Promise<void> {
+  // TODO: Delete from Firestore
+  throw new Error('Not implemented');
+}
+
+/**
+ * Validate smart rule data against schema
+ */
+export function validateSmartRuleData(data: unknown): { success: boolean; error?: string; data?: SmartRuleType } {
+  const result = SmartRuleSchema.safeParse(data);
+  if (!result.success) {
+    return { success: false, error: result.error.message };
+  }
+  return { success: true, data: result.data };
+}

--- a/packages/api/test/integration/smartRules.emu.spec.ts
+++ b/packages/api/test/integration/smartRules.emu.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * SmartRules Service Integration Tests (Firebase Emulator)
+ * Per AOSS Section 2.3 — Domain Rules / Smart Rules
+ * 
+ * These tests run against the Firebase Emulator Suite.
+ * 
+ * Lisa v0.2.0-rc2
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+
+describe('SmartRules Service Integration (Emulator)', () => {
+  beforeAll(async () => {
+    // TODO: Initialize Firebase Admin with emulator settings
+  });
+
+  afterAll(async () => {
+    // TODO: Cleanup Firestore data
+  });
+
+  beforeEach(async () => {
+    // TODO: Clear test collection before each test
+  });
+
+  describe('CRUD Operations', () => {
+    it.skip('should create and retrieve a smart rule', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should update an existing smart rule', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should delete a smart rule', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should list smart rules with pagination', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should filter smart rules by enabled status', async () => {
+      // TODO: Implement with emulator
+    });
+  });
+
+  describe('Error Handling', () => {
+    it.skip('should return 404 for non-existent rule', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should return 409 on duplicate ruleId', async () => {
+      // TODO: Implement with emulator
+    });
+
+    it.skip('should return 400 on invalid rule data', async () => {
+      // TODO: Implement with emulator
+    });
+  });
+});

--- a/packages/api/test/smartRule.service.spec.ts
+++ b/packages/api/test/smartRule.service.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * SmartRules Service Unit Tests
+ * Per AOSS Section 2.3 — Domain Rules / Smart Rules
+ * 
+ * Lisa v0.2.0-rc2
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as smartRulesService from '../src/services/smartRulesService';
+
+describe('SmartRules Service', () => {
+  describe('validateSmartRuleData', () => {
+    it('should validate a correct smart rule', () => {
+      const validRule = {
+        ruleId: 'test-rule-001',
+        name: 'Test Rule',
+        description: 'A test rule',
+        enabled: true,
+        priority: 100,
+        condition: {
+          field: 'brand',
+          matchType: 'equals',
+          value: 'Nike',
+        },
+        action: {
+          targetField: 'category',
+          valueTemplate: 'Athletic Footwear',
+        },
+      };
+      const result = smartRulesService.validateSmartRuleData(validRule);
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+    });
+
+    it('should reject missing required fields', () => {
+      const invalidRule = {
+        ruleId: 'test-rule-002',
+        // missing name, condition, action
+      };
+      const result = smartRulesService.validateSmartRuleData(invalidRule);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should reject invalid matchType', () => {
+      const invalidRule = {
+        ruleId: 'test-rule-003',
+        name: 'Invalid Rule',
+        condition: {
+          field: 'brand',
+          matchType: 'invalid_match_type',
+          value: 'Nike',
+        },
+        action: {
+          targetField: 'category',
+          valueTemplate: 'Athletic Footwear',
+        },
+      };
+      const result = smartRulesService.validateSmartRuleData(invalidRule);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('listSmartRules', () => {
+    it.skip('should list all smart rules', async () => {
+      // TODO: Implement after service is complete
+    });
+  });
+
+  describe('getSmartRule', () => {
+    it.skip('should retrieve an existing smart rule', async () => {
+      // TODO: Implement after service is complete
+    });
+  });
+
+  describe('createSmartRule', () => {
+    it.skip('should create a new smart rule', async () => {
+      // TODO: Implement after service is complete
+    });
+  });
+
+  describe('updateSmartRule', () => {
+    it.skip('should update an existing smart rule', async () => {
+      // TODO: Implement after service is complete
+    });
+  });
+
+  describe('deleteSmartRule', () => {
+    it.skip('should delete an existing smart rule', async () => {
+      // TODO: Implement after service is complete
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Scaffolds backend service stubs, endpoint handlers, and test stubs for SmartRules and AITemplate CRUD operations.

## Changes

### Services
- `packages/api/src/services/smartRulesService.ts` — CRUD stubs for SmartRules
- `packages/api/src/services/aiTemplateService.ts` — CRUD stubs for AITemplates

### Endpoints
- `packages/api/src/endpoints/admin/settings.smartrules.ts` — Express handlers with `requireAdmin` guard

### Tests
- `packages/api/test/smartRule.service.spec.ts` — Unit test stubs
- `packages/api/test/integration/smartRules.emu.spec.ts` — Emulator integration test stubs

### Docs
- `docs/admin-settings-smartrules.md` — Design notes and API reference

## Related

- PR #218: Attributes persistence & API (Lisa v0.2.0)
- Notion: [ROPI AOSS Build Progress Log](https://www.notion.so/ROPI-AOSS-Build-Progress-Log)

## Prompt-Version

Lisa v0.2.0-rc2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API endpoints for SmartRules management (list, create, read, update, delete)
  * Added admin API endpoints for AI Template management (list, create, read, update, delete)

* **Documentation**
  * Added comprehensive admin settings documentation for SmartRules and AI Template configuration

* **Tests**
  * Added test frameworks for SmartRules service validation and integration testing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->