### PR TITLE
[LP-1.0.2] Add data-field/name attributes to attribute and product inputs

### DIFF
--- a/packages/web/src/components/product/CoreInformationTab.tsx
+++ b/packages/web/src/components/product/CoreInformationTab.tsx
@@ -32,6 +32,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.sku}
               onChange={(e) => onUpdate('sku', e.target.value)}
+              data-field="product.sku"
+              name="product.sku"
             />
           </div>
           
@@ -44,6 +46,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.styleId}
               onChange={(e) => onUpdate('styleId', e.target.value)}
+              data-field="product.styleId"
+              name="product.styleId"
             />
           </div>
           
@@ -56,6 +60,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.name}
               onChange={(e) => onUpdate('name', e.target.value)}
+              data-field="product.name"
+              name="product.name"
             />
           </div>
         </div>
@@ -73,6 +79,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.brand}
               onChange={(e) => onUpdate('brand', e.target.value)}
+              data-field="product.brand"
+              name="product.brand"
             />
           </div>
           
@@ -85,6 +93,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.category}
               onChange={(e) => onUpdate('category', e.target.value)}
+              data-field="product.category"
+              name="product.category"
             />
           </div>
           
@@ -96,6 +106,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.department}
               onChange={(e) => onUpdate('department', e.target.value)}
+              data-field="product.department"
+              name="product.department"
             >
               <option value="">Select...</option>
               <option value="Men">Men</option>
@@ -112,6 +124,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.subcategory}
               onChange={(e) => onUpdate('subcategory', e.target.value)}
+              data-field="product.subcategory"
+              name="product.subcategory"
             />
           </div>
         </div>
@@ -127,6 +141,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.firstReceived}
               onChange={(e) => onUpdate('firstReceived', e.target.value)}
+              data-field="product.firstReceived"
+              name="product.firstReceived"
             />
           </div>
           
@@ -139,6 +155,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.launchDate}
               onChange={(e) => onUpdate('launchDate', e.target.value)}
+              data-field="product.launchDate"
+              name="product.launchDate"
             />
           </div>
           
@@ -148,6 +166,8 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
               className="form-input"
               value={product.launchStatus}
               onChange={(e) => onUpdate('launchStatus', e.target.value)}
+              data-field="product.launchStatus"
+              name="product.launchStatus"
             >
               <option value="scheduled">Scheduled</option>
               <option value="soft_launch">Soft Launch</option>
@@ -164,7 +184,7 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
           <label className="form-label">
             Active Websites <span className="required">*</span>
           </label>
-          <div className="checkbox-group">
+          <div className="checkbox-group" data-field="product.websites" data-testid="product-websites">
             {['shiekh.com', 'shiekhshoes.com', 'example.com'].map(website => (
               <label key={website} className="checkbox-label">
                 <input
@@ -176,6 +196,7 @@ function CoreInformationTab({ product, onUpdate }: CoreInformationTabProps) {
                       : product.websites.filter(w => w !== website);
                     onUpdate('websites', updated);
                   }}
+                  name={`product.websites.${website}`}
                 />
                 {website}
               </label>

--- a/packages/web/src/components/product/ProductAttributesTab.tsx
+++ b/packages/web/src/components/product/ProductAttributesTab.tsx
@@ -53,6 +53,8 @@ function AttributeInput({
 }) {
   const stringValue = typeof value === 'string' ? value : '';
   const arrayValue = Array.isArray(value) ? value : [];
+  // Canonical field key for scroll-to-field targeting (LP-1.0.2)
+  const fieldKey = `attributes.${attr.attribute_id}`;
 
   switch (attr.data_type) {
     case 'enum':
@@ -62,6 +64,8 @@ function AttributeInput({
           value={stringValue}
           onChange={(e) => onChange(e.target.value)}
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         >
           <option value="">— Select —</option>
           {(attr.allowed_values || []).map((opt) => (
@@ -88,6 +92,8 @@ function AttributeInput({
           }
           placeholder="Enter values separated by commas"
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         />
       );
 
@@ -99,6 +105,8 @@ function AttributeInput({
             checked={Boolean(value)}
             onChange={(e) => onChange(e.target.checked)}
             data-testid={`attr-input-${attr.attribute_id}`}
+            data-field={fieldKey}
+            name={fieldKey}
           />
           <span>{value ? 'Yes' : 'No'}</span>
         </label>
@@ -114,6 +122,8 @@ function AttributeInput({
           onChange={(e) => onChange(e.target.value ? Number(e.target.value) : '')}
           step={attr.data_type === 'currency' ? '0.01' : 'any'}
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         />
       );
 
@@ -125,6 +135,8 @@ function AttributeInput({
           value={stringValue}
           onChange={(e) => onChange(e.target.value)}
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         />
       );
 
@@ -142,6 +154,8 @@ function AttributeInput({
           }}
           rows={3}
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         />
       );
 
@@ -154,6 +168,8 @@ function AttributeInput({
           value={stringValue}
           onChange={(e) => onChange(e.target.value)}
           data-testid={`attr-input-${attr.attribute_id}`}
+          data-field={fieldKey}
+          name={fieldKey}
         />
       );
   }

--- a/packages/web/test/unit/AttributeInputDataField.spec.tsx
+++ b/packages/web/test/unit/AttributeInputDataField.spec.tsx
@@ -1,0 +1,226 @@
+/**
+ * AttributeInput data-field Attribute Tests
+ * 
+ * Tests that all attribute inputs have proper data-field and name attributes
+ * for scroll-to-field navigation (LP-1.0.2)
+ * 
+ * Lisa LP-1.0.2
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ProductAttributesTab from '../../src/components/product/ProductAttributesTab';
+import type { Attribute } from '../../src/hooks/useAttributes';
+
+const mockAttributes: Attribute[] = [
+  {
+    attribute_id: 'color',
+    label: 'Color',
+    data_type: 'enum',
+    status: 'active',
+    allowed_values: ['Red', 'Blue', 'Green'],
+  },
+  {
+    attribute_id: 'size',
+    label: 'Size',
+    data_type: 'string',
+    status: 'active',
+  },
+  {
+    attribute_id: 'is_featured',
+    label: 'Is Featured',
+    data_type: 'boolean',
+    status: 'active',
+  },
+  {
+    attribute_id: 'price',
+    label: 'Price',
+    data_type: 'currency',
+    status: 'active',
+  },
+  {
+    attribute_id: 'release_date',
+    label: 'Release Date',
+    data_type: 'date',
+    status: 'active',
+  },
+  {
+    attribute_id: 'tags',
+    label: 'Tags',
+    data_type: 'multiSelect',
+    status: 'active',
+  },
+  {
+    attribute_id: 'metadata',
+    label: 'Metadata',
+    data_type: 'json',
+    status: 'active',
+  },
+];
+
+// Mock useAttributeRegistry hook (used by ProductAttributesTab)
+vi.mock('../../src/hooks/useAttributeRegistry', () => ({
+  useAttributeRegistry: () => ({
+    attributes: mockAttributes,
+    activeAttributes: mockAttributes,
+    requiredAttributes: [],
+    loading: false,
+    error: null,
+    getAttributeById: (id: string) => mockAttributes.find(a => a.attribute_id === id),
+    getAttributesByCategory: () => [],
+    refresh: vi.fn(),
+  }),
+}));
+
+// Mock useGlobalLoading hook
+vi.mock('../../src/hooks/useGlobalLoading', () => ({
+  useGlobalLoading: () => ({
+    isLoading: false,
+    setLoading: vi.fn(),
+    addLoadingSource: vi.fn(),
+    removeLoadingSource: vi.fn(),
+    loadingSources: new Set(),
+    error: null,
+    setError: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+const mockProduct = {
+  id: 'test-product',
+  sku: 'TEST-SKU',
+  styleId: 'STYLE-001',
+  name: 'Test Product',
+  brand: 'Test Brand',
+  category: 'Shoes',
+  department: 'Men',
+  subcategory: 'Sneakers',
+  firstReceived: '2025-01-01',
+  launchDate: '2025-02-01',
+  launchStatus: 'scheduled',
+  websites: ['shiekh.com'],
+  attributes: {
+    color: 'Red',
+    size: 'Large',
+    is_featured: true,
+    price: 99.99,
+    release_date: '2025-03-01',
+    tags: ['new', 'sale'],
+    metadata: { key: 'value' },
+  },
+  skuConfidence: 1,
+  exportReady: true,
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-15T00:00:00Z',
+};
+
+describe('AttributeInput data-field attributes (LP-1.0.2)', () => {
+  const renderTab = () => {
+    return render(
+      <BrowserRouter>
+        <ProductAttributesTab product={mockProduct as any} onUpdate={vi.fn()} />
+      </BrowserRouter>
+    );
+  };
+
+  it('renders enum input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-color');
+    expect(input).toHaveAttribute('data-field', 'attributes.color');
+    expect(input).toHaveAttribute('name', 'attributes.color');
+  });
+
+  it('renders string input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-size');
+    expect(input).toHaveAttribute('data-field', 'attributes.size');
+    expect(input).toHaveAttribute('name', 'attributes.size');
+  });
+
+  it('renders boolean input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-is_featured');
+    expect(input).toHaveAttribute('data-field', 'attributes.is_featured');
+    expect(input).toHaveAttribute('name', 'attributes.is_featured');
+  });
+
+  it('renders currency input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-price');
+    expect(input).toHaveAttribute('data-field', 'attributes.price');
+    expect(input).toHaveAttribute('name', 'attributes.price');
+  });
+
+  it('renders date input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-release_date');
+    expect(input).toHaveAttribute('data-field', 'attributes.release_date');
+    expect(input).toHaveAttribute('name', 'attributes.release_date');
+  });
+
+  it('renders multiSelect input with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-tags');
+    expect(input).toHaveAttribute('data-field', 'attributes.tags');
+    expect(input).toHaveAttribute('name', 'attributes.tags');
+  });
+
+  it('renders json textarea with correct data-field attribute', () => {
+    renderTab();
+    
+    const input = screen.getByTestId('attr-input-metadata');
+    expect(input).toHaveAttribute('data-field', 'attributes.metadata');
+    expect(input).toHaveAttribute('name', 'attributes.metadata');
+  });
+
+  it('all inputs follow canonical key format: attributes.<attribute_id>', () => {
+    renderTab();
+    
+    // Get all inputs with data-field
+    const inputs = document.querySelectorAll('[data-field^="attributes."]');
+    
+    expect(inputs.length).toBeGreaterThan(0);
+    
+    inputs.forEach((input) => {
+      const dataField = input.getAttribute('data-field');
+      const name = input.getAttribute('name');
+      
+      // Verify format: attributes.<attribute_id>
+      expect(dataField).toMatch(/^attributes\.[a-z_]+$/);
+      
+      // Verify name matches data-field
+      expect(name).toBe(dataField);
+    });
+  });
+
+  it('inputs can be queried by data-field selector for scroll-to', () => {
+    renderTab();
+    
+    // Simulate how handleScrollToField finds elements
+    const colorInput = document.querySelector('[data-field="attributes.color"]');
+    expect(colorInput).toBeInTheDocument();
+    expect(colorInput).toBe(screen.getByTestId('attr-input-color'));
+    
+    const sizeInput = document.querySelector('[data-field="attributes.size"]');
+    expect(sizeInput).toBeInTheDocument();
+    expect(sizeInput).toBe(screen.getByTestId('attr-input-size'));
+  });
+
+  it('inputs can also be queried by name attribute as fallback', () => {
+    renderTab();
+    
+    // Simulate fallback query used by handleScrollToField
+    const colorInput = document.querySelector('[name="attributes.color"]');
+    expect(colorInput).toBeInTheDocument();
+    
+    const priceInput = document.querySelector('[name="attributes.price"]');
+    expect(priceInput).toBeInTheDocument();
+  });
+});

--- a/packages/web/test/unit/CoreInformationTabDataField.spec.tsx
+++ b/packages/web/test/unit/CoreInformationTabDataField.spec.tsx
@@ -1,0 +1,215 @@
+/**
+ * CoreInformationTab data-field Attribute Tests
+ * 
+ * Tests that all product-level inputs have proper data-field and name attributes
+ * for scroll-to-field navigation (LP-1.0.2)
+ * 
+ * Lisa LP-1.0.2
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import CoreInformationTab from '../../src/components/product/CoreInformationTab';
+
+const mockProduct = {
+  id: 'test-product',
+  sku: 'TEST-SKU',
+  styleId: 'STYLE-001',
+  name: 'Test Product',
+  brand: 'Test Brand',
+  category: 'Shoes',
+  department: 'Men',
+  subcategory: 'Sneakers',
+  firstReceived: '2025-01-01',
+  launchDate: '2025-02-01',
+  launchStatus: 'scheduled',
+  websites: ['shiekh.com'],
+  attributes: {},
+  skuConfidence: 1,
+  exportReady: true,
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-15T00:00:00Z',
+};
+
+describe('CoreInformationTab data-field attributes (LP-1.0.2)', () => {
+  const renderTab = () => {
+    return render(
+      <BrowserRouter>
+        <CoreInformationTab product={mockProduct as any} onUpdate={vi.fn()} />
+      </BrowserRouter>
+    );
+  };
+
+  describe('Identification section', () => {
+    it('SKU input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.sku"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.sku');
+      expect(input).toHaveValue('TEST-SKU');
+    });
+
+    it('Style ID input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.styleId"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.styleId');
+      expect(input).toHaveValue('STYLE-001');
+    });
+
+    it('Product Name input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.name"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.name');
+      expect(input).toHaveValue('Test Product');
+    });
+  });
+
+  describe('Classification section', () => {
+    it('Brand input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.brand"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.brand');
+      expect(input).toHaveValue('Test Brand');
+    });
+
+    it('Category input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.category"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.category');
+      expect(input).toHaveValue('Shoes');
+    });
+
+    it('Department select has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const select = document.querySelector('[data-field="product.department"]');
+      expect(select).toBeInTheDocument();
+      expect(select).toHaveAttribute('name', 'product.department');
+      expect(select).toHaveValue('Men');
+    });
+
+    it('Subcategory input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.subcategory"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.subcategory');
+      expect(input).toHaveValue('Sneakers');
+    });
+  });
+
+  describe('Lifecycle section', () => {
+    it('First Received date input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.firstReceived"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.firstReceived');
+      expect(input).toHaveValue('2025-01-01');
+    });
+
+    it('Launch Date input has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const input = document.querySelector('[data-field="product.launchDate"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'product.launchDate');
+      expect(input).toHaveValue('2025-02-01');
+    });
+
+    it('Launch Status select has correct data-field and name attributes', () => {
+      renderTab();
+      
+      const select = document.querySelector('[data-field="product.launchStatus"]');
+      expect(select).toBeInTheDocument();
+      expect(select).toHaveAttribute('name', 'product.launchStatus');
+      expect(select).toHaveValue('scheduled');
+    });
+  });
+
+  describe('Website Assignment section', () => {
+    it('Websites checkbox group has correct data-field attribute', () => {
+      renderTab();
+      
+      const group = document.querySelector('[data-field="product.websites"]');
+      expect(group).toBeInTheDocument();
+    });
+
+    it('Individual website checkboxes have name attributes', () => {
+      renderTab();
+      
+      const checkbox1 = document.querySelector('[name="product.websites.shiekh.com"]');
+      const checkbox2 = document.querySelector('[name="product.websites.shiekhshoes.com"]');
+      const checkbox3 = document.querySelector('[name="product.websites.example.com"]');
+      
+      expect(checkbox1).toBeInTheDocument();
+      expect(checkbox2).toBeInTheDocument();
+      expect(checkbox3).toBeInTheDocument();
+    });
+  });
+
+  describe('scroll-to-field compatibility', () => {
+    it('all product fields can be queried by data-field selector', () => {
+      renderTab();
+      
+      const productFields = [
+        'product.sku',
+        'product.styleId',
+        'product.name',
+        'product.brand',
+        'product.category',
+        'product.department',
+        'product.subcategory',
+        'product.firstReceived',
+        'product.launchDate',
+        'product.launchStatus',
+        'product.websites',
+      ];
+      
+      productFields.forEach((fieldKey) => {
+        const element = document.querySelector(`[data-field="${fieldKey}"]`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+
+    it('all inputs follow canonical key format: product.<field>', () => {
+      renderTab();
+      
+      const productInputs = document.querySelectorAll('[data-field^="product."]');
+      
+      expect(productInputs.length).toBe(11); // 10 fields + 1 websites group
+      
+      productInputs.forEach((input) => {
+        const dataField = input.getAttribute('data-field');
+        
+        // Verify format: product.<field>
+        expect(dataField).toMatch(/^product\.[a-zA-Z]+$/);
+      });
+    });
+
+    it('simulates handleScrollToField behavior', () => {
+      renderTab();
+      
+      // Simulate how handleScrollToField finds elements
+      // First try name, then data-field
+      const findField = (fieldKey: string): Element | null => {
+        return document.querySelector(`[name="${fieldKey}"]`) ||
+               document.querySelector(`[data-field="${fieldKey}"]`);
+      };
+      
+      expect(findField('product.sku')).toBeInTheDocument();
+      expect(findField('product.brand')).toBeInTheDocument();
+      expect(findField('product.launchDate')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

LP-1.0.2 implements data-field and name attributes on all attribute inputs and product-level inputs to enable reliable scroll-to-field navigation from the Observations panel.

## Changes

### ProductAttributesTab.tsx
- Added `data-field` and `name` attributes to all AttributeInput types:
  - `enum` (select dropdown)
  - `multiSelect` (text input)
  - `boolean` (checkbox)
  - `number` and `currency` (number inputs)
  - `date` (date input)
  - `json` (textarea)
  - `string` (text input, default)
- **Canonical format**: `attributes.<attribute_id>` (e.g., `attributes.color`, `attributes.size`)

### CoreInformationTab.tsx
- Added `data-field` and `name` attributes to all product-level inputs:
  - **Identification**: sku, styleId, name
  - **Classification**: brand, category, department, subcategory
  - **Lifecycle**: firstReceived, launchDate, launchStatus
  - **Website Assignment**: websites checkbox group
- **Canonical format**: `product.<field>` (e.g., `product.sku`, `product.brand`)

## Tests

Added 25 new unit tests:

### AttributeInputDataField.spec.tsx (10 tests)
- Verifies data-field attributes on all input types (enum, string, boolean, currency, date, multiSelect, json)
- Verifies canonical key format: `attributes.<attribute_id>`
- Verifies inputs can be queried by `[data-field]` selector
- Verifies name attribute matches data-field for fallback

### CoreInformationTabDataField.spec.tsx (15 tests)
- Verifies data-field attributes on all product sections
- Verifies canonical key format: `product.<field>`
- Verifies scroll-to-field compatibility via selector queries

## Scroll-to Integration

The ObservationsPanel `handleScrollToField` function already supports both selectors:
```javascript
const field = document.querySelector(`[name="${linkedField}"]`) ||
              document.querySelector(`[data-field="${linkedField}"]`);
```

With this PR, observation `linkedField` values like:
- `attributes.color` → scrolls to color input
- `product.sku` → scrolls to SKU input
- `product.brand` → scrolls to brand input

## Test Results

```
Test Files  4 passed (4)
     Tests  61 passed (61)
```

All 25 new LP-1.0.2 tests pass. All pre-existing unit tests pass.

## Related

- Depends on LP-1.0.1 (FieldPicker, normalizeFieldLink) - PR #281
- Part of LP-1.0.0 Observations Workflows implementation

---
Lisa LP-1.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests validating form field attributes across product information and product attribute tabs, covering all input types.

* **Chores**
  * Enhanced form inputs with additional attributes to improve accessibility and automation support. No functional changes to user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->