### PR TITLE
LP-1.1.14: FieldPicker UX groups with visual distinction

### DIFF
--- a/packages/web/src/components/product/FieldPicker.css
+++ b/packages/web/src/components/product/FieldPicker.css
@@ -3,6 +3,9 @@
  * 
  * LP-1.0.1: Styles for the FieldPicker component.
  * Provides a clean, accessible typeahead dropdown UI.
+ * 
+ * LP-1.1.14: Enhanced visual distinction between product fields and attributes,
+ * with sub-grouping of attributes by category.
  */
 
 .field-picker {
@@ -89,13 +92,39 @@
   z-index: 1000;
 }
 
+/* LP-1.1.14: Enhanced group styling */
 .field-picker-group {
   list-style: none;
 }
 
+/* Product Fields group - blue accent */
+.field-picker-group--product {
+  border-left: 3px solid var(--product-field-color, #2563eb);
+}
+
+/* Attributes group - purple accent */
+.field-picker-group--attribute {
+  border-left: 3px solid var(--attribute-color, #7c3aed);
+}
+
+/* Parent attribute group (contains subcategories) */
+.field-picker-group--parent {
+  border-left: none;
+}
+
+/* Sub-group for attribute categories */
+.field-picker-group--sub {
+  border-left: 2px solid var(--attribute-color-light, #c4b5fd);
+  margin-left: 8px;
+  margin-bottom: 4px;
+}
+
 .field-picker-group-title {
-  padding: 8px 12px 4px;
-  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px 6px;
+  font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -104,10 +133,55 @@
   border-bottom: 1px solid var(--border-color, #eee);
 }
 
+/* Sub-group title - smaller and indented */
+.field-picker-group-title--sub {
+  padding: 6px 8px 4px;
+  font-size: 10px;
+  font-weight: 500;
+  background: var(--subgroup-bg, #fafafa);
+  border-bottom: 1px solid var(--border-color-light, #f0f0f0);
+}
+
+.field-picker-group-title-text {
+  flex: 1;
+}
+
+.field-picker-group-count {
+  background: var(--count-bg, #e5e7eb);
+  color: var(--text-muted, #6b7280);
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+}
+
+/* Type icons in group headers */
+.field-picker-type-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.field-picker-type-icon--product {
+  color: var(--product-field-color, #2563eb);
+}
+
+.field-picker-type-icon--attribute {
+  color: var(--attribute-color, #7c3aed);
+}
+
 .field-picker-group-list {
   padding: 0;
   margin: 0;
   list-style: none;
+}
+
+.field-picker-subcategories {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  background: var(--subcategories-bg, #fefefe);
 }
 
 .field-picker-option {
@@ -132,9 +206,46 @@
   font-weight: 600;
 }
 
+/* LP-1.1.14: Type-specific option styling */
+.field-picker-option--product:hover,
+.field-picker-option--product.highlighted {
+  background-color: var(--product-hover-bg, #eff6ff);
+}
+
+.field-picker-option--attribute:hover,
+.field-picker-option--attribute.highlighted {
+  background-color: var(--attribute-hover-bg, #f5f3ff);
+}
+
 .field-picker-option-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 14px;
   color: var(--text-color, #333);
+}
+
+/* LP-1.1.14: Type badge (P for Product, A for Attribute) */
+.field-picker-option-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.field-picker-option-badge--product {
+  background-color: var(--product-badge-bg, #dbeafe);
+  color: var(--product-field-color, #2563eb);
+}
+
+.field-picker-option-badge--attribute {
+  background-color: var(--attribute-badge-bg, #ede9fe);
+  color: var(--attribute-color, #7c3aed);
 }
 
 .field-picker-option-key {
@@ -184,4 +295,49 @@
 
 .field-picker-dropdown {
   animation: fadeIn 0.15s ease-out;
+}
+
+/* LP-1.1.11: Compact mode for inline display */
+.field-picker.compact .field-picker-input {
+  padding: 4px 48px 4px 8px;
+  font-size: 13px;
+}
+
+.field-picker.compact .field-picker-clear {
+  right: 24px;
+  padding: 2px 6px;
+  font-size: 14px;
+}
+
+.field-picker.compact .field-picker-arrow {
+  right: 6px;
+  font-size: 8px;
+}
+
+.field-picker.compact .field-picker-dropdown {
+  max-height: 240px;
+}
+
+.field-picker.compact .field-picker-option {
+  padding: 6px 10px;
+}
+
+.field-picker.compact .field-picker-option-label {
+  font-size: 13px;
+}
+
+.field-picker.compact .field-picker-group-title {
+  padding: 6px 10px 4px;
+  font-size: 10px;
+}
+
+.field-picker.compact .field-picker-group-title--sub {
+  padding: 4px 6px 3px;
+  font-size: 9px;
+}
+
+.field-picker.compact .field-picker-option-badge {
+  width: 16px;
+  height: 16px;
+  font-size: 9px;
 }

--- a/packages/web/src/components/product/FieldPicker.tsx
+++ b/packages/web/src/components/product/FieldPicker.tsx
@@ -7,6 +7,7 @@
  * Features:
  * - Typeahead search with fuzzy matching
  * - Groups options by type (Product fields, Attributes)
+ * - LP-1.1.14: Sub-groups attributes by category with visual distinction
  * - Supports manual entry with client-side normalization
  * - Keyboard navigation (arrow keys, enter, escape)
  * 
@@ -21,12 +22,43 @@ import { normalizeFieldLink } from '../../utils/normalizeFieldLink';
 import attributeRegistry from '@/../../sdk/config/attributeRegistry.json';
 import './FieldPicker.css';
 
+/**
+ * LP-1.1.14: Category display names for attribute sub-groups
+ */
+const CATEGORY_LABELS: Record<string, string> = {
+  sku_core: 'Core',
+  identifiers: 'Identifiers',
+  classification: 'Classification',
+  color: 'Color',
+  dimensions: 'Dimensions',
+  measurements: 'Measurements',
+  materials_construction: 'Materials',
+  material_design: 'Design',
+  material_performance: 'Performance',
+  identity_demographic: 'Demographics',
+  descriptions_sites: 'Descriptions',
+  seo: 'SEO',
+  lifecycle: 'Lifecycle',
+  compliance: 'Compliance',
+  product_flags: 'Flags',
+  launch_media: 'Launch Media',
+  launch_media_message: 'Launch Messages',
+  launch_media_pricing: 'Launch Pricing',
+  launch_media_shipping: 'Launch Shipping',
+  sport_league: 'Sports & Leagues',
+  rics_reference: 'Reference',
+  core_header_meta: 'Header Meta',
+  attributes: 'Other',
+};
+
 interface FieldPickerProps {
   value: FieldLink | null;
   onChange: (fieldLink: FieldLink | null) => void;
   disabled?: boolean;
   placeholder?: string;
   className?: string;
+  /** LP-1.1.11: Compact mode for inline display */
+  compact?: boolean;
 }
 
 interface AttributeFromRegistry {
@@ -46,6 +78,7 @@ export function FieldPicker({
   disabled = false,
   placeholder = 'Select or type a field...',
   className = '',
+  compact = false,
 }: FieldPickerProps) {
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
@@ -91,15 +124,42 @@ export function FieldPicker({
   }, [allOptions, inputValue]);
 
   // Group filtered options by type
+  // LP-1.1.14: Sub-group attributes by category for better UX
   const groupedOptions = useMemo(() => {
     const productFields = filteredOptions.filter((opt) => opt.type === 'product');
     const attributes = filteredOptions.filter((opt) => opt.type === 'attribute');
-    return { productFields, attributes };
+    
+    // Group attributes by category
+    const attributesByCategory = attributes.reduce((acc, attr) => {
+      const category = attr.category || 'attributes';
+      if (!acc[category]) {
+        acc[category] = [];
+      }
+      acc[category].push(attr);
+      return acc;
+    }, {} as Record<string, FieldPickerOption[]>);
+    
+    // Sort categories by label
+    const sortedCategories = Object.keys(attributesByCategory).sort((a, b) => {
+      const labelA = CATEGORY_LABELS[a] || a;
+      const labelB = CATEGORY_LABELS[b] || b;
+      return labelA.localeCompare(labelB);
+    });
+    
+    return { productFields, attributes, attributesByCategory, sortedCategories };
   }, [filteredOptions]);
 
   // Flat list for keyboard navigation
+  // LP-1.1.14: Updated to preserve order with sub-grouped attributes
   const flatOptions = useMemo(() => {
-    return [...groupedOptions.productFields, ...groupedOptions.attributes];
+    const result = [...groupedOptions.productFields];
+    
+    // Add attributes in category order
+    for (const category of groupedOptions.sortedCategories) {
+      result.push(...groupedOptions.attributesByCategory[category]);
+    }
+    
+    return result;
   }, [groupedOptions]);
 
   // Sync input value with external value
@@ -133,7 +193,7 @@ export function FieldPicker({
     if (highlightedIndex >= 0 && listRef.current) {
       const items = listRef.current.querySelectorAll('.field-picker-option');
       const item = items[highlightedIndex];
-      if (item) {
+      if (item && typeof item.scrollIntoView === 'function') {
         item.scrollIntoView({ block: 'nearest' });
       }
     }
@@ -234,13 +294,20 @@ export function FieldPicker({
   const renderOptionGroup = (
     title: string,
     options: FieldPickerOption[],
-    startIndex: number
+    startIndex: number,
+    groupType: 'product' | 'attribute' = 'product',
+    isSubGroup: boolean = false
   ) => {
     if (options.length === 0) return null;
 
     return (
-      <li key={title} className="field-picker-group">
-        <div className="field-picker-group-title">{title}</div>
+      <li key={title} className={`field-picker-group ${groupType === 'attribute' ? 'field-picker-group--attribute' : 'field-picker-group--product'} ${isSubGroup ? 'field-picker-group--sub' : ''}`}>
+        <div className={`field-picker-group-title ${isSubGroup ? 'field-picker-group-title--sub' : ''}`}>
+          {groupType === 'product' && <span className="field-picker-type-icon field-picker-type-icon--product">📋</span>}
+          {groupType === 'attribute' && !isSubGroup && <span className="field-picker-type-icon field-picker-type-icon--attribute">🏷️</span>}
+          <span className="field-picker-group-title-text">{title}</span>
+          <span className="field-picker-group-count">{options.length}</span>
+        </div>
         <ul className="field-picker-group-list">
           {options.map((option, idx) => {
             const globalIndex = startIndex + idx;
@@ -250,13 +317,18 @@ export function FieldPicker({
             return (
               <li
                 key={option.key}
-                className={`field-picker-option ${isHighlighted ? 'highlighted' : ''} ${isSelected ? 'selected' : ''}`}
+                className={`field-picker-option field-picker-option--${option.type} ${isHighlighted ? 'highlighted' : ''} ${isSelected ? 'selected' : ''}`}
                 onClick={() => handleOptionSelect(option)}
                 onMouseEnter={() => setHighlightedIndex(globalIndex)}
                 role="option"
                 aria-selected={isSelected}
               >
-                <span className="field-picker-option-label">{option.label}</span>
+                <span className="field-picker-option-label">
+                  <span className={`field-picker-option-badge field-picker-option-badge--${option.type}`}>
+                    {option.type === 'product' ? 'P' : 'A'}
+                  </span>
+                  {option.label}
+                </span>
                 <span className="field-picker-option-key">{option.key}</span>
               </li>
             );
@@ -266,10 +338,47 @@ export function FieldPicker({
     );
   };
 
+  /**
+   * LP-1.1.14: Render attribute sub-groups by category
+   */
+  const renderAttributeGroups = () => {
+    const { attributesByCategory, sortedCategories, productFields } = groupedOptions;
+    
+    if (sortedCategories.length === 0) return null;
+    
+    // Calculate starting index (after product fields)
+    let currentIndex = productFields.length;
+    
+    return (
+      <li className="field-picker-group field-picker-group--attribute field-picker-group--parent">
+        <div className="field-picker-group-title">
+          <span className="field-picker-type-icon field-picker-type-icon--attribute">🏷️</span>
+          <span className="field-picker-group-title-text">Attributes</span>
+          <span className="field-picker-group-count">{groupedOptions.attributes.length}</span>
+        </div>
+        <ul className="field-picker-subcategories">
+          {sortedCategories.map((category) => {
+            const categoryOptions = attributesByCategory[category];
+            const categoryLabel = CATEGORY_LABELS[category] || category.replace(/_/g, ' ');
+            const group = renderOptionGroup(
+              categoryLabel,
+              categoryOptions,
+              currentIndex,
+              'attribute',
+              true
+            );
+            currentIndex += categoryOptions.length;
+            return group;
+          })}
+        </ul>
+      </li>
+    );
+  };
+
   return (
     <div
       ref={containerRef}
-      className={`field-picker ${className} ${isOpen ? 'open' : ''} ${disabled ? 'disabled' : ''}`}
+      className={`field-picker ${className} ${isOpen ? 'open' : ''} ${disabled ? 'disabled' : ''} ${compact ? 'compact' : ''}`}
     >
       <div className="field-picker-input-wrapper">
         <input
@@ -315,13 +424,11 @@ export function FieldPicker({
               {renderOptionGroup(
                 'Product Fields',
                 groupedOptions.productFields,
-                0
+                0,
+                'product',
+                false
               )}
-              {renderOptionGroup(
-                'Attributes',
-                groupedOptions.attributes,
-                groupedOptions.productFields.length
-              )}
+              {renderAttributeGroups()}
             </>
           )}
         </ul>

--- a/packages/web/test/unit/FieldPickerGroups.spec.tsx
+++ b/packages/web/test/unit/FieldPickerGroups.spec.tsx
@@ -1,0 +1,251 @@
+/**
+ * FieldPicker UX Groups Tests
+ * 
+ * LP-1.1.14: Tests for visual and semantic grouping of product fields
+ * and attributes in the FieldPicker component.
+ * 
+ * Validates:
+ * - Product fields vs attributes are visually distinguished
+ * - Attributes are sub-grouped by category
+ * - Type badges are rendered correctly
+ * - Keyboard navigation works with sub-grouped options
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FieldPicker } from '../../src/components/product/FieldPicker';
+
+// Mock the attributeRegistry
+vi.mock('@/../../sdk/config/attributeRegistry.json', () => ({
+  default: {
+    attributes: [
+      { attribute_id: 'primary_color', label: 'Primary Color', category: 'color', status: 'active' },
+      { attribute_id: 'secondary_color', label: 'Secondary Color', category: 'color', status: 'active' },
+      { attribute_id: 'material', label: 'Material', category: 'materials_construction', status: 'active' },
+      { attribute_id: 'brand', label: 'Brand', category: 'sku_core', status: 'active' },
+      { attribute_id: 'inactive_attr', label: 'Inactive', category: 'color', status: 'inactive' },
+    ],
+  },
+}));
+
+describe('LP-1.1.14: FieldPicker UX Groups', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  describe('Group Visual Separation', () => {
+    it('should render Product Fields group with product icon', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      // Focus to open dropdown
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Check for Product Fields group title
+      expect(screen.getByText('Product Fields')).toBeInTheDocument();
+      // Check for product icon (📋)
+      const productIcon = screen.queryByText('📋');
+      expect(productIcon).toBeInTheDocument();
+    });
+
+    it('should render Attributes group with attribute icon', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Check for Attributes group title
+      expect(screen.getByText('Attributes')).toBeInTheDocument();
+      // Check for attribute icon (🏷️)
+      const attrIcon = screen.queryByText('🏷️');
+      expect(attrIcon).toBeInTheDocument();
+    });
+
+    it('should display option badges with type indicators', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Check for P badges (Product) and A badges (Attribute)
+      const pBadges = screen.getAllByText('P');
+      const aBadges = screen.getAllByText('A');
+      
+      expect(pBadges.length).toBeGreaterThan(0);
+      expect(aBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Attribute Category Sub-Groups', () => {
+    it('should group attributes by category', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Look for category sub-group titles
+      expect(screen.getByText('Color')).toBeInTheDocument();
+      expect(screen.getByText('Materials')).toBeInTheDocument();
+      expect(screen.getByText('Core')).toBeInTheDocument();
+    });
+
+    it('should only show active attributes', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Inactive attribute should not appear
+      expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
+    });
+
+    it('should display attribute count per category', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Color category has 2 active attributes
+      // Check for count badge
+      const countBadges = document.querySelectorAll('.field-picker-group-count');
+      expect(countBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Filtering with Groups', () => {
+    it('should filter and maintain group structure', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'color' } });
+      
+      // Should show color category attributes
+      expect(screen.getByText('Primary Color')).toBeInTheDocument();
+      expect(screen.getByText('Secondary Color')).toBeInTheDocument();
+      
+      // Other categories should be hidden when no matches
+      expect(screen.queryByText('Material')).not.toBeInTheDocument();
+    });
+
+    it('should show product fields when filtering by product field label', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'MPN' } });
+      
+      // Should show MPN product field
+      expect(screen.getByText('MPN')).toBeInTheDocument();
+      // Check for Product Fields group
+      expect(screen.getByText('Product Fields')).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard Navigation', () => {
+    it('should navigate through grouped options with arrow keys', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Navigate down
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      
+      // First option should be highlighted
+      const highlightedOption = document.querySelector('.field-picker-option.highlighted');
+      expect(highlightedOption).toBeInTheDocument();
+    });
+
+    it('should select option on Enter key', async () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      
+      // Navigate to first option
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      // Select it
+      fireEvent.keyDown(input, { key: 'Enter' });
+      
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('Compact Mode', () => {
+    it('should apply compact class when compact prop is true', () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+          compact
+        />
+      );
+      
+      const container = document.querySelector('.field-picker');
+      expect(container).toHaveClass('compact');
+    });
+
+    it('should not apply compact class by default', () => {
+      render(
+        <FieldPicker
+          value={null}
+          onChange={mockOnChange}
+        />
+      );
+      
+      const container = document.querySelector('.field-picker');
+      expect(container).not.toHaveClass('compact');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
LP-1.1.14: Makes FieldPicker visually and semantically separate product fields from attributes, with sub-grouping of attributes by category.

## Changes

### FieldPicker Component (`packages/web/src/components/product/FieldPicker.tsx`)
- Added visual icons: 📋 for product fields, 🏷️ for attributes
- Added type badges (P/A) on each option for quick identification
- Sub-group attributes by category (e.g., Color, Materials, Dimensions)
- Added item count badges per group/subgroup
- Added `CATEGORY_LABELS` mapping for human-readable category names
- Fixed `scrollIntoView` check for JSDOM test compatibility
- Added `compact` prop for inline display mode (LP-1.1.11)

### FieldPicker CSS (`packages/web/src/components/product/FieldPicker.css`)
- Color-coded groups: blue accent for product fields, purple for attributes
- Enhanced hover states per type (different colors)
- Type badge styling (square badges with P/A letters)
- Sub-group indentation and styling
- Group count badge styling
- Compact mode styles for smaller inline display

### New Tests (`packages/web/test/unit/FieldPickerGroups.spec.tsx`)
- 12 new tests covering:
  - Group visual separation (icons, badges)
  - Attribute category sub-grouping
  - Filter behavior with grouped structure
  - Keyboard navigation through sub-groups
  - Compact mode class application

## Testing
```bash
# Run new tests
cd packages/web && npx vitest run test/unit/FieldPickerGroups.spec.tsx

# Run existing FieldPicker tests (no regressions)
cd packages/web && npx vitest run test/FieldPicker.test.tsx
```

All 30 FieldPicker-related tests pass (18 existing + 12 new).

## Visual Preview
The FieldPicker dropdown now shows:
- **Product Fields** section with 📋 icon and blue accent
- **Attributes** section with 🏷️ icon and purple accent, sub-grouped by category (Color, Materials, etc.)
- Each option has a colored badge showing P (product) or A (attribute)
- Count badges show number of items in each group

## Related
- Part of LP-1.1 Observations Pipeline series
- Follows LP-1.1.11 (ObservationsPanel unification) where compact mode was spec'd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grouped organization of product fields and attributes with visual borders and color accents
  * Attribute sub-grouping by category with labels and count indicators
  * Type badges (P for Product, A for Attribute) for quick item differentiation
  * Compact mode for space-constrained inline layouts

* **Style**
  * Enhanced visual hierarchy with improved hover and selected states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->