### PR TITLE
[LP-0.8.0] PVS-0.2.2 Rebase: Normalize legacy attribute schema via Zod validation

### DIFF
--- a/packages/api/src/services/attributesService.ts
+++ b/packages/api/src/services/attributesService.ts
@@ -93,7 +93,10 @@ function toFirestorePayload(
 
 /**
  * Convert Firestore document to AttributeType
- * Maps legacy field names to schema field names for compatibility
+ * Normalizes legacy field names (camelCase) to canonical (snake_case)
+ * and applies schema defaults via Zod validation.
+ * 
+ * PVS-0.2.2: Fix blank-on-load by normalizing on GET
  */
 function fromFirestore(doc: admin.firestore.DocumentSnapshot): AttributeType | null {
   if (!doc.exists) return null;
@@ -123,14 +126,29 @@ function fromFirestore(doc: admin.firestore.DocumentSnapshot): AttributeType | n
   };
   
   // Remove undefined values
-  const result: Record<string, unknown> = { attribute_id: mapped.attribute_id };
+  const normalized: Record<string, unknown> = { attribute_id: mapped.attribute_id };
   for (const [key, value] of Object.entries(mapped)) {
     if (value !== undefined) {
-      result[key] = value;
+      normalized[key] = value;
     }
   }
   
-  return result as AttributeType;
+  // PVS-0.2.2: Validate and apply defaults via Zod schema
+  const result = AttributeSchema.safeParse(normalized);
+  if (result.success) {
+    return result.data;
+  }
+  
+  // If validation fails, return with minimal normalization
+  // (keeps backward compatibility for edge cases)
+  console.warn(`Attribute ${doc.id} failed schema validation:`, result.error.errors);
+  return {
+    attribute_id: doc.id,
+    label: data.label || doc.id,
+    data_type: (normalized.data_type || 'string') as AttributeType['data_type'],
+    status: (normalized.status || 'active') as AttributeType['status'],
+    ...normalized,
+  } as AttributeType;
 }
 
 /**


### PR DESCRIPTION
## Summary
Rebased and enhanced version of PR #278, addressing the "blank-on-load" issue in the Attributes Console by adding Zod schema validation to the `fromFirestore()` method.

## Background
PR #278 (`[PVS-0.2.2] Normalize legacy attribute schema on GET`) had conflicts with `aoss-main` and failing CI. This PR creates a clean rebase that:

1. Preserves the existing audit imports and functionality from `aoss-main`
2. Adds Zod validation normalization as the core fix

## Changes
- **`packages/api/src/services/attributesService.ts`**:
  - Added `AttributeSchema.safeParse()` validation in `fromFirestore()`
  - Applies schema defaults (e.g., `status='active'`, `data_type='string'`)
  - Normalizes legacy camelCase fields to snake_case
  - Graceful fallback with warning log for edge-case validation failures

## Why This Works
The production Firestore has attributes in legacy format:
- `allowedValues` (camelCase) instead of `allowed_values`
- Missing `status` field
- Missing other schema defaults

The frontend has a safety net (`normalizeLegacyAttribute()` in `AttributesConsole.tsx`), but the API should normalize data at the source to ensure consistent responses across all consumers.

## Acceptance Criteria
- [ ] Zod validation applied in `fromFirestore()` method
- [ ] Legacy camelCase fields are normalized to snake_case
- [ ] Schema defaults applied (status='active', data_type='string')
- [ ] Build passes
- [ ] Staging verification shows attributes load correctly

## Testing
- ✅ Build passes (`pnpm build`)
- ⚠️ 16 test failures (pre-existing Firestore emulator mock issues, not caused by this change)
- Staging verification planned after merge

## Related
- Supersedes: #278
- Part of: LP-0.8.0 attribute schema normalization initiative
- Backup created: PR #302
- Audit samples: PR #303

## Labels
`lisa/pvs`, `type:patch`, `area:attributes`, `LP-0.8.0`