### PR TITLE
LP-2.0.2: Sync — normalize data_type tokens & add definition_version

### DIFF
--- a/packages/api/esbuild.config.js
+++ b/packages/api/esbuild.config.js
@@ -8,12 +8,10 @@
 const esbuild = require('esbuild');
 const path = require('path');
 
-esbuild.build({
-  entryPoints: ['src/index.ts'],
+const commonOptions = {
   bundle: true,
   platform: 'node',
   target: 'node20',
-  outfile: 'dist/index.js',
   format: 'cjs',
   sourcemap: true,
   alias: {
@@ -51,4 +49,22 @@ esbuild.build({
   ],
   resolveExtensions: ['.ts', '.js'],
   logLevel: 'info',
+};
+
+// Build main index
+esbuild.build({
+  ...commonOptions,
+  entryPoints: ['src/index.ts'],
+  outfile: 'dist/index.js',
+}).catch(() => process.exit(1));
+
+// Build task files separately for CLI usage
+esbuild.build({
+  ...commonOptions,
+  entryPoints: [
+    'src/tasks/syncAttributeRegistry.ts',
+    'src/tasks/migrateProductsToAttributes.ts',
+    'src/tasks/normalizeProductAttributeValues.ts',
+  ],
+  outdir: 'dist/tasks',
 }).catch(() => process.exit(1));

--- a/packages/api/src/tasks/syncAttributeRegistry.ts
+++ b/packages/api/src/tasks/syncAttributeRegistry.ts
@@ -4,6 +4,8 @@
  * Idempotent migration/sync that populates settings/attributes/keys/{attributeId}
  * from the canonical attribute registry JSON (or from Notion if configured).
  * 
+ * LP-2.0.2: Added normalizeDataType() and definition_version/canonical fields
+ * 
  * Lisa v1.0.0
  * 
  * References:
@@ -12,6 +14,7 @@
  * 
  * Usage:
  *   CLI: pnpm api:sync:attributes
+ *   CLI (dry-run): pnpm api:sync:attributes --dry-run
  *   Cloud Function: Call syncAttributeRegistry endpoint (admin-only)
  */
 
@@ -25,7 +28,7 @@ interface AttributeDefinition {
   label: string;
   external_header?: string;
   category?: string;
-  data_type: 'string' | 'number' | 'boolean' | 'enum' | 'currency' | 'json' | 'multiSelect' | 'date';
+  data_type: string; // Original type from JSON (text, longText, select, etc.)
   allowed_values?: string[];
   synonyms?: string[];
   required_for_completion?: boolean;
@@ -36,19 +39,115 @@ interface AttributeDefinition {
   source?: 'notion' | 'derived' | 'json';
 }
 
+// LP-2.0.2: Canonical data_type tokens
+type CanonicalDataType = 'string' | 'number' | 'boolean' | 'enum' | 'multiSelect' | 'date' | 'currency' | 'json';
+
 interface SyncResult {
   created: number;
   updated: number;
   skipped: number;
   errors: string[];
   attributes: string[];
+  dryRunOutput?: DryRunEntry[];
+}
+
+// LP-2.0.2: Dry-run output entry
+interface DryRunEntry {
+  attributeId: string;
+  currentDataType: string | null;
+  normalizedDataType: CanonicalDataType;
+  newFields: {
+    definition_version: string;
+    canonical: boolean;
+  };
+  action: 'CREATE' | 'UPDATE';
 }
 
 // Path to the attribute registry JSON file
-const REGISTRY_JSON_PATH = path.resolve(__dirname, '../../../sdk/config/attributeRegistry.json');
+// Use process.cwd() to handle both source and dist execution
+const REGISTRY_JSON_PATH = process.env.REGISTRY_JSON_PATH || 
+  path.resolve(process.cwd(), 'packages/sdk/config/attributeRegistry.json');
 
 // Firestore collection path
 const ATTRIBUTES_COLLECTION = 'settings/attributes/keys';
+
+/**
+ * LP-2.0.2: Normalize data_type tokens to canonical form
+ * 
+ * Mapping:
+ * - 'text' => 'string'
+ * - 'longText' => 'string'
+ * - 'number' => 'number'
+ * - 'boolean' => 'boolean'
+ * - 'select' => 'enum'
+ * - 'multiSelect' => 'multiSelect'
+ * - 'date' => 'date'
+ * - 'money' => 'currency'
+ * - 'currency' => 'currency'
+ * - 'json' => 'json'
+ * 
+ * Default: 'string' for unknown types
+ */
+function normalizeDataType(dt: string | undefined): CanonicalDataType {
+  if (!dt) return 'string';
+  
+  const normalized = dt.toLowerCase().trim();
+  
+  switch (normalized) {
+    case 'text':
+    case 'longtext':
+    case 'string':
+      return 'string';
+    case 'number':
+    case 'integer':
+    case 'float':
+    case 'decimal':
+      return 'number';
+    case 'boolean':
+    case 'bool':
+      return 'boolean';
+    case 'select':
+    case 'enum':
+    case 'dropdown':
+      return 'enum';
+    case 'multiselect':
+    case 'multi_select':
+    case 'multi-select':
+    case 'tags':
+      return 'multiSelect';
+    case 'date':
+    case 'datetime':
+    case 'timestamp':
+      return 'date';
+    case 'money':
+    case 'currency':
+    case 'price':
+      return 'currency';
+    case 'json':
+    case 'object':
+    case 'array':
+      return 'json';
+    default:
+      console.warn(`⚠️ Unknown data_type "${dt}", defaulting to "string"`);
+      return 'string';
+  }
+}
+
+/**
+ * Get the registry version from the JSON file
+ */
+function getRegistryVersion(): string {
+  try {
+    if (!fs.existsSync(REGISTRY_JSON_PATH)) {
+      return '0.0.0';
+    }
+    const raw = fs.readFileSync(REGISTRY_JSON_PATH, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return parsed.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
 
 /**
  * Load attribute registry from the JSON file
@@ -167,14 +266,22 @@ async function deriveAttributesFromProducts(): Promise<AttributeDefinition[]> {
 
 /**
  * Main sync function - loads registry and upserts to Firestore
+ * 
+ * LP-2.0.2: Added data_type normalization, definition_version, and canonical fields
+ * 
+ * @param options.dryRun - If true, print intended changes without writing to Firestore
  */
-export async function runSyncAttributeRegistry(): Promise<SyncResult> {
+export async function runSyncAttributeRegistry(options?: { dryRun?: boolean }): Promise<SyncResult> {
+  const isDryRun = options?.dryRun ?? false;
+  const registryVersion = getRegistryVersion();
+  
   const result: SyncResult = {
     created: 0,
     updated: 0,
     skipped: 0,
     errors: [],
     attributes: [],
+    dryRunOutput: isDryRun ? [] : undefined,
   };
 
   // Initialize Firebase Admin if not already initialized
@@ -203,7 +310,16 @@ export async function runSyncAttributeRegistry(): Promise<SyncResult> {
     return result;
   }
 
-  console.log(`\n📋 Syncing ${registry.length} attributes to Firestore...\n`);
+  if (isDryRun) {
+    console.log(`\n🔍 DRY RUN: Would sync ${registry.length} attributes to Firestore`);
+    console.log(`   Registry version: ${registryVersion}\n`);
+    console.log('─'.repeat(100));
+    console.log(`${'Attribute ID'.padEnd(30)} | ${'Current Type'.padEnd(15)} | ${'Normalized'.padEnd(15)} | ${'Action'.padEnd(10)} | New Fields`);
+    console.log('─'.repeat(100));
+  } else {
+    console.log(`\n📋 Syncing ${registry.length} attributes to Firestore...`);
+    console.log(`   Registry version: ${registryVersion}\n`);
+  }
 
   // Process each attribute
   for (const attr of registry) {
@@ -212,30 +328,68 @@ export async function runSyncAttributeRegistry(): Promise<SyncResult> {
     
     try {
       const existingDoc = await docRef.get();
+      const existingData = existingDoc.exists ? existingDoc.data() : null;
       const now = new Date().toISOString();
       
-      if (existingDoc.exists) {
-        // Update existing attribute (merge to preserve any local customizations)
-        await docRef.set({
-          ...attr,
-          updatedBy: 'system',
-          updatedAt: now,
-        }, { merge: true });
+      // LP-2.0.2: Normalize data_type
+      const originalDataType = attr.data_type || (attr as any).dataType || (attr as any).dataTypeInJson;
+      const normalizedDataType = normalizeDataType(originalDataType);
+      const isJsonSource = attr.source === 'json';
+      
+      // Build the document to write (preserving allowed_values exactly)
+      const docToWrite = {
+        ...attr,
+        data_type: normalizedDataType, // LP-2.0.2: Normalized type
+        definition_version: registryVersion, // LP-2.0.2: Version tracking
+        canonical: isJsonSource, // LP-2.0.2: Mark JSON-sourced as canonical
+        updatedBy: 'system',
+        updatedAt: now,
+      };
+
+      // If creating new doc, add createdBy/createdAt
+      if (!existingDoc.exists) {
+        (docToWrite as any).createdBy = 'system';
+        (docToWrite as any).createdAt = now;
+      }
+      
+      const action: 'CREATE' | 'UPDATE' = existingDoc.exists ? 'UPDATE' : 'CREATE';
+      const currentDataType = existingData?.data_type || null;
+      
+      if (isDryRun) {
+        // Dry run: log the proposed change
+        const dryRunEntry: DryRunEntry = {
+          attributeId: attr.attribute_id,
+          currentDataType,
+          normalizedDataType,
+          newFields: {
+            definition_version: registryVersion,
+            canonical: isJsonSource,
+          },
+          action,
+        };
+        result.dryRunOutput!.push(dryRunEntry);
         
-        result.updated++;
-        console.log(`  ↻ Updated: ${attr.attribute_id}`);
+        const typeChange = currentDataType !== normalizedDataType 
+          ? `${currentDataType || 'N/A'} → ${normalizedDataType}` 
+          : normalizedDataType;
+        console.log(
+          `${attr.attribute_id.padEnd(30)} | ${(currentDataType || 'N/A').padEnd(15)} | ${normalizedDataType.padEnd(15)} | ${action.padEnd(10)} | v=${registryVersion}, canonical=${isJsonSource}`
+        );
+        
+        if (action === 'CREATE') result.created++;
+        else result.updated++;
       } else {
-        // Create new attribute
-        await docRef.set({
-          ...attr,
-          createdBy: 'system',
-          createdAt: now,
-          updatedBy: 'system',
-          updatedAt: now,
-        });
+        // Actual sync: write to Firestore with merge to preserve local customizations
+        // IMPORTANT: merge: true preserves allowed_values and other local changes
+        await docRef.set(docToWrite, { merge: true });
         
-        result.created++;
-        console.log(`  ✓ Created: ${attr.attribute_id}`);
+        if (action === 'CREATE') {
+          result.created++;
+          console.log(`  ✓ Created: ${attr.attribute_id} (${normalizedDataType})`);
+        } else {
+          result.updated++;
+          console.log(`  ↻ Updated: ${attr.attribute_id} (${originalDataType} → ${normalizedDataType})`);
+        }
       }
       
       result.attributes.push(attr.attribute_id);
@@ -248,10 +402,18 @@ export async function runSyncAttributeRegistry(): Promise<SyncResult> {
   }
 
   console.log('\n─────────────────────────────────────');
-  console.log(`📊 Sync Complete:`);
-  console.log(`   Created: ${result.created}`);
-  console.log(`   Updated: ${result.updated}`);
-  console.log(`   Errors:  ${result.errors.length}`);
+  if (isDryRun) {
+    console.log(`📊 DRY RUN Summary:`);
+    console.log(`   Would create: ${result.created}`);
+    console.log(`   Would update: ${result.updated}`);
+    console.log(`   Errors:       ${result.errors.length}`);
+    console.log(`\n   ⚠️  No changes were made to Firestore`);
+  } else {
+    console.log(`📊 Sync Complete:`);
+    console.log(`   Created: ${result.created}`);
+    console.log(`   Updated: ${result.updated}`);
+    console.log(`   Errors:  ${result.errors.length}`);
+  }
   console.log('─────────────────────────────────────\n');
 
   return result;
@@ -259,9 +421,20 @@ export async function runSyncAttributeRegistry(): Promise<SyncResult> {
 
 /**
  * CLI entry point
+ * 
+ * Usage:
+ *   pnpm api:sync:attributes              # Actual sync
+ *   pnpm api:sync:attributes --dry-run    # Preview changes without writing
  */
 if (require.main === module) {
-  runSyncAttributeRegistry()
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  
+  if (dryRun) {
+    console.log('🔍 Running in DRY RUN mode - no changes will be made\n');
+  }
+  
+  runSyncAttributeRegistry({ dryRun })
     .then((result) => {
       if (result.errors.length > 0) {
         console.error('Sync completed with errors');


### PR DESCRIPTION
## LP-2.0.2: Registry Sync Normalization

### Objective
Normalize `data_type` tokens in the registry sync process and add `definition_version` and `canonical` metadata to every `settings/attributes/keys/*` document in Firestore. This is non-destructive (no `allowed_values` changes).

### Changes
1. **Added `normalizeDataType()` function** that maps legacy types to canonical tokens:
   - `text`, `longText` → `string`
   - `number`, `integer`, `float`, `decimal` → `number`
   - `boolean`, `bool` → `boolean`
   - `select`, `enum`, `dropdown` → `enum`
   - `multiSelect`, `multi_select` → `multiSelect`
   - `date`, `datetime`, `timestamp` → `date`
   - `money`, `currency`, `price` → `currency`
   - `json`, `object`, `array` → `json`

2. **Added new fields to synced documents:**
   - `definition_version`: Registry JSON version (e.g., `1.0.1`)
   - `canonical: true` for JSON-sourced attributes

3. **Added `--dry-run` argument** to preview changes without writing

4. **Updated esbuild config** to output task files separately for CLI usage

### Notion References
- Attribute Registry: https://www.notion.so/2b845ee1ec5a81228b07ca97964cd033
- Attribute Validation Schema: https://www.notion.so/2b845ee1ec5a805fba0ef665dfb17396

---

## Staging Verification

### Dry-Run Output
```
✅ Loaded 67 attributes from attributeRegistry.json

🔍 DRY RUN: Would sync 67 attributes to Firestore
   Registry version: 1.0.1

   Would create: 5
   Would update: 62
   Errors:       0
```

### Actual Sync to Staging
```
📋 Syncing 67 attributes to Firestore...
   Registry version: 1.0.1

   Created: 5
   Updated: 62
   Errors:  0
```

### Sample Document Snapshots

#### sku (string type)
```json
{
  \"attribute_id\": \"sku\",
  \"data_type\": \"string\",
  \"definition_version\": \"1.0.1\",
  \"canonical\": true,
  \"category\": \"sku_core\"
}
```

#### mpn (string type)
```json
{
  \"attribute_id\": \"mpn\",
  \"data_type\": \"string\",
  \"definition_version\": \"1.0.1\",
  \"canonical\": true,
  \"category\": \"sku_core\"
}
```

#### category (enum type with allowed_values)
```json
{
  \"attribute_id\": \"category\",
  \"data_type\": \"enum\",
  \"definition_version\": \"1.0.1\",
  \"canonical\": true,
  \"category\": \"classification\",
  \"allowed_values\": [\"Footwear\", \"Apparel\", \"Accessories\", ...]
}
```

#### primary_color (enum type)
```json
{
  \"attribute_id\": \"primary_color\",
  \"data_type\": \"enum\",
  \"definition_version\": \"1.0.1\",
  \"canonical\": true,
  \"allowed_values\": [\"Beige\", \"Black\", \"Blue\", ...]
}
```

#### material (multiSelect type)
```json
{
  \"attribute_id\": \"material\",
  \"data_type\": \"multiSelect\",
  \"definition_version\": \"1.0.1\",
  \"canonical\": true,
  \"allowed_values\": [\"Canvas\", \"Cotton\", \"Leather\", ...]
}
```

### Validation ✅
- [x] `settings/attributes/keys/*` have `definition_version` equal to JSON version (`1.0.1`)
- [x] `data_type` is in canonical tokens (`string`, `number`, `boolean`, `enum`, `multiSelect`, `date`, `currency`, `json`)
- [x] No changes to `allowed_values` (preserved via merge)
- [x] No attribute definition or registry files modified

## Commits
- `5c77e2e` - LP-2.0.2: Sync — normalize data_type tokens & add definition_version

## Files Changed
- `packages/api/src/tasks/syncAttributeRegistry.ts` - Added normalization logic
- `packages/api/esbuild.config.js` - Output task files separately

## Labels
- LP-2.0.x
- staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run mode for attribute registry synchronization to preview changes before applying them
  * Implemented data type normalization for consistent attribute handling
  * Enhanced registry loading with multiple fallback mechanisms

* **Chores**
  * Optimized build configuration for improved consistency and maintainability
  * Added version tracking and improved registry management logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->