### PR TITLE
ci: increase e2e timeout to 60min (temporary) — Lisa v0.2.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Temporary increase while frontend E2E tests are stabilized. Will revert after stabilization. Prompt-Version: Lisa v0.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended end-to-end testing timeout to accommodate longer test execution periods, improving test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->