### PR TITLE
LP-2.1.2: Registry — require mpn for import

### DIFF
--- a/packages/sdk/config/attributeRegistry.json
+++ b/packages/sdk/config/attributeRegistry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "attributes": [
     {
       "attribute_id": "sku",
@@ -9,8 +9,8 @@
       "data_type": "text",
       "required_for_completion": true,
       "required_for_export": true,
-      "import_required": true,
-      "ai_usage_notes": "Primary SKU / item id.",
+      "import_required": false,
+      "ai_usage_notes": "Primary SKU / item id. Optional for import (MPN is primary identifier).",
       "status": "active"
     },
     {
@@ -32,8 +32,8 @@
       "data_type": "text",
       "required_for_completion": true,
       "required_for_export": true,
-      "import_required": false,
-      "ai_usage_notes": "Manufacturer part number",
+      "import_required": true,
+      "ai_usage_notes": "Manufacturer part number. Required for import (LP-2.1.2).",
       "status": "active"
     },
     {


### PR DESCRIPTION
## LP-2.1.2: Registry Configuration Update

### Overview
Updates `attributeRegistry.json` to make MPN the required identifier for import, aligning the registry with LP-2.1.0/LP-2.1.1 "MPN-first" normalization.

### Changes
- Set `mpn.import_required = true` (primary identifier for import)
- Set `sku.import_required = false` (optional for import)
- Bump registry version to 1.0.2
- Updated `ai_usage_notes` for both attributes to reflect new import requirements

### Related PRs
- LP-2.1.0: PR #315 (merged) — SDK `deriveProductId()` MPN-first
- LP-2.1.1: PR #316 (merged) — API validation layer

### Testing
- [ ] Dry-run sync: `node packages/api/dist/tasks/syncAttributeRegistry.js --dry-run`
- [ ] Backup staging Firestore before sync
- [ ] Run staging sync
- [ ] Validate mpn/sku attribute snapshots in Firestore

### File Changes
- `packages/sdk/config/attributeRegistry.json` (version 1.0.1 → 1.0.2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.0.2.

* **Configuration Updates**
  * SKU is now optional for imports, with MPN serving as the primary identifier.
  * Part number (MPN) is now required for imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->