### PR TITLE
LP-2.1.0: SDK — MPN-first import normalizer

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,6 +31,7 @@
     "validation"
   ],
   "dependencies": {
+    "csv-parse": "^6.1.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/packages/sdk/scripts/dry-run-output-mixed.json
+++ b/packages/sdk/scripts/dry-run-output-mixed.json
@@ -1,0 +1,224 @@
+{
+  "summary": {
+    "totalRows": 7,
+    "validRows": 4,
+    "invalidRows": 3,
+    "mpnOnly": 1,
+    "skuOnly": 2,
+    "bothMpnAndSku": 3,
+    "neitherMpnNorSku": 1,
+    "missingMpnCount": 3
+  },
+  "rows": [
+    {
+      "lineNumber": 2,
+      "source": {
+        "MPN": "NK-AIR-MAX-270",
+        "SKU": "SKU-001",
+        "Product Name": "Nike Air Max 270 - Black",
+        "Brand": "Nike",
+        "Description": "Premium running sneaker",
+        "MSRP": "159.99",
+        "Quantity": "25"
+      },
+      "normalized": {
+        "mpn": "NK-AIR-MAX-270",
+        "sku": "SKU-001",
+        "title": "Nike Air Max 270 - Black",
+        "brand": "Nike",
+        "description": "Premium running sneaker",
+        "msrp": 159.99,
+        "currency": "USD",
+        "quantity": 25
+      },
+      "productId": "nk-air-max-270",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": true,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 3,
+      "source": {
+        "MPN": "",
+        "SKU": "SKU-002",
+        "Product Name": "Product Without MPN",
+        "Brand": "Generic",
+        "Description": "Missing MPN field",
+        "MSRP": "49.99",
+        "Quantity": "10"
+      },
+      "normalized": {
+        "sku": "SKU-002",
+        "title": "Product Without MPN",
+        "brand": "Generic",
+        "description": "Missing MPN field",
+        "msrp": 49.99,
+        "currency": "USD",
+        "quantity": 10
+      },
+      "productId": "sku-002",
+      "validation": {
+        "isValid": false,
+        "missingRequired": [
+          "mpn"
+        ],
+        "hasMpn": false,
+        "hasSku": true,
+        "productIdSource": "sku"
+      }
+    },
+    {
+      "lineNumber": 4,
+      "source": {
+        "MPN": "ADIDAS-UB-21",
+        "SKU": "",
+        "Product Name": "Adidas Ultraboost - No SKU",
+        "Brand": "Adidas",
+        "Description": "Product with MPN only",
+        "MSRP": "190.00",
+        "Quantity": "30"
+      },
+      "normalized": {
+        "mpn": "ADIDAS-UB-21",
+        "title": "Adidas Ultraboost - No SKU",
+        "brand": "Adidas",
+        "description": "Product with MPN only",
+        "msrp": 190,
+        "currency": "USD",
+        "quantity": 30
+      },
+      "productId": "adidas-ub-21",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 5,
+      "source": {
+        "MPN": "",
+        "SKU": "",
+        "Product Name": "No MPN or SKU Product",
+        "Brand": "Unknown",
+        "Description": "Both MPN and SKU missing",
+        "MSRP": "0.00",
+        "Quantity": "0"
+      },
+      "normalized": {
+        "title": "No MPN or SKU Product",
+        "brand": "Unknown",
+        "description": "Both MPN and SKU missing",
+        "msrp": 0,
+        "currency": "USD",
+        "quantity": 0
+      },
+      "validation": {
+        "isValid": false,
+        "missingRequired": [
+          "mpn"
+        ],
+        "hasMpn": false,
+        "hasSku": false,
+        "productIdSource": "none"
+      }
+    },
+    {
+      "lineNumber": 6,
+      "source": {
+        "MPN": "NK-JORDAN-1",
+        "SKU": "SKU-005",
+        "Product Name": "Jordan Retro 1 High",
+        "Brand": "Jordan",
+        "Description": "Classic basketball shoe",
+        "MSRP": "180.00",
+        "Quantity": "15"
+      },
+      "normalized": {
+        "mpn": "NK-JORDAN-1",
+        "sku": "SKU-005",
+        "title": "Jordan Retro 1 High",
+        "brand": "Jordan",
+        "description": "Classic basketball shoe",
+        "msrp": 180,
+        "currency": "USD",
+        "quantity": 15
+      },
+      "productId": "nk-jordan-1",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": true,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 7,
+      "source": {
+        "MPN": "",
+        "SKU": "SKU-006",
+        "Product Name": "Another Missing MPN",
+        "Brand": "Brand X",
+        "Description": "Product without MPN",
+        "MSRP": "75.00",
+        "Quantity": "5"
+      },
+      "normalized": {
+        "sku": "SKU-006",
+        "title": "Another Missing MPN",
+        "brand": "Brand X",
+        "description": "Product without MPN",
+        "msrp": 75,
+        "currency": "USD",
+        "quantity": 5
+      },
+      "productId": "sku-006",
+      "validation": {
+        "isValid": false,
+        "missingRequired": [
+          "mpn"
+        ],
+        "hasMpn": false,
+        "hasSku": true,
+        "productIdSource": "sku"
+      }
+    },
+    {
+      "lineNumber": 8,
+      "source": {
+        "MPN": "PUMA-RS-X",
+        "SKU": "SKU-007",
+        "Product Name": "Puma RS-X - Multi",
+        "Brand": "Puma",
+        "Description": "Bold chunky sneaker",
+        "MSRP": "120.00",
+        "Quantity": "20"
+      },
+      "normalized": {
+        "mpn": "PUMA-RS-X",
+        "sku": "SKU-007",
+        "title": "Puma RS-X - Multi",
+        "brand": "Puma",
+        "description": "Bold chunky sneaker",
+        "msrp": 120,
+        "currency": "USD",
+        "quantity": 20
+      },
+      "productId": "puma-rs-x",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": true,
+        "productIdSource": "mpn"
+      }
+    }
+  ]
+}

--- a/packages/sdk/scripts/dry-run-output-mpn-only.json
+++ b/packages/sdk/scripts/dry-run-output-mpn-only.json
@@ -1,0 +1,154 @@
+{
+  "summary": {
+    "totalRows": 5,
+    "validRows": 5,
+    "invalidRows": 0,
+    "mpnOnly": 5,
+    "skuOnly": 0,
+    "bothMpnAndSku": 0,
+    "neitherMpnNorSku": 0,
+    "missingMpnCount": 0
+  },
+  "rows": [
+    {
+      "lineNumber": 2,
+      "source": {
+        "MPN": "NK-AIR-MAX-270",
+        "Product Name": "Nike Air Max 270 - Black",
+        "Brand": "Nike",
+        "Description": "Premium running sneaker with Air Max cushioning",
+        "MSRP": "159.99",
+        "Quantity": "25"
+      },
+      "normalized": {
+        "mpn": "NK-AIR-MAX-270",
+        "title": "Nike Air Max 270 - Black",
+        "brand": "Nike",
+        "description": "Premium running sneaker with Air Max cushioning",
+        "msrp": 159.99,
+        "currency": "USD",
+        "quantity": 25
+      },
+      "productId": "nk-air-max-270",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 3,
+      "source": {
+        "MPN": "NK-JORDAN-1",
+        "Product Name": "Jordan Retro 1 High - White",
+        "Brand": "Jordan",
+        "Description": "Classic basketball shoe with iconic design",
+        "MSRP": "180.00",
+        "Quantity": "15"
+      },
+      "normalized": {
+        "mpn": "NK-JORDAN-1",
+        "title": "Jordan Retro 1 High - White",
+        "brand": "Jordan",
+        "description": "Classic basketball shoe with iconic design",
+        "msrp": 180,
+        "currency": "USD",
+        "quantity": 15
+      },
+      "productId": "nk-jordan-1",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 4,
+      "source": {
+        "MPN": "ADIDAS-UB-21",
+        "Product Name": "Adidas Ultraboost 21 - Grey",
+        "Brand": "Adidas",
+        "Description": "High-performance running shoe",
+        "MSRP": "190.00",
+        "Quantity": "30"
+      },
+      "normalized": {
+        "mpn": "ADIDAS-UB-21",
+        "title": "Adidas Ultraboost 21 - Grey",
+        "brand": "Adidas",
+        "description": "High-performance running shoe",
+        "msrp": 190,
+        "currency": "USD",
+        "quantity": 30
+      },
+      "productId": "adidas-ub-21",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 5,
+      "source": {
+        "MPN": "NB-574-CLASSIC",
+        "Product Name": "New Balance 574 Classic - Navy",
+        "Brand": "New Balance",
+        "Description": "Retro lifestyle sneaker",
+        "MSRP": "89.99",
+        "Quantity": "40"
+      },
+      "normalized": {
+        "mpn": "NB-574-CLASSIC",
+        "title": "New Balance 574 Classic - Navy",
+        "brand": "New Balance",
+        "description": "Retro lifestyle sneaker",
+        "msrp": 89.99,
+        "currency": "USD",
+        "quantity": 40
+      },
+      "productId": "nb-574-classic",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 6,
+      "source": {
+        "MPN": "PUMA-RS-X",
+        "Product Name": "Puma RS-X - Multi",
+        "Brand": "Puma",
+        "Description": "Bold chunky sneaker with retro vibe",
+        "MSRP": "120.00",
+        "Quantity": "20"
+      },
+      "normalized": {
+        "mpn": "PUMA-RS-X",
+        "title": "Puma RS-X - Multi",
+        "brand": "Puma",
+        "description": "Bold chunky sneaker with retro vibe",
+        "msrp": 120,
+        "currency": "USD",
+        "quantity": 20
+      },
+      "productId": "puma-rs-x",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": false,
+        "productIdSource": "mpn"
+      }
+    }
+  ]
+}

--- a/packages/sdk/scripts/import-dry-run.js
+++ b/packages/sdk/scripts/import-dry-run.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * LP-2.1.0: Import Dry-Run CLI
+ * 
+ * Validates CSV import files using MPN-first normalization rules
+ * without persisting to Firestore.
+ * 
+ * Usage:
+ *   node import-dry-run.js <csv-path> [--format json|csv] [--output <path>]
+ * 
+ * Examples:
+ *   node import-dry-run.js sample.csv --format json
+ *   node import-dry-run.js sample.csv --format csv --output normalized.csv
+ */
+
+import { createReadStream, writeFileSync } from 'fs';
+import { parse } from 'csv-parse';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+// Import SDK functions (transpiled)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// We need to dynamically import the transpiled SDK
+let normalizeImportRow, deriveProductId, validateRequiredFields, DEFAULT_COLUMN_MAPPINGS;
+
+async function loadSDK() {
+  try {
+    const sdk = await import('../dist/index.js');
+    normalizeImportRow = sdk.normalizeImportRow;
+    deriveProductId = sdk.deriveProductId;
+    validateRequiredFields = sdk.validateRequiredFields;
+    DEFAULT_COLUMN_MAPPINGS = sdk.DEFAULT_COLUMN_MAPPINGS;
+  } catch (err) {
+    console.error('Error loading SDK. Ensure the SDK is built (npm run build):', err.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Parse CSV file into rows
+ */
+async function parseCSV(csvPath) {
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    const parser = createReadStream(csvPath).pipe(
+      parse({
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      })
+    );
+
+    parser.on('data', (row) => rows.push(row));
+    parser.on('error', reject);
+    parser.on('end', () => resolve(rows));
+  });
+}
+
+/**
+ * Process a single row and return normalized result with validation
+ */
+function processRow(row, lineNumber) {
+  const normalized = normalizeImportRow(row, DEFAULT_COLUMN_MAPPINGS);
+  const missingFields = validateRequiredFields(normalized, DEFAULT_COLUMN_MAPPINGS);
+  const productId = deriveProductId({ mpn: normalized.mpn, sku: normalized.sku });
+
+  return {
+    lineNumber,
+    source: row,
+    normalized,
+    productId,
+    validation: {
+      isValid: missingFields.length === 0,
+      missingRequired: missingFields,
+      hasMpn: !!normalized.mpn,
+      hasSku: !!normalized.sku,
+      productIdSource: normalized.mpn ? 'mpn' : (normalized.sku ? 'sku' : 'none'),
+    },
+  };
+}
+
+/**
+ * Format results as JSON
+ */
+function formatJSON(results, summary) {
+  return JSON.stringify({
+    summary,
+    rows: results,
+  }, null, 2);
+}
+
+/**
+ * Format results as CSV
+ */
+function formatCSV(results) {
+  if (results.length === 0) return '';
+
+  // Get all normalized field keys from first result
+  const normalizedKeys = Object.keys(results[0].normalized);
+  const headers = [
+    'lineNumber',
+    'isValid',
+    'missingRequired',
+    'productId',
+    'productIdSource',
+    ...normalizedKeys,
+  ];
+
+  const csvRows = [headers.join(',')];
+
+  for (const result of results) {
+    const row = [
+      result.lineNumber,
+      result.validation.isValid,
+      result.validation.missingRequired.join(';'),
+      result.productId || '',
+      result.validation.productIdSource,
+      ...normalizedKeys.map(key => {
+        const val = result.normalized[key];
+        if (val === undefined || val === null) return '';
+        if (Array.isArray(val)) return `"${val.join(';')}"`;
+        if (typeof val === 'string' && (val.includes(',') || val.includes('"'))) {
+          return `"${val.replace(/"/g, '""')}"`;
+        }
+        return val;
+      }),
+    ];
+    csvRows.push(row.join(','));
+  }
+
+  return csvRows.join('\n');
+}
+
+/**
+ * Main entry point
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`
+LP-2.1.0: Import Dry-Run CLI
+
+Usage:
+  node import-dry-run.js <csv-path> [options]
+
+Options:
+  --format <json|csv>  Output format (default: json)
+  --output <path>      Write output to file instead of stdout
+  --help, -h           Show this help message
+
+Examples:
+  node import-dry-run.js sample.csv
+  node import-dry-run.js sample.csv --format csv --output normalized.csv
+`);
+    process.exit(0);
+  }
+
+  const csvPath = args[0];
+  const formatIdx = args.indexOf('--format');
+  const outputIdx = args.indexOf('--output');
+  
+  const format = formatIdx >= 0 ? args[formatIdx + 1] : 'json';
+  const outputPath = outputIdx >= 0 ? args[outputIdx + 1] : null;
+
+  if (!['json', 'csv'].includes(format)) {
+    console.error(`Invalid format: ${format}. Use 'json' or 'csv'.`);
+    process.exit(1);
+  }
+
+  // Load SDK
+  await loadSDK();
+
+  console.error(`\n📂 Processing: ${csvPath}`);
+  console.error(`📋 Format: ${format}`);
+  console.error(`📊 Using MPN-first normalization (LP-2.1.0)\n`);
+
+  // Parse CSV
+  let rows;
+  try {
+    rows = await parseCSV(csvPath);
+  } catch (err) {
+    console.error(`Error reading CSV: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.error(`📝 Found ${rows.length} rows\n`);
+
+  // Process each row
+  const results = [];
+  let validCount = 0;
+  let invalidCount = 0;
+  let mpnOnlyCount = 0;
+  let skuOnlyCount = 0;
+  let bothCount = 0;
+  let neitherCount = 0;
+
+  for (let i = 0; i < rows.length; i++) {
+    const lineNumber = i + 2; // +2: line 1 is header, array is 0-indexed
+    const result = processRow(rows[i], lineNumber);
+    results.push(result);
+
+    if (result.validation.isValid) {
+      validCount++;
+    } else {
+      invalidCount++;
+    }
+
+    const hasMpn = result.validation.hasMpn;
+    const hasSku = result.validation.hasSku;
+    if (hasMpn && hasSku) bothCount++;
+    else if (hasMpn) mpnOnlyCount++;
+    else if (hasSku) skuOnlyCount++;
+    else neitherCount++;
+  }
+
+  // Build summary
+  const summary = {
+    totalRows: rows.length,
+    validRows: validCount,
+    invalidRows: invalidCount,
+    mpnOnly: mpnOnlyCount,
+    skuOnly: skuOnlyCount,
+    bothMpnAndSku: bothCount,
+    neitherMpnNorSku: neitherCount,
+    missingMpnCount: invalidCount, // Since mpn is required
+  };
+
+  // Format output
+  let output;
+  if (format === 'json') {
+    output = formatJSON(results, summary);
+  } else {
+    output = formatCSV(results);
+  }
+
+  // Write output
+  if (outputPath) {
+    writeFileSync(outputPath, output);
+    console.error(`✅ Output written to: ${outputPath}`);
+  } else {
+    console.log(output);
+  }
+
+  // Print summary to stderr
+  console.error(`\n${'='.repeat(50)}`);
+  console.error(`📊 SUMMARY`);
+  console.error(`${'='.repeat(50)}`);
+  console.error(`Total rows:         ${summary.totalRows}`);
+  console.error(`Valid rows:         ${summary.validRows}`);
+  console.error(`Invalid rows:       ${summary.invalidRows}`);
+  console.error(`${'─'.repeat(50)}`);
+  console.error(`MPN only:           ${summary.mpnOnly}`);
+  console.error(`SKU only:           ${summary.skuOnly}`);
+  console.error(`Both MPN & SKU:     ${summary.bothMpnAndSku}`);
+  console.error(`Neither:            ${summary.neitherMpnNorSku}`);
+  console.error(`${'='.repeat(50)}`);
+
+  // Exit with error if there are invalid rows
+  if (invalidCount > 0) {
+    console.error(`\n⚠️  ${invalidCount} row(s) have validation errors (missing required fields)`);
+  } else {
+    console.error(`\n✅ All rows passed validation`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/packages/sdk/scripts/sample-mixed.csv
+++ b/packages/sdk/scripts/sample-mixed.csv
@@ -1,0 +1,8 @@
+MPN,SKU,Product Name,Brand,Description,MSRP,Quantity
+NK-AIR-MAX-270,SKU-001,"Nike Air Max 270 - Black",Nike,"Premium running sneaker",159.99,25
+,SKU-002,"Product Without MPN",Generic,"Missing MPN field",49.99,10
+ADIDAS-UB-21,,"Adidas Ultraboost - No SKU",Adidas,"Product with MPN only",190.00,30
+,,"No MPN or SKU Product",Unknown,"Both MPN and SKU missing",0.00,0
+NK-JORDAN-1,SKU-005,"Jordan Retro 1 High",Jordan,"Classic basketball shoe",180.00,15
+,SKU-006,"Another Missing MPN",Brand X,"Product without MPN",75.00,5
+PUMA-RS-X,SKU-007,"Puma RS-X - Multi",Puma,"Bold chunky sneaker",120.00,20

--- a/packages/sdk/scripts/sample-mpn-only.csv
+++ b/packages/sdk/scripts/sample-mpn-only.csv
@@ -1,0 +1,6 @@
+MPN,Product Name,Brand,Description,MSRP,Quantity
+NK-AIR-MAX-270,"Nike Air Max 270 - Black",Nike,"Premium running sneaker with Air Max cushioning",159.99,25
+NK-JORDAN-1,"Jordan Retro 1 High - White",Jordan,"Classic basketball shoe with iconic design",180.00,15
+ADIDAS-UB-21,"Adidas Ultraboost 21 - Grey",Adidas,"High-performance running shoe",190.00,30
+NB-574-CLASSIC,"New Balance 574 Classic - Navy",New Balance,"Retro lifestyle sneaker",89.99,40
+PUMA-RS-X,"Puma RS-X - Multi",Puma,"Bold chunky sneaker with retro vibe",120.00,20

--- a/packages/sdk/src/builders/importRowBuilder.ts
+++ b/packages/sdk/src/builders/importRowBuilder.ts
@@ -73,8 +73,8 @@ export function buildImportRow(
     validation.isValid = false;
   }
   
-  // Derive product ID from SKU
-  const productId = deriveProductId(normalized.sku);
+  // Derive product ID from MPN (preferred) or SKU (fallback) — LP-2.1.0
+  const productId = deriveProductId({ mpn: normalized.mpn, sku: normalized.sku });
   
   // Build metadata
   const meta: ImportRowMeta = {

--- a/packages/sdk/src/normalization/importNormalizer.ts
+++ b/packages/sdk/src/normalization/importNormalizer.ts
@@ -10,10 +10,16 @@ import type { ImportSourceColumns, ImportNormalizedFields, ColumnMapping } from 
 /**
  * Default column mappings for RetailOps CSV
  * Maps common RO column names to AOSS normalized fields
+ * 
+ * LP-2.1.0: MPN-first — MPN is required, SKU is optional
+ * MPN is the canonical product identifier per Product Schema / Attribute Registry
  */
 export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
-  // Core fields
-  { sourceColumn: 'SKU', targetField: 'sku', required: true, transform: 'trim' },
+  // Core fields — MPN is required (LP-2.1.0), SKU is optional
+  { sourceColumn: 'MPN', targetField: 'mpn', required: true, transform: 'trim' },
+  { sourceColumn: 'mpn', targetField: 'mpn', required: true, transform: 'trim' },
+  { sourceColumn: 'Manufacturer Part Number', targetField: 'mpn', required: true, transform: 'trim' },
+  { sourceColumn: 'SKU', targetField: 'sku', required: false, transform: 'trim' },
   { sourceColumn: 'Product Name', targetField: 'title', required: true, transform: 'trim' },
   { sourceColumn: 'Brand', targetField: 'brand', required: true, transform: 'trim' },
   { sourceColumn: 'Description', targetField: 'description', transform: 'trim' },
@@ -28,9 +34,6 @@ export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
   { sourceColumn: 'Color', targetField: 'color', transform: 'trim' },
   { sourceColumn: 'Size', targetField: 'size', transform: 'trim' },
   { sourceColumn: 'Material', targetField: 'material', transform: 'trim' },
-  { sourceColumn: 'MPN', targetField: 'mpn', transform: 'trim' },
-  { sourceColumn: 'mpn', targetField: 'mpn', transform: 'trim' },
-  { sourceColumn: 'Manufacturer Part Number', targetField: 'mpn', transform: 'trim' },
   
   // Pricing
   { sourceColumn: 'MSRP', targetField: 'msrp', transform: 'number' },
@@ -142,20 +145,22 @@ export function normalizeImportRow(
 }
 
 /**
- * Derive product ID from SKU
- * Per AOSS Section 3.1 — SKU is the unique key for products
+ * Derive product ID from MPN (preferred) or SKU (fallback)
+ * LP-2.1.0: MPN-first — prefer MPN for productId derivation
+ * Per Product Schema / Attribute Registry — MPN is canonical
  * 
- * @param sku - Product SKU
+ * @param options - Object containing mpn and/or sku
  * @returns Product ID for use in products/{productId}
  */
-export function deriveProductId(sku: string | undefined): string | undefined {
-  if (!sku) {
+export function deriveProductId({ mpn, sku }: { mpn?: string; sku?: string }): string | undefined {
+  const source = mpn || sku;
+  if (!source) {
     return undefined;
   }
   
-  // Convert SKU to lowercase and replace non-alphanumeric with hyphens
+  // Convert source to lowercase and replace non-alphanumeric with hyphens
   // e.g., "NK-AIR-MAX-270-BLK-10" -> "nk-air-max-270-blk-10"
-  return sku.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return String(source).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
 /**
@@ -175,22 +180,22 @@ export function isEmptyRow(sourceColumns: ImportSourceColumns): boolean {
  * 
  * @param normalized - Normalized fields
  * @param mappings - Column mappings (to check required fields)
- * @returns Array of missing required field names
+ * @returns Array of missing required field names (deduplicated)
  */
 export function validateRequiredFields(
   normalized: ImportNormalizedFields,
   mappings: ColumnMapping[] = DEFAULT_COLUMN_MAPPINGS
 ): string[] {
-  const missingFields: string[] = [];
+  const missingFields = new Set<string>();
   
   for (const mapping of mappings) {
     if (mapping.required) {
       const value = normalized[mapping.targetField];
       if (value === undefined || value === null || value === '') {
-        missingFields.push(mapping.targetField);
+        missingFields.add(mapping.targetField);
       }
     }
   }
   
-  return missingFields;
+  return Array.from(missingFields);
 }

--- a/packages/sdk/src/schema/importEngine.ts
+++ b/packages/sdk/src/schema/importEngine.ts
@@ -43,9 +43,11 @@ export interface ImportSourceColumns {
 /**
  * Normalized product fields mapped from source columns
  * Per AOSS Section 3.2 — Import Normalization Rules
+ * LP-2.1.0: MPN is the canonical product identifier
  */
 export interface ImportNormalizedFields {
-  // Core fields
+  // Core fields — MPN is primary identifier (LP-2.1.0)
+  mpn?: string;
   sku?: string;
   title?: string;
   brand?: string;

--- a/packages/sdk/src/validators/importValidator.ts
+++ b/packages/sdk/src/validators/importValidator.ts
@@ -2,6 +2,8 @@
  * Import Row Validator
  * Per AOSS Section 2.2 — Attribute Validation Schema
  * 
+ * LP-2.1.0: MPN-first — MPN is required, SKU is optional
+ * 
  * Validates normalized import rows and generates validation issues.
  */
 
@@ -27,20 +29,60 @@ function createIssue(
 }
 
 /**
- * Validate SKU format and uniqueness
+ * Validate MPN (Manufacturer Part Number) - REQUIRED per LP-2.1.0
  */
-function validateSKU(sku: string | undefined): ValidationIssue[] {
+function validateMPN(mpn: string | undefined): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   
-  if (!sku) {
+  if (!mpn) {
     issues.push(
       createIssue(
         'MISSING_REQUIRED_FIELD',
         'error',
-        'sku',
-        'SKU is required'
+        'mpn',
+        'MPN (Manufacturer Part Number) is required'
       )
     );
+    return issues;
+  }
+  
+  // Check MPN format (basic alphanumeric + hyphens/underscores)
+  if (!/^[A-Z0-9\-_]+$/i.test(mpn)) {
+    issues.push(
+      createIssue(
+        'INVALID_FORMAT',
+        'error',
+        'mpn',
+        'MPN must contain only alphanumeric characters, hyphens, and underscores',
+        mpn
+      )
+    );
+  }
+  
+  // Check MPN length
+  if (mpn.length < 2 || mpn.length > 50) {
+    issues.push(
+      createIssue(
+        'INVALID_VALUE',
+        'error',
+        'mpn',
+        'MPN must be between 2 and 50 characters',
+        mpn
+      )
+    );
+  }
+  
+  return issues;
+}
+
+/**
+ * Validate SKU format (OPTIONAL per LP-2.1.0)
+ */
+function validateSKU(sku: string | undefined): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  
+  // LP-2.1.0: SKU is optional, so no error if missing
+  if (!sku) {
     return issues;
   }
   
@@ -364,6 +406,8 @@ function validateMedia(normalized: ImportNormalizedFields): ValidationIssue[] {
 /**
  * Validate a normalized import row
  * 
+ * LP-2.1.0: MPN-first — MPN is required, SKU is optional
+ * 
  * @param normalized - Normalized fields to validate
  * @returns Validation results with errors and warnings
  */
@@ -373,8 +417,9 @@ export function validateImportRow(
   const errors: ValidationIssue[] = [];
   const warnings: ValidationIssue[] = [];
   
-  // Validate core required fields
-  const skuIssues = validateSKU(normalized.sku);
+  // Validate core required fields (LP-2.1.0: MPN is now required)
+  const mpnIssues = validateMPN(normalized.mpn);
+  const skuIssues = validateSKU(normalized.sku); // Optional but validated if present
   const titleIssues = validateTitle(normalized.title);
   const brandIssues = validateBrand(normalized.brand);
   
@@ -386,6 +431,7 @@ export function validateImportRow(
   
   // Separate errors and warnings from all issues
   const allIssues = [
+    ...mpnIssues,
     ...skuIssues,
     ...titleIssues,
     ...brandIssues,

--- a/packages/sdk/test/importNormalizer.test.ts
+++ b/packages/sdk/test/importNormalizer.test.ts
@@ -1,6 +1,8 @@
 /**
  * Import Normalizer Tests
  * Tests for CSV normalization and field mapping
+ * 
+ * LP-2.1.0: Added MPN-first tests
  */
 
 import { describe, it, expect } from 'vitest';
@@ -114,14 +116,29 @@ describe('Import Normalizer', () => {
 
   describe('deriveProductId', () => {
     it('should derive product ID from SKU', () => {
-      expect(deriveProductId('TEST-SKU-001')).toBe('test-sku-001');
-      expect(deriveProductId('NK_AIR_MAX')).toBe('nk-air-max');
-      expect(deriveProductId('Product 123')).toBe('product-123');
+      expect(deriveProductId({ sku: 'TEST-SKU-001' })).toBe('test-sku-001');
+      expect(deriveProductId({ sku: 'NK_AIR_MAX' })).toBe('nk-air-max');
+      expect(deriveProductId({ sku: 'Product 123' })).toBe('product-123');
     });
 
     it('should return undefined for empty SKU', () => {
-      expect(deriveProductId(undefined)).toBeUndefined();
-      expect(deriveProductId('')).toBeUndefined();
+      expect(deriveProductId({})).toBeUndefined();
+      expect(deriveProductId({ sku: '' })).toBeUndefined();
+    });
+
+    // LP-2.1.0: MPN-first tests
+    it('LP-2.1.0: should prefer MPN over SKU for product ID derivation', () => {
+      expect(deriveProductId({ mpn: 'MPN-123', sku: 'SKU-456' })).toBe('mpn-123');
+    });
+
+    it('LP-2.1.0: should derive product ID from MPN when no SKU', () => {
+      expect(deriveProductId({ mpn: 'NK-AIR-MAX-270' })).toBe('nk-air-max-270');
+      expect(deriveProductId({ mpn: 'PRODUCT_MPN_001' })).toBe('product-mpn-001');
+    });
+
+    it('LP-2.1.0: should fall back to SKU when MPN is empty', () => {
+      expect(deriveProductId({ mpn: '', sku: 'FALLBACK-SKU' })).toBe('fallback-sku');
+      expect(deriveProductId({ mpn: undefined, sku: 'SKU-ONLY' })).toBe('sku-only');
     });
   });
 
@@ -150,6 +167,7 @@ describe('Import Normalizer', () => {
   describe('validateRequiredFields', () => {
     it('should return empty array for valid row', () => {
       const normalized = {
+        mpn: 'MPN-001',
         sku: 'TEST-001',
         title: 'Product',
         brand: 'Brand',
@@ -161,7 +179,7 @@ describe('Import Normalizer', () => {
 
     it('should return missing required fields', () => {
       const normalized = {
-        sku: 'TEST-001',
+        mpn: 'MPN-001',
         // title missing
         // brand missing
       };
@@ -169,6 +187,63 @@ describe('Import Normalizer', () => {
       const missing = validateRequiredFields(normalized);
       expect(missing).toContain('title');
       expect(missing).toContain('brand');
+    });
+
+    // LP-2.1.0: MPN-first required field tests
+    it('LP-2.1.0: should require MPN for import', () => {
+      const normalized = {
+        sku: 'SKU-001',
+        title: 'Product',
+        brand: 'Brand',
+        // mpn missing
+      };
+
+      const missing = validateRequiredFields(normalized);
+      expect(missing).toContain('mpn');
+    });
+
+    it('LP-2.1.0: should not require SKU (optional)', () => {
+      const normalized = {
+        mpn: 'MPN-001',
+        title: 'Product',
+        brand: 'Brand',
+        // sku intentionally missing — should be OK
+      };
+
+      const missing = validateRequiredFields(normalized);
+      expect(missing).not.toContain('sku');
+      expect(missing).toEqual([]);
+    });
+
+    it('LP-2.1.0: row with MPN only (no SKU) normalizes correctly', () => {
+      const sourceColumns: ImportSourceColumns = {
+        'MPN': 'MPN-ONLY-001',
+        'Product Name': 'MPN Only Product',
+        'Brand': 'Test Brand',
+      };
+
+      const normalized = normalizeImportRow(sourceColumns);
+      const missing = validateRequiredFields(normalized);
+
+      expect(normalized.mpn).toBe('MPN-ONLY-001');
+      expect(normalized.sku).toBeUndefined();
+      expect(missing).toEqual([]);
+    });
+
+    it('LP-2.1.0: row without MPN yields missing required field', () => {
+      const sourceColumns: ImportSourceColumns = {
+        'SKU': 'SKU-ONLY-001',
+        'Product Name': 'SKU Only Product',
+        'Brand': 'Test Brand',
+        // MPN missing
+      };
+
+      const normalized = normalizeImportRow(sourceColumns);
+      const missing = validateRequiredFields(normalized);
+
+      expect(normalized.sku).toBe('SKU-ONLY-001');
+      expect(normalized.mpn).toBeUndefined();
+      expect(missing).toContain('mpn');
     });
   });
 });

--- a/packages/sdk/test/importRowBuilder.test.ts
+++ b/packages/sdk/test/importRowBuilder.test.ts
@@ -1,6 +1,8 @@
 /**
  * Import Row Builder Tests
  * Tests for building complete Import Engine Rows
+ * 
+ * LP-2.1.0: Updated for MPN-first normalization
  */
 
 import { describe, it, expect } from 'vitest';
@@ -11,6 +13,7 @@ describe('Import Row Builder', () => {
   describe('buildImportRow', () => {
     it('should build a valid import row', () => {
       const sourceColumns: ImportSourceColumns = {
+        'MPN': 'MPN-TEST-001',
         'SKU': 'TEST-SKU-001',
         'Product Name': 'Test Product',
         'Brand': 'Test Brand',
@@ -28,18 +31,42 @@ describe('Import Row Builder', () => {
       expect(row?.batchId).toBe('batch-123');
       expect(row?.source.columns).toEqual(sourceColumns);
       expect(row?.source.lineNumber).toBe(2);
+      expect(row?.normalized.mpn).toBe('MPN-TEST-001');
       expect(row?.normalized.sku).toBe('TEST-SKU-001');
       expect(row?.normalized.title).toBe('Test Product');
       expect(row?.normalized.brand).toBe('Test Brand');
-      expect(row?.meta.productId).toBe('test-sku-001');
+      // LP-2.1.0: productId should derive from MPN (preferred)
+      expect(row?.meta.productId).toBe('mpn-test-001');
       expect(row?.meta.importedBy).toBe('user-456');
       expect(row?.meta.status).toBe('pending');
       expect(row?.validation.isValid).toBe(true);
     });
 
+    // LP-2.1.0: Test MPN-only row (no SKU)
+    it('LP-2.1.0: should build valid row with MPN only (no SKU)', () => {
+      const sourceColumns: ImportSourceColumns = {
+        'MPN': 'MPN-ONLY-001',
+        'Product Name': 'MPN Only Product',
+        'Brand': 'Test Brand',
+      };
+
+      const row = buildImportRow(sourceColumns, {
+        batchId: 'batch-123',
+        lineNumber: 2,
+        userId: 'user-456',
+      });
+
+      expect(row).toBeDefined();
+      expect(row?.normalized.mpn).toBe('MPN-ONLY-001');
+      expect(row?.normalized.sku).toBeUndefined();
+      expect(row?.meta.productId).toBe('mpn-only-001');
+      expect(row?.validation.isValid).toBe(true);
+    });
+
     it('should mark row as failed if validation fails', () => {
       const sourceColumns: ImportSourceColumns = {
-        'SKU': '', // Missing required field
+        'MPN': '', // Missing required field (LP-2.1.0)
+        'SKU': 'TEST-SKU-001',
         'Product Name': 'Test Product',
         'Brand': 'Test Brand',
       };
@@ -55,10 +82,12 @@ describe('Import Row Builder', () => {
       expect(row?.validation.errors.length).toBeGreaterThan(0);
       expect(row?.meta.status).toBe('failed');
       expect(row?.meta.errorMessage).toBeDefined();
+      expect(row?.meta.errorMessage).toContain('mpn');
     });
 
     it('should skip empty rows', () => {
       const sourceColumns: ImportSourceColumns = {
+        'MPN': '',
         'SKU': '',
         'Product Name': null,
         'Brand': undefined,
@@ -76,6 +105,7 @@ describe('Import Row Builder', () => {
 
     it('should not skip empty rows if configured', () => {
       const sourceColumns: ImportSourceColumns = {
+        'MPN': '',
         'SKU': '',
         'Product Name': null,
         'Brand': undefined,
@@ -97,17 +127,20 @@ describe('Import Row Builder', () => {
     it('should build multiple rows', () => {
       const csvData = [
         {
+          'MPN': 'MPN-001',
           'SKU': 'SKU-001',
           'Product Name': 'Product 1',
           'Brand': 'Brand A',
         },
         {
+          'MPN': 'MPN-002',
           'SKU': 'SKU-002',
           'Product Name': 'Product 2',
           'Brand': 'Brand B',
         },
         {
-          'SKU': '', // Empty row - should be skipped
+          'MPN': '', // Empty row - should be skipped
+          'SKU': '',
           'Product Name': null,
           'Brand': undefined,
         },
@@ -116,8 +149,8 @@ describe('Import Row Builder', () => {
       const rows = buildImportRows(csvData, 'batch-123', 'user-456');
 
       expect(rows).toHaveLength(2); // Empty row skipped
-      expect(rows[0].normalized.sku).toBe('SKU-001');
-      expect(rows[1].normalized.sku).toBe('SKU-002');
+      expect(rows[0].normalized.mpn).toBe('MPN-001');
+      expect(rows[1].normalized.mpn).toBe('MPN-002');
       expect(rows[0].source.lineNumber).toBe(2); // Line 1 is header
       expect(rows[1].source.lineNumber).toBe(3);
     });

--- a/packages/sdk/test/importValidator.test.ts
+++ b/packages/sdk/test/importValidator.test.ts
@@ -1,6 +1,8 @@
 /**
  * Import Validator Tests
  * Tests for validation logic
+ * 
+ * LP-2.1.0: Updated for MPN-first — MPN is required, SKU is optional
  */
 
 import { describe, it, expect } from 'vitest';
@@ -11,6 +13,7 @@ describe('Import Validator', () => {
   describe('validateImportRow', () => {
     it('should pass validation for valid row', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'VALID-SKU-001',
         title: 'Valid Product Title',
         brand: 'Valid Brand',
@@ -24,8 +27,10 @@ describe('Import Validator', () => {
       expect(validation.errors).toHaveLength(0);
     });
 
-    it('should fail validation for missing SKU', () => {
+    // LP-2.1.0: MPN is now required
+    it('LP-2.1.0: should fail validation for missing MPN', () => {
       const normalized: ImportNormalizedFields = {
+        sku: 'SKU-001',
         title: 'Product',
         brand: 'Brand',
       };
@@ -33,13 +38,27 @@ describe('Import Validator', () => {
       const validation = validateImportRow(normalized);
 
       expect(validation.isValid).toBe(false);
-      expect(validation.errors).toHaveLength(1);
-      expect(validation.errors[0].code).toBe('MISSING_REQUIRED_FIELD');
-      expect(validation.errors[0].field).toBe('sku');
+      expect(validation.errors.some(e => e.field === 'mpn')).toBe(true);
+      expect(validation.errors.some(e => e.code === 'MISSING_REQUIRED_FIELD')).toBe(true);
+    });
+
+    // LP-2.1.0: SKU is now optional
+    it('LP-2.1.0: should pass validation without SKU (optional)', () => {
+      const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
+        title: 'Product Title Here',
+        brand: 'Brand',
+      };
+
+      const validation = validateImportRow(normalized);
+
+      expect(validation.isValid).toBe(true);
+      expect(validation.errors.some(e => e.field === 'sku')).toBe(false);
     });
 
     it('should fail validation for missing title', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         brand: 'Brand',
       };
@@ -50,8 +69,22 @@ describe('Import Validator', () => {
       expect(validation.errors.some(e => e.field === 'title')).toBe(true);
     });
 
-    it('should fail validation for invalid SKU format', () => {
+    it('LP-2.1.0: should fail validation for invalid MPN format', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'invalid mpn!',
+        title: 'Product',
+        brand: 'Brand',
+      };
+
+      const validation = validateImportRow(normalized);
+
+      expect(validation.isValid).toBe(false);
+      expect(validation.errors.some(e => e.field === 'mpn' && e.code === 'INVALID_FORMAT')).toBe(true);
+    });
+
+    it('should fail validation for invalid SKU format when provided', () => {
+      const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'invalid sku!',
         title: 'Product',
         brand: 'Brand',
@@ -60,11 +93,12 @@ describe('Import Validator', () => {
       const validation = validateImportRow(normalized);
 
       expect(validation.isValid).toBe(false);
-      expect(validation.errors.some(e => e.code === 'INVALID_FORMAT')).toBe(true);
+      expect(validation.errors.some(e => e.code === 'INVALID_FORMAT' && e.field === 'sku')).toBe(true);
     });
 
     it('should warn for short title', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         title: 'Prod',
         brand: 'Brand',
@@ -79,6 +113,7 @@ describe('Import Validator', () => {
 
     it('should fail validation for negative prices', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         title: 'Product',
         brand: 'Brand',
@@ -93,6 +128,7 @@ describe('Import Validator', () => {
 
     it('should warn if retail price > MSRP', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         title: 'Product',
         brand: 'Brand',
@@ -108,6 +144,7 @@ describe('Import Validator', () => {
 
     it('should fail validation for invalid date', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         title: 'Product',
         brand: 'Brand',
@@ -122,6 +159,7 @@ describe('Import Validator', () => {
 
     it('should fail validation for invalid URL', () => {
       const normalized: ImportNormalizedFields = {
+        mpn: 'MPN-001',
         sku: 'SKU-001',
         title: 'Product',
         brand: 'Brand',
@@ -153,8 +191,8 @@ describe('Import Validator', () => {
           {
             code: 'MISSING_REQUIRED_FIELD' as const,
             severity: 'error' as const,
-            field: 'sku',
-            message: 'SKU is required',
+            field: 'mpn',
+            message: 'MPN is required',
           },
         ],
         warnings: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.1.0
       zod:
         specifier: ^3.22.0
         version: 3.25.76
@@ -1781,6 +1784,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-parse@6.1.0:
+    resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -5127,6 +5133,8 @@ snapshots:
       css-tree: 3.1.0
 
   csstype@3.2.3: {}
+
+  csv-parse@6.1.0: {}
 
   data-uri-to-buffer@4.0.1: {}
 


### PR DESCRIPTION
## LP-2.1.0: SDK — MPN-first import normalizer (dry-run ready)

### Summary
Makes the SDK import normalization MPN-first: requires `mpn`, makes `sku` optional, and prefers MPN for `productId` derivation. Adds dry-run tooling and unit tests.

### Notion Reference
- **Product Schema / Attribute Registry**: MPN is canonical product identifier
- **Registry JSON**: YES — planned in LP-2.1.2

### Changes

#### Core Schema (`packages/sdk/src/schema/importEngine.ts`)
- Added `mpn` field to `ImportNormalizedFields` interface (LP-2.1.0 comment)

#### Column Mappings (`packages/sdk/src/normalization/importNormalizer.ts`)
- **MPN**: `required: true`, `transform: 'trim'` (supports `MPN`, `mpn`, `Manufacturer Part Number`)
- **SKU**: `required: false` (now optional)
- Updated `deriveProductId({ mpn, sku })` to prefer MPN for productId derivation
- Fixed `validateRequiredFields()` to deduplicate missing fields

#### Validator (`packages/sdk/src/validators/importValidator.ts`)
- Added `validateMPN()` function — MPN is required
- Updated `validateSKU()` — SKU is now optional (only validates format if present)
- `validateImportRow()` now validates MPN first

#### Row Builder (`packages/sdk/src/builders/importRowBuilder.ts`)
- Updated `deriveProductId()` call to use new `{ mpn, sku }` signature

### Dry-Run CLI
Added `packages/sdk/scripts/import-dry-run.js`:
- Accepts CSV path, uses current mappings to call `normalizeImportRow`
- Prints normalized rows and any missing required fields (mpn)
- Provides clear JSON or CSV output for ingest by the API
- Usage: `node import-dry-run.js <csv-path> [--format json|csv] [--output <path>]`

### Unit Tests Added
| Test | Description | Status |
|------|-------------|--------|
| Test A | Row with MPN (no SKU) normalizes and `deriveProductId` uses MPN | ✅ |
| Test B | Row without MPN yields missing required field in normalized output | ✅ |
| MPN-first tests | Additional LP-2.1.0 specific tests in all test files | ✅ |

### Dry-Run Outputs

#### Sample 1: MPN-only rows (`sample-mpn-only.csv`)
```
Total rows:         5
Valid rows:         5
Invalid rows:       0
MPN only:           5
SKU only:           0
Both MPN & SKU:     0
Neither:            0
✅ All rows passed validation
```

#### Sample 2: Mixed rows (`sample-mixed.csv`)
```
Total rows:         7
Valid rows:         4
Invalid rows:       3
MPN only:           1
SKU only:           2
Both MPN & SKU:     3
Neither:            1
⚠️  3 row(s) have validation errors (missing required fields)
```

### Validation & Acceptance
- [x] Unit tests pass (222 tests)
- [x] Dry-run shows `mpn` present and `productId` derives from MPN where present
- [x] No server/API changes — safe and test-only at SDK level

### Files Changed
- `packages/sdk/src/schema/importEngine.ts`
- `packages/sdk/src/normalization/importNormalizer.ts`
- `packages/sdk/src/validators/importValidator.ts`
- `packages/sdk/src/builders/importRowBuilder.ts`
- `packages/sdk/test/importNormalizer.test.ts`
- `packages/sdk/test/importValidator.test.ts`
- `packages/sdk/test/importRowBuilder.test.ts`
- `packages/sdk/scripts/import-dry-run.js` (new)
- `packages/sdk/scripts/sample-mpn-only.csv` (new)
- `packages/sdk/scripts/sample-mixed.csv` (new)
- `packages/sdk/scripts/dry-run-output-*.json` (new)

### Next Steps
- **LP-2.1.1**: API — Import Server-side Validation & Enforcement
- **LP-2.1.2**: Registry JSON Update (`mpn.import_required = true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MPN (Manufacturer Part Number) is now the primary product identifier for imports, with automatic fallback to SKU if MPN is unavailable.
  * Added dry-run validation capability to preview import results before processing CSV files.

* **Chores**
  * Added CSV parsing dependency to support enhanced import validation capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->