### PR TITLE
LP-2.1.4: Lock down Firestore products collection writes (Security)

### DIFF
--- a/HOMER_LP-2.1.4_AUDIT.txt
+++ b/HOMER_LP-2.1.4_AUDIT.txt
@@ -1,0 +1,134 @@
+# HOMER_LP-2.1.4_AUDIT.txt
+# LP-2.1.4: Lock Down Firestore Products Collection Writes
+# Generated: 2025-12-21T10:20:00Z
+
+## Summary
+SECURITY LP to prevent direct client writes to products/* collection.
+Forces all product attribute updates through server API or admin role.
+
+## Branch & Commits
+- Branch: lp/2.1.4-firestore-products-lockdown
+- Commit: 72af213b362b68d936bcdb85811b71844d73b92f
+- PR: https://github.com/twgallo13/ROPI-V2.1/pull/319
+
+## Files Changed
+1. firestore.rules
+   - Updated products/{productId} match block
+   - Read: authenticated users (unchanged)
+   - Write: requires isAdmin() OR isAdminViaMetadata()
+
+2. infra/backup/firestore.rules.before-lockdown (NEW)
+   - Backup of previous rules for rollback
+
+## Firebase Deploy
+- Command: firebase deploy --only firestore:rules --project ropi-bccee
+- Status: ✅ SUCCESS
+- Log: logs/lp-2.1.4-rules-deploy.log
+- Output:
+  ```
+  ✔  cloud.firestore: rules file firestore.rules compiled successfully
+  ✔  firestore: released rules firestore.rules to cloud.firestore
+  ✔  Deploy complete!
+  Project Console: https://console.firebase.google.com/project/ropi-bccee/overview
+  ```
+
+## Smoke Tests (Emulator)
+- Command: firebase emulators:exec --only firestore "node test-script"
+- Log: logs/lp-2.1.4-emulator-test.log
+
+### Test Results
+| # | Test | Expected | Actual | Status |
+|---|------|----------|--------|--------|
+| 1 | Non-admin user write | PERMISSION_DENIED | PERMISSION_DENIED | ✅ PASS |
+| 2 | Admin user write (role claim) | SUCCESS | SUCCESS | ✅ PASS |
+| 3 | Non-admin user read | SUCCESS | SUCCESS | ✅ PASS |
+
+### Raw Test Output
+```
+=== LP-2.1.4: Client Write DENIED Test (Emulator) ===
+
+--- TEST 1: Non-admin user write (should FAIL) ---
+[2025-12-21T10:15:10.569Z]  @firebase/firestore: Firestore (12.6.0): GrpcConnection RPC 'Write' stream error. 
+Code: 7 Message: 7 PERMISSION_DENIED:
+Property role is undefined on object. for 'create' @ L123, false for 'create' @ L268
+✅ Non-admin write correctly DENIED (PERMISSION_DENIED)
+
+--- TEST 2: Admin user write (should SUCCEED) ---
+✅ Admin write correctly SUCCEEDED
+
+--- TEST 3: Non-admin user READ (should SUCCEED) ---
+✅ Non-admin read correctly SUCCEEDED
+
+=== All smoke tests PASSED ===
+✔  Script exited successfully (code 0)
+```
+
+## Admin SDK Write Verification
+- Command: node admin-sdk-test.js
+- Sample Product: 123
+- Write test field: _lp214_test_admin
+- Result: ✅ SUCCEEDED
+- Cleanup: ✅ Test fields removed
+
+## Firestore Sample Documents
+### Product: 123
+```json
+{
+  "id": "123",
+  "status": "in-progress",
+  "brand": "Nike"
+}
+```
+
+### Product: 14943667
+```json
+{
+  "id": "14943667",
+  "mpn": "14943667",
+  "status": "intake",
+  "brand": "NEW ERA CAPS",
+  "_migratedVersion": "1.0.0"
+}
+```
+
+### Product: 14943678
+```json
+{
+  "id": "14943678",
+  "mpn": "14943678",
+  "status": "intake",
+  "brand": "NEW ERA CAPS",
+  "_migratedVersion": "1.0.0"
+}
+```
+
+## metadata/admins Document
+```json
+{
+  "emails": [
+    "theo@shiekhshoes.org",
+    "theo@shiekh.com"
+  ],
+  "updatedAt": {
+    "_seconds": 1764694118,
+    "_nanoseconds": 418000000
+  },
+  "updatedBy": "system"
+}
+```
+
+## Rollback Steps
+1. cp infra/backup/firestore.rules.before-lockdown firestore.rules
+2. firebase deploy --only firestore:rules --project ropi-bccee
+
+## Risks & Next Steps
+- **Risk**: Any existing client-side code that directly writes to products/* will now fail.
+  Client apps must be updated to use server API endpoints (PATCH /api/products/:mpn/attributes).
+- **Risk**: If metadata/admins doc is deleted/corrupted, isAdminViaMetadata() will fail.
+  Custom claims (isAdmin()) should be the primary auth method in production.
+- **Next Step**: LP-2.1.5 (MPN-first importer) after Lisa validates this LP.
+
+## Status
+- PR NOT MERGED — awaiting Lisa sign-off
+- Rules deployed to staging (ropi-bccee)
+- All smoke tests PASSED

--- a/infra/backup/firestore.rules.before-lockdown
+++ b/infra/backup/firestore.rules.before-lockdown
@@ -104,24 +104,12 @@ service cloud.firestore {
     }
     
     // ========================================
-    // PRODUCTS COLLECTION (LP-2.1.4 — Lockdown)
+    // PRODUCTS COLLECTION (Placeholder)
     // ========================================
-    // Related Notion docs:
-    // - Section 2.1 — Product Schema
-    // - Section 9 — Security & IAM
-    //
-    // LP-2.1.4: Lock down direct client writes to products/*
-    // All product attribute updates must go through server API endpoints.
-    // This prevents unexpected attribute mutation from client-side code.
+    // TODO: Implement product security rules
+    // TODO: Add field-level validation
     match /products/{productId} {
-      // Read: authenticated users can read products
-      allow read: if request.auth != null;
-      
-      // Write: only admins (server/service accounts with admin role or metadata allow-list)
-      // Client updates MUST call API endpoints (PATCH /api/products/:mpn/attributes)
-      // Uses existing isAdmin() (custom claims) and isAdminViaMetadata() (metadata/admins doc)
-      allow write: if request.auth != null 
-                   && (isAdmin() || isAdminViaMetadata());
+      allow read, write: if request.auth != null;
     }
     
     // ========================================

--- a/logs/lp-2.1.4-emulator-test.log
+++ b/logs/lp-2.1.4-emulator-test.log
@@ -1,0 +1,93 @@
+i  emulators: Starting emulators: firestore
+i  firestore: Firestore Emulator logging to firestore-debug.log
+✔  firestore: Firestore Emulator UI websocket is running on 9150.
+i  Running script: node << 'NODESCRIPT'
+const { initializeTestEnvironment, assertFails, assertSucceeds } = require('@firebase/rules-unit-testing');
+const fs = require('fs');
+
+(async () => {
+  console.log('=== LP-2.1.4: Client Write DENIED Test (Emulator) ===');
+  
+  const testEnv = await initializeTestEnvironment({
+    projectId: 'ropi-bccee-test',
+    firestore: {
+      rules: fs.readFileSync('firestore.rules', 'utf8'),
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+  
+  // Test 1: Non-admin authenticated user write (should FAIL)
+  console.log('\n--- TEST 1: Non-admin user write (should FAIL) ---');
+  const nonAdminUser = testEnv.authenticatedContext('non-admin-user-123', {
+    email: 'regularuser@example.com',
+    email_verified: true,
+  });
+  const nonAdminDb = nonAdminUser.firestore();
+  
+  try {
+    await assertFails(
+      nonAdminDb.collection('products').doc('test-product-123').set({
+        name: 'Test Product',
+        status: 'draft'
+      })
+    );
+    console.log('✅ Non-admin write correctly DENIED (PERMISSION_DENIED)');
+  } catch (error) {
+    console.log('❌ Test failed:', error.message);
+  }
+  
+  // Test 2: Admin user with role claim (should SUCCEED)
+  console.log('\n--- TEST 2: Admin user write (should SUCCEED) ---');
+  const adminUser = testEnv.authenticatedContext('admin-user-456', {
+    email: 'theo@shiekhshoes.org',
+    email_verified: true,
+    role: 'admin'
+  });
+  const adminDb = adminUser.firestore();
+  
+  try {
+    await assertSucceeds(
+      adminDb.collection('products').doc('test-product-456').set({
+        name: 'Admin Test Product',
+        status: 'active'
+      })
+    );
+    console.log('✅ Admin write correctly SUCCEEDED');
+  } catch (error) {
+    console.log('❌ Test failed:', error.message);
+  }
+  
+  // Test 3: Non-admin READ (should SUCCEED)
+  console.log('\n--- TEST 3: Non-admin user READ (should SUCCEED) ---');
+  try {
+    await assertSucceeds(nonAdminDb.collection('products').doc('test-product-456').get());
+    console.log('✅ Non-admin read correctly SUCCEEDED');
+  } catch (error) {
+    console.log('❌ Test failed:', error.message);
+  }
+  
+  await testEnv.cleanup();
+  console.log('\n=== All smoke tests PASSED ===');
+  process.exit(0);
+})();
+NODESCRIPT
+=== LP-2.1.4: Client Write DENIED Test (Emulator) ===
+
+--- TEST 1: Non-admin user write (should FAIL) ---
+[2025-12-21T10:15:10.569Z]  @firebase/firestore: Firestore (12.6.0): GrpcConnection RPC 'Write' stream 0x485f037c error. Code: 7 Message: 7 PERMISSION_DENIED: 
+Property role is undefined on object. for 'create' @ L123, false for 'create' @ L268, Property role is undefined on object. for 'update' @ L123, false for 'update' @ L268, Property role is undefined on object. for 'create' @ L123, false for 'create' @ L268
+✅ Non-admin write correctly DENIED (PERMISSION_DENIED)
+
+--- TEST 2: Admin user write (should SUCCEED) ---
+✅ Admin write correctly SUCCEEDED
+
+--- TEST 3: Non-admin user READ (should SUCCEED) ---
+✅ Non-admin read correctly SUCCEEDED
+
+=== All smoke tests PASSED ===
+✔  Script exited successfully (code 0)
+i  emulators: Shutting down emulators.
+i  firestore: Stopping Firestore Emulator
+i  hub: Stopping emulator hub
+i  logging: Stopping Logging Emulator

--- a/logs/lp-2.1.4-rules-deploy.log
+++ b/logs/lp-2.1.4-rules-deploy.log
@@ -1,0 +1,13 @@
+
+=== Deploying to 'ropi-bccee'...
+
+i  deploying firestore
+i  firestore: reading indexes from firestore.indexes.json...
+i  cloud.firestore: checking firestore.rules for compilation errors...
+✔  cloud.firestore: rules file firestore.rules compiled successfully
+i  firestore: uploading rules firestore.rules...
+✔  firestore: released rules firestore.rules to cloud.firestore
+
+✔  Deploy complete!
+
+Project Console: https://console.firebase.google.com/project/ropi-bccee/overview


### PR DESCRIPTION
## LP-2.1.4: Lock Down Firestore Products Collection Writes

### Purpose
**SECURITY**: Prevent direct client writes to `products/*` and force all product attribute updates through server API (or admin role). This closes the largest root cause for unexpected attribute mutation.

### Changes
- `firestore.rules`: Updated `products/{productId}` match block:
  - **Read**: Unchanged — authenticated users can read
  - **Write**: Now requires `isAdmin()` (custom claims `role == 'admin'`) OR `isAdminViaMetadata()` (email in `metadata/admins.emails`)
- Added backup at `infra/backup/firestore.rules.before-lockdown`

### Rules Diff
```diff
-    // PRODUCTS COLLECTION (Placeholder)
-    // TODO: Implement product security rules
-    // TODO: Add field-level validation
+    // PRODUCTS COLLECTION (LP-2.1.4 — Lockdown)
+    // LP-2.1.4: Lock down direct client writes to products/*
+    // All product attribute updates must go through server API endpoints.
     match /products/{productId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if request.auth != null 
+                   && (isAdmin() || isAdminViaMetadata());
     }
```

### Staging Deployment
- ✅ Rules deployed to `ropi-bccee` via `firebase deploy --only firestore:rules`
- Deploy log: `logs/lp-2.1.4-rules-deploy.log`

### Smoke Test Results
| Test | Expected | Result |
|------|----------|--------|
| Non-admin user write | PERMISSION_DENIED | ✅ DENIED |
| Admin user write (role claim) | SUCCESS | ✅ SUCCEEDED |
| Non-admin user read | SUCCESS | ✅ SUCCEEDED |

### Smoke Test Output
```
=== LP-2.1.4: Client Write DENIED Test (Emulator) ===

--- TEST 1: Non-admin user write (should FAIL) ---
GrpcConnection RPC 'Write' stream error. Code: 7 Message: PERMISSION_DENIED
✅ Non-admin write correctly DENIED (PERMISSION_DENIED)

--- TEST 2: Admin user write (should SUCCEED) ---
✅ Admin write correctly SUCCEEDED

--- TEST 3: Non-admin user READ (should SUCCEED) ---
✅ Non-admin read correctly SUCCEEDED

=== All smoke tests PASSED ===
```

### Rollback Steps
1. Restore rules: `cp infra/backup/firestore.rules.before-lockdown firestore.rules`
2. Deploy: `firebase deploy --only firestore:rules --project ropi-bccee`

### References
- Notion: Section 9 — Security & IAM
- Notion: Section 2.1 — Product Schema

### Checklist
- [x] Backup created (`infra/backup/firestore.rules.before-lockdown`)
- [x] Rules deployed to staging
- [x] Smoke tests passed (emulator)
- [x] Admin SDK write verified
- [ ] Awaiting Lisa sign-off before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product data access controls to restrict write access to admin users only. Read access for authenticated users remains unchanged.
  * Added deployment documentation and backup procedures for access control changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->