### PR TITLE
fix(ci): Use esbuild for API tasks in staging-verify

### DIFF
--- a/.github/workflows/staging-verify.yml
+++ b/.github/workflows/staging-verify.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build API & Web
         run: |
           pnpm --filter @ropi-aoss/api build
+          cd packages/api && npx tsc
           pnpm --filter @ropi-aoss/web build
 
       - name: Create service account JSON from secret

--- a/.github/workflows/staging-verify.yml
+++ b/.github/workflows/staging-verify.yml
@@ -1,0 +1,125 @@
+name: Staging Verify (Normalization / Import / Export / E2E)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: 'The branch/ref to test (PR branch)'
+        required: true
+        default: 'chore/normalize-attribute-registry-notion-2025-12-09'
+
+jobs:
+  staging-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROJECT }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      GCP_SA_KEY_BASE64: ${{ secrets.GCP_SA_KEY_BASE64 }}
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        run: npm i -g pnpm@8
+
+      - name: Install dependencies
+        run: pnpm install -w
+
+      - name: Build API & Web
+        run: |
+          pnpm --filter @ropi-aoss/api build
+          pnpm --filter @ropi-aoss/web build
+
+      - name: Create service account JSON from secret
+        if: env.GCP_SA_KEY_BASE64 != ''
+        run: |
+          mkdir -p /tmp/ropi_secrets
+          echo "$GCP_SA_KEY_BASE64" | base64 --decode > /tmp/ropi_secrets/gcp_sa.json
+          echo "Wrote GCP SA to /tmp/ropi_secrets/gcp_sa.json"
+        shell: bash
+
+      - name: Set GOOGLE_APPLICATION_CREDENTIALS
+        if: env.GCP_SA_KEY_BASE64 != ''
+        run: echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/ropi_secrets/gcp_sa.json" >> $GITHUB_ENV
+
+      - name: Run attribute normalization (idempotent)
+        run: |
+          pnpm --filter @ropi-aoss/api normalize:attributes > /tmp/normalize.log 2>&1 || { cat /tmp/normalize.log; exit 10; }
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/ropi_secrets/gcp_sa.json
+
+      - name: Upload normalize log
+        uses: actions/upload-artifact@v4
+        with:
+          name: normalize-log
+          path: /tmp/normalize.log
+
+      - name: Run import validation (if script exists)
+        run: |
+          if [ -f ./scripts/validate_import.sh ]; then
+            ./scripts/validate_import.sh ./BUILD_ROPI_AOSS_v1/02-schema/sample_import_required.csv > /tmp/import_validate.log 2>&1 || { cat /tmp/import_validate.log; exit 11; }
+          else
+            echo "NO_IMPORT_VALIDATOR" > /tmp/import_validate.log
+            echo "No import validator script found — manual check recommended" >> /tmp/import_validate.log
+          fi
+
+      - name: Upload import validation log
+        uses: actions/upload-artifact@v4
+        with:
+          name: import-validate-log
+          path: /tmp/import_validate.log
+
+      - name: Run export to RO staging (if script exists)
+        run: |
+          if [ -f ./scripts/run_export_staging.sh ]; then
+            ./scripts/run_export_staging.sh > /tmp/export.log 2>&1 || { cat /tmp/export.log; exit 12; }
+          else
+            echo "NO_EXPORT_SCRIPT" > /tmp/export.log
+            echo "No export script found — manual RO export recommended" >> /tmp/export.log
+          fi
+
+      - name: Upload export log
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-log
+          path: /tmp/export.log
+
+      - name: Install Firebase CLI
+        run: |
+          npm i -g firebase-tools
+
+      - name: Deploy to staging (functions + hosting)
+        run: |
+          echo "Deploying to Firebase project $FIREBASE_PROJECT"
+          firebase deploy --only functions,hosting --token "$FIREBASE_TOKEN" --project "$FIREBASE_PROJECT" > /tmp/firebase_deploy.log 2>&1 || { cat /tmp/firebase_deploy.log; exit 13; }
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROJECT }}
+
+      - name: Upload firebase deploy log
+        uses: actions/upload-artifact@v4
+        with:
+          name: firebase-deploy-log
+          path: /tmp/firebase_deploy.log
+
+      - name: Run Playwright E2E
+        run: |
+          pnpm --filter @ropi-aoss/web test:e2e --reporter=list > /tmp/e2e.log 2>&1 || { cat /tmp/e2e.log; exit 14; }
+
+      - name: Upload e2e log
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-log
+          path: /tmp/e2e.log
+
+      - name: Staging verify summary
+        run: |
+          echo "Workflow finished. Artifacts: normalize-log, import-validate-log, export-log, firebase-deploy-log, e2e-log"

--- a/.github/workflows/staging-verify.yml
+++ b/.github/workflows/staging-verify.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build API & Web
         run: |
           pnpm --filter @ropi-aoss/api build
-          cd packages/api && npx tsc
+          cd packages/api && node build-tasks.js
           pnpm --filter @ropi-aoss/web build
 
       - name: Create service account JSON from secret

--- a/packages/api/build-tasks.js
+++ b/packages/api/build-tasks.js
@@ -1,0 +1,48 @@
+/**
+ * Build script for API tasks
+ * Compiles TypeScript task files to JavaScript
+ */
+
+const esbuild = require('esbuild');
+const path = require('path');
+const fs = require('fs');
+
+const tasksDir = path.resolve(__dirname, 'src/tasks');
+const outDir = path.resolve(__dirname, 'dist/tasks');
+
+// Ensure output directory exists
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+// Get all .ts files in tasks directory
+const taskFiles = fs.readdirSync(tasksDir)
+  .filter(file => file.endsWith('.ts'))
+  .map(file => path.join(tasksDir, file));
+
+console.log(`Building ${taskFiles.length} task files...`);
+
+esbuild.build({
+  entryPoints: taskFiles,
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  outdir: outDir,
+  format: 'cjs',
+  sourcemap: true,
+  alias: {
+    '@ropi-aoss/sdk': path.resolve(__dirname, '../sdk/src/index.ts'),
+  },
+  external: [
+    'firebase-admin',
+    'firebase-functions',
+    '@google-cloud/firestore',
+    '@notionhq/client',
+  ],
+  logLevel: 'info',
+}).then(() => {
+  console.log('✅ Tasks built successfully');
+}).catch((err) => {
+  console.error('❌ Task build failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes TypeScript compilation issues in the staging-verify workflow.

**Issue:**
Using `tsc` to compile tasks failed due to cross-package imports and rootDir constraints.

**Solution:**
- Created `packages/api/build-tasks.js` using esbuild
- Bundles task files with SDK dependencies
- Uses same alias configuration as main esbuild.config.js
- Properly handles cross-package imports

**Tested:**
✅ Local build successful (all 3 tasks compiled)
✅ Replaces failed approach from PR #251

**Related:** 
- Failed run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20088134267
- PR #249 (attribute registry normalization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build process to include additional task compilation step during API package builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->