### PR TITLE
test: fix firebase-admin mock for admin-users tests (pr261)

### DIFF
--- a/packages/api/test/admin-users-enhanced.test.ts
+++ b/packages/api/test/admin-users-enhanced.test.ts
@@ -15,15 +15,38 @@ import { createUserHandler, updateUserHandler, deleteUserHandler } from '../src/
 import { normalizeRole } from '../src/constants/roles';
 
 // Mock Firebase Admin
-vi.mock('firebase-admin', () => ({
-  default: {
-    firestore: {
-      Timestamp: {
-        now: () => ({ seconds: 1234567890, nanoseconds: 0 }),
-      },
-    },
-  },
-}));
+vi.mock('firebase-admin', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  const authMock = () => ({
+    createUser: vi.fn().mockImplementation(async ({ email, password }) => {
+      return { uid: `uid-${Math.random().toString(36).slice(2,9)}`, email };
+    }),
+    updateUser: vi.fn().mockImplementation(async (uid, props) => {
+      return { uid, ...props };
+    }),
+    deleteUser: vi.fn().mockResolvedValue(undefined),
+    getUser: vi.fn().mockImplementation(async (uid) => ({
+      uid,
+      email: `${uid}@example.com`,
+      customClaims: {},
+    })),
+    setCustomUserClaims: vi.fn().mockResolvedValue(undefined),
+    generatePasswordResetLink: vi.fn().mockResolvedValue('https://reset.example/'),
+    verifyIdToken: vi.fn().mockImplementation(async (token) => {
+      if (token && token.startsWith('emulator-')) {
+        return { uid: 'emulator-admin', email: 'emulator@local', admin: true };
+      }
+      return { uid: 'test-uid', email: 'test@example.com', admin: true };
+    }),
+  });
+
+  return {
+    ...actual,
+    auth: authMock,
+    firestore: actual.firestore,
+  };
+});
 
 // Mock middleware
 vi.mock('../src/middleware/auth', () => ({


### PR DESCRIPTION
Updates test mock to export auth() with createUser/updateUser/deleteUser/getUser/setCustomUserClaims/verifyIdToken to fix emulator tests.

**Changes**:
- Replaced incomplete vi.mock('firebase-admin') with complete mock
- Added auth() function mock with all required methods
- Uses importOriginal to preserve actual firestore implementation

**Fixes**: Test infrastructure issue causing 13 test failures in admin-users-enhanced.test.ts

**Related**: Fixes failing tests in PR #261