### PR TITLE
[PVS-1.1.4] CI: Ensure pnpm available in GitHub Actions (corepack prepare)

### DIFF
--- a/.github/workflows/api-integration-emulator.yml
+++ b/.github/workflows/api-integration-emulator.yml
@@ -29,13 +29,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install pnpm
-        run: npm install -g pnpm@8
+      - name: Prepare pnpm via corepack
+        run: corepack prepare pnpm@8 --activate
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@latest
@@ -83,13 +86,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install pnpm
-        run: npm install -g pnpm@8
+      - name: Prepare pnpm via corepack
+        run: corepack prepare pnpm@8 --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,12 +12,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Install pnpm
-        run: npm install -g pnpm@8
+      - name: Prepare pnpm via corepack
+        run: corepack prepare pnpm@8 --activate
       - name: Install dependencies
         run: pnpm install
       

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,8 +21,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install pnpm
-        run: npm install -g pnpm@8
+      - name: Enable corepack and prepare pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@8 --activate
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,14 +45,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Enable corepack (for pnpm cache support)
+        run: corepack enable
+
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: Install pnpm
-        run: npm install -g pnpm@8
+      - name: Prepare pnpm via corepack
+        run: corepack prepare pnpm@8 --activate
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-verify.yml
+++ b/.github/workflows/staging-verify.yml
@@ -27,8 +27,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install pnpm
-        run: npm i -g pnpm@8
+      - name: Enable corepack and prepare pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@8 --activate
 
       - name: Install dependencies
         run: pnpm install -w


### PR DESCRIPTION
### LP-1.1.4 — Ensure pnpm is available in GitHub Actions workflow jobs

**Changes:**
- Add `corepack enable` and `corepack prepare pnpm@8 --activate` steps to workflows that run pnpm
- Replaced `npm install -g pnpm@8` with corepack approach for consistency
- Fixed `e2e-tests.yml` where `cache: 'pnpm'` in setup-node requires pnpm to be available beforehand

**Workflows modified:**
- `.github/workflows/e2e-tests.yml`
- `.github/workflows/api-integration-emulator.yml` (both jobs)
- `.github/workflows/deploy-preview.yml`
- `.github/workflows/deploy-staging.yml`
- `.github/workflows/staging-verify.yml`

**Expectation:**
- E2E job and other CI jobs that use pnpm should no longer fail due to pnpm missing
- The `cache: 'pnpm'` option will work correctly since corepack enables pnpm first


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows to use Corepack for package manager management, improving dependency installation reliability across automated testing and deployment pipelines.

---

*Note: These changes are internal infrastructure updates with no impact to end-users or product functionality.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->