### PR TITLE
chore(test): add data-testid for New Attribute & harden E2E (Lisa v0.2.0)

### DIFF
--- a/packages/web/e2e/admin-attribute-crud.spec.ts
+++ b/packages/web/e2e/admin-attribute-crud.spec.ts
@@ -17,16 +17,28 @@ test.describe('Admin Attribute Management', () => {
     
     // Navigate to attributes page
     await page.goto('/settings/attributes');
+    
+    // Wait for page to load
+    const pageHeading = page.getByRole('heading', { name: /attribute manager/i, level: 1 });
+    await pageHeading.waitFor({ state: 'visible', timeout: 60000 });
+    
+    // Wait for New Attribute button to be visible
+    const newBtn = page.getByTestId('new-attribute-button');
+    await newBtn.waitFor({ state: 'visible', timeout: 60000 });
   });
 
   test('should display attribute manager page', async ({ page }) => {
     await expect(page.locator('h1')).toContainText('Attribute Manager');
-    await expect(page.locator('button:has-text("New Attribute")')).toBeVisible();
+    await expect(page.getByTestId('new-attribute-button')).toBeVisible();
   });
 
   test('should create a new attribute', async ({ page }) => {
     // Click New Attribute button
-    await page.click('button:has-text("New Attribute")');
+    await page.getByTestId('new-attribute-button').click();
+    
+    // Wait for form to appear
+    const form = page.locator('.attribute-form');
+    await form.waitFor({ state: 'visible', timeout: 30000 });
     
     // Fill in form
     await page.fill('input[name="attribute_id"]', 'test-attr-001');
@@ -78,7 +90,11 @@ test.describe('Admin Attribute Management', () => {
 
   test('should validate required fields', async ({ page }) => {
     // Click New Attribute button
-    await page.click('button:has-text("New Attribute")');
+    await page.getByTestId('new-attribute-button').click();
+    
+    // Wait for form to appear
+    const form = page.locator('.attribute-form');
+    await form.waitFor({ state: 'visible', timeout: 30000 });
     
     // Try to save without filling required fields
     // await page.click('button:has-text("Create")');
@@ -121,7 +137,11 @@ test.describe('Admin Attribute Management', () => {
 
   test('should cancel attribute creation', async ({ page }) => {
     // Click New Attribute button
-    await page.click('button:has-text("New Attribute")');
+    await page.getByTestId('new-attribute-button').click();
+    
+    // Wait for form to appear
+    const form = page.locator('.attribute-form');
+    await form.waitFor({ state: 'visible', timeout: 30000 });
     
     // Fill in partial data
     await page.fill('input[name="attribute_id"]', 'cancelled-attr');
@@ -138,7 +158,15 @@ test.describe('Attribute Form Validation', () => {
   test.beforeEach(async ({ page }) => {
     // TODO: Admin login
     await page.goto('/settings/attributes');
-    await page.click('button:has-text("New Attribute")');
+    
+    // Wait for New Attribute button and click it
+    const newBtn = page.getByTestId('new-attribute-button');
+    await newBtn.waitFor({ state: 'visible', timeout: 60000 });
+    await newBtn.click();
+    
+    // Wait for form to appear
+    const form = page.locator('.attribute-form');
+    await form.waitFor({ state: 'visible', timeout: 30000 });
   });
 
   test('should validate attribute_id format', async ({ page }) => {

--- a/packages/web/src/pages/Settings/AttributeManager.tsx
+++ b/packages/web/src/pages/Settings/AttributeManager.tsx
@@ -109,7 +109,7 @@ export default function AttributeManager() {
     <div className="attribute-manager">
       <div className="header">
         <h1>Attribute Manager</h1>
-        <button className="primary" onClick={handleCreate}>
+        <button className="primary" data-testid="new-attribute-button" onClick={handleCreate}>
           + New Attribute
         </button>
       </div>


### PR DESCRIPTION
## Summary

This PR adds test hardening to the admin attribute CRUD E2E tests:

### Changes
- ✅ Added `data-testid="new-attribute-button"` to the New Attribute button in AttributeManager.tsx
- ✅ Updated all beforeEach hooks to use `getByTestId()` selectors instead of brittle text-based selectors
- ✅ Added explicit waits with 60s timeout for page heading and button visibility
- ✅ Added explicit waits with 30s timeout for form appearance

### Benefits
- More robust E2E tests that don't depend on button text content
- Explicit waits prevent race conditions and timing issues
- Data-testid approach aligns with testing best practices
- Reduces flakiness by waiting for specific elements before interaction

### Test Coverage
- Updates beforeEach hooks in both test suites
- Updates 5 tests that interact with the New Attribute button
- Maintains all existing test logic while improving selector reliability

### Note
This is a minimal, targeted PR that focuses on test hardening. It should be merged after the main feature is stabilized.