### PR TITLE
ci: increase e2e timeout to 60min (temporary) — Lisa v0.2.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Temporary increase for E2E job while tests in PR #221 are stabilized. Will revert after stabilization. Prompt-Version: Lisa v0.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow timeout increased (from 15 to 60 minutes) for end-to-end test jobs, reducing chances of premature job termination and allowing longer test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->