### PR TITLE
[LP-1.1.5] Test: Fix API integration tests - emulator setup and vitest mock hoisting

### DIFF
--- a/firebase-test.json
+++ b/firebase-test.json
@@ -1,0 +1,14 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    }
+  },
+  "firestore": {
+    "rules": "firestore.test.rules"
+  }
+}

--- a/firestore.test.rules
+++ b/firestore.test.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Allow all operations in test environment
+    match /{document=**} {
+      allow read, write: if true;
+    }
+  }
+}

--- a/packages/api/src/services/productCommitService.ts
+++ b/packages/api/src/services/productCommitService.ts
@@ -206,6 +206,11 @@ export async function processImportBatch(
   batchId: string,
   userId: string
 ): Promise<BatchProcessResult> {
+  // Ensure Firebase is initialized before getting Firestore instance
+  if (!admin.apps.length) {
+    const projectId = process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID;
+    admin.initializeApp(projectId ? { projectId } : undefined);
+  }
   const db = admin.firestore();
   
   // Read batch document
@@ -299,6 +304,11 @@ export async function getBatchStatus(batchId: string): Promise<{
   blockedCount?: number;
   processedAt?: string;
 }> {
+  // Ensure Firebase is initialized before getting Firestore instance
+  if (!admin.apps.length) {
+    const projectId = process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID;
+    admin.initializeApp(projectId ? { projectId } : undefined);
+  }
   const db = admin.firestore();
   const batchRef = db.collection('import_batches').doc(batchId);
   const batchDoc = await batchRef.get();

--- a/packages/api/test/attributes.service.spec.ts
+++ b/packages/api/test/attributes.service.spec.ts
@@ -31,7 +31,7 @@ describe('Attributes Service', () => {
     // Initialize Firebase Admin if not already done
     if (!admin.apps.length) {
       admin.initializeApp({
-        projectId: 'demo-test-project',
+        projectId: process.env.GCLOUD_PROJECT || 'demo-ropi-test',
       });
     }
     

--- a/packages/api/test/integration/attributes.emu.spec.ts
+++ b/packages/api/test/integration/attributes.emu.spec.ts
@@ -33,7 +33,7 @@ describeIfEmulator('Attributes Emulator Integration Tests', () => {
     // Initialize Firebase Admin with emulator
     if (!admin.apps.length) {
       admin.initializeApp({
-        projectId: 'demo-integration-test',
+        projectId: process.env.GCLOUD_PROJECT || 'demo-ropi-test',
       });
     }
     

--- a/packages/api/test/integration/syncAttributeRegistry.emu.spec.ts
+++ b/packages/api/test/integration/syncAttributeRegistry.emu.spec.ts
@@ -25,7 +25,7 @@ describeIfEmulator('Sync Attribute Registry Integration Tests', () => {
     // Initialize Firebase Admin with emulator
     if (!admin.apps.length) {
       admin.initializeApp({
-        projectId: 'demo-integration-test',
+        projectId: process.env.GCLOUD_PROJECT || 'demo-ropi-test',
       });
     }
     

--- a/packages/api/test/productCommitService.test.ts
+++ b/packages/api/test/productCommitService.test.ts
@@ -19,17 +19,11 @@ describe('Product Commit Service', () => {
   beforeEach(async () => {
     // Initialize Firebase Admin if not already done
     if (!admin.apps.length) {
-      admin.initializeApp({
-        projectId: 'demo-test-project',
-      });
+      const projectId = process.env.GCLOUD_PROJECT || 'demo-ropi-test';
+      admin.initializeApp({ projectId });
     }
     
     db = admin.firestore();
-    
-    // Use emulator for tests
-    if (process.env.FIRESTORE_EMULATOR_HOST) {
-      console.log('Using Firestore emulator');
-    }
   });
 
   afterEach(async () => {

--- a/packages/api/vitest.setup.ts
+++ b/packages/api/vitest.setup.ts
@@ -6,8 +6,12 @@ const isEmulator =
   !!process.env.FIRESTORE_EMULATOR_HOST ||
   process.env.NODE_ENV === 'test_emulator';
 
-if (!isEmulator) {
-  vi.mock('firebase-admin', async (importOriginal) => {
+if (isEmulator) {
+  // Running integration tests against emulator: do not mock admin
+  console.log('Running in emulator mode: using real firebase-admin');
+} else {
+  // vi.doMock is NOT hoisted, so the condition is properly evaluated at runtime
+  vi.doMock('firebase-admin', async (importOriginal) => {
     const actual = await importOriginal();
 
     // Track initialized apps so tests that check admin.apps work
@@ -85,7 +89,4 @@ if (!isEmulator) {
       apps,
     };
   });
-} else {
-  // Running integration tests against emulator: do not mock admin
-  // Optional: console.log('Running in emulator mode: using real firebase-admin')
 }


### PR DESCRIPTION
## Summary

Fixes API integration tests that were failing due to vitest mock hoisting and Firebase Admin SDK initialization issues when running against the Firestore emulator.

## Problem

1. **vitest mock hoisting**: `vi.mock` calls are hoisted to the top of the module by vitest, ignoring runtime conditions. Even though `vitest.setup.ts` had a condition `if (!isEmulator) { vi.mock(...) }`, the mock was always registered.

2. **Firebase Admin initialization timing**: Service modules were calling `admin.firestore()` before the test's `beforeEach` could initialize Firebase Admin, resulting in "batch not found" errors even after writes.

3. **Inconsistent project IDs**: Tests used different project IDs (`demo-test-project`, `demo-integration-test`) while the emulator used `demo-ropi-test`.

## Solution

### 1. vitest.setup.ts - Use `vi.doMock` instead of `vi.mock`
```typescript
// Before: vi.mock is hoisted, ignoring the condition
if (!isEmulator) {
  vi.mock('firebase-admin', ...);  // Always runs!
}

// After: vi.doMock respects runtime conditions
if (isEmulator) {
  console.log('Running in emulator mode...');
} else {
  vi.doMock('firebase-admin', ...);  // Only runs when !isEmulator
}
```

### 2. productCommitService.ts - Defensive Admin initialization
Added `admin.apps.length` check before using Firestore to ensure Firebase is initialized when service is imported before test setup.

### 3. Test files - Standardized project ID
All emulator-based tests now use `process.env.GCLOUD_PROJECT || 'demo-ropi-test'`.

### 4. Added test-specific Firebase config
- `firebase-test.json`: Separate config for emulator testing
- `firestore.test.rules`: Permissive rules for local testing

## Testing

```bash
# Run productCommitService tests with emulator
GCLOUD_PROJECT=demo-ropi-test firebase emulators:exec \
  --config firebase-test.json --only firestore --project demo-ropi-test \
  "pnpm vitest run test/productCommitService.test.ts"

# Result: 6/6 tests pass
```

## Files Changed

- `packages/api/vitest.setup.ts` - Fixed mock hoisting issue
- `packages/api/src/services/productCommitService.ts` - Added defensive init
- `packages/api/test/productCommitService.test.ts` - Cleaned up debug code
- `packages/api/test/attributes.service.spec.ts` - Fixed project ID
- `packages/api/test/integration/attributes.emu.spec.ts` - Fixed project ID
- `packages/api/test/integration/syncAttributeRegistry.emu.spec.ts` - Fixed project ID
- `firebase-test.json` - New: emulator test config
- `firestore.test.rules` - New: permissive test rules

## Related

- Part of LP-1.1 test infrastructure fixes
- Enables `productCommitService.test.ts` to run against Firestore emulator
- Prerequisite for PR #285 (LP-1.1.1 Mobile Observations)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment configuration to use environment-based project settings instead of hardcoded values.
  * Improved Firebase emulator integration for testing environments.

* **Chores**
  * Added test environment configuration for Firebase emulator settings.
  * Added Firestore security rules for test environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->