### PR TITLE
[PVS-1.1.3] Fix: Firestore .count() emulator fallback (emulator-compatible)

### DIFF
--- a/packages/api/src/services/attributesService.ts
+++ b/packages/api/src/services/attributesService.ts
@@ -162,8 +162,16 @@ export async function listAttributes(
   }
   
   // Get total count (for small collections; optimize for large ones)
-  const totalSnapshot = await db.collection(ATTRIBUTES_COLLECTION).count().get();
-  const total = totalSnapshot.data().count;
+  // Use try/catch to handle Firestore emulator which doesn't support aggregation count()
+  let total = 0;
+  try {
+    const totalSnapshot = await db.collection(ATTRIBUTES_COLLECTION).count().get();
+    total = totalSnapshot?.data()?.count ?? 0;
+  } catch (err) {
+    // Fallback for Firestore emulator which doesn't support aggregation count()
+    const allDocs = await db.collection(ATTRIBUTES_COLLECTION).get();
+    total = allDocs.size;
+  }
   
   return {
     items,


### PR DESCRIPTION
### LP-1.1.3 — Firestore count() emulator fallback

**Goal:** Ensure code runs correctly against the Firestore emulator by attempting to use aggregation `.count()` when available, but falling back to `get().size` in the emulator.

**Changes:**  
- Add try/catch fallback around `.count().get()` in `attributesService.ts` line 165

**File modified:**
- `packages/api/src/services/attributesService.ts`

**Testing:**  
- API unit tests: 132 passed (pre-existing failures unrelated to this change)
- Integration tests will validate via CI

**Acceptance:**  
- Integration tests that failed previously due to `.count()` should now pass on emulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved attribute count retrieval reliability with enhanced fallback mechanisms for increased compatibility across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->