### PR TITLE
LP-2.1.5 — Make imports MPN-first (require mpn, prefer mpn for productId)

### DIFF
--- a/sample_import_mpn_first.csv
+++ b/sample_import_mpn_first.csv
@@ -1,0 +1,4 @@
+MPN,SKU,Product Name,Brand,Description,MSRP,Quantity
+MPNA-001,SKU-A1,Sample Product A,Brand A,Sample product with both MPN and SKU,49.99,10
+,SKU-B1,Sample Product B,Brand B,Missing MPN field - should fail,29.99,5
+MPNC-003,SKU-C3,Sample Product C,Brand C,Another valid product with MPN,99.99,20

--- a/staging_dry_run_result.json
+++ b/staging_dry_run_result.json
@@ -1,0 +1,131 @@
+(node:70684) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///workspaces/ROPI-V2.1/packages/sdk/scripts/import-dry-run.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /workspaces/ROPI-V2.1/packages/sdk/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+📂 Processing: ../../sample_import_mpn_first.csv
+📋 Format: json
+📊 Using MPN-first normalization (LP-2.1.0)
+
+📝 Found 3 rows
+
+{
+  "summary": {
+    "totalRows": 3,
+    "validRows": 2,
+    "invalidRows": 1,
+    "mpnOnly": 0,
+    "skuOnly": 1,
+    "bothMpnAndSku": 2,
+    "neitherMpnNorSku": 0,
+    "missingMpnCount": 1
+  },
+  "rows": [
+    {
+      "lineNumber": 2,
+      "source": {
+        "MPN": "MPNA-001",
+        "SKU": "SKU-A1",
+        "Product Name": "Sample Product A",
+        "Brand": "Brand A",
+        "Description": "Sample product with both MPN and SKU",
+        "MSRP": "49.99",
+        "Quantity": "10"
+      },
+      "normalized": {
+        "mpn": "MPNA-001",
+        "sku": "SKU-A1",
+        "title": "Sample Product A",
+        "brand": "Brand A",
+        "description": "Sample product with both MPN and SKU",
+        "msrp": 49.99,
+        "currency": "USD",
+        "quantity": 10
+      },
+      "productId": "mpna-001",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": true,
+        "productIdSource": "mpn"
+      }
+    },
+    {
+      "lineNumber": 3,
+      "source": {
+        "MPN": "",
+        "SKU": "SKU-B1",
+        "Product Name": "Sample Product B",
+        "Brand": "Brand B",
+        "Description": "Missing MPN field - should fail",
+        "MSRP": "29.99",
+        "Quantity": "5"
+      },
+      "normalized": {
+        "sku": "SKU-B1",
+        "title": "Sample Product B",
+        "brand": "Brand B",
+        "description": "Missing MPN field - should fail",
+        "msrp": 29.99,
+        "currency": "USD",
+        "quantity": 5
+      },
+      "productId": "sku-b1",
+      "validation": {
+        "isValid": false,
+        "missingRequired": [
+          "mpn"
+        ],
+        "hasMpn": false,
+        "hasSku": true,
+        "productIdSource": "sku"
+      }
+    },
+    {
+      "lineNumber": 4,
+      "source": {
+        "MPN": "MPNC-003",
+        "SKU": "SKU-C3",
+        "Product Name": "Sample Product C",
+        "Brand": "Brand C",
+        "Description": "Another valid product with MPN",
+        "MSRP": "99.99",
+        "Quantity": "20"
+      },
+      "normalized": {
+        "mpn": "MPNC-003",
+        "sku": "SKU-C3",
+        "title": "Sample Product C",
+        "brand": "Brand C",
+        "description": "Another valid product with MPN",
+        "msrp": 99.99,
+        "currency": "USD",
+        "quantity": 20
+      },
+      "productId": "mpnc-003",
+      "validation": {
+        "isValid": true,
+        "missingRequired": [],
+        "hasMpn": true,
+        "hasSku": true,
+        "productIdSource": "mpn"
+      }
+    }
+  ]
+}
+
+==================================================
+📊 SUMMARY
+==================================================
+Total rows:         3
+Valid rows:         2
+Invalid rows:       1
+──────────────────────────────────────────────────
+MPN only:           0
+SKU only:           1
+Both MPN & SKU:     2
+Neither:            0
+==================================================
+
+⚠️  1 row(s) have validation errors (missing required fields)


### PR DESCRIPTION
## Summary

LP-2.1.5: Validates and documents the MPN-first import architecture.

**Note**: The core functionality was already implemented in LP-2.1.0 through LP-2.1.2. This PR provides verification artifacts.

## What's Included

### Already Implemented (Prior LPs)
- **LP-2.1.0**: `importNormalizer.ts` - MPN required, SKU optional in `DEFAULT_COLUMN_MAPPINGS`
- **LP-2.1.0**: `deriveProductId()` - Prefers MPN for productId derivation
- **LP-2.1.1**: Validation layer with blocking errors for missing MPN
- **LP-2.1.2**: `attributeRegistry.json` - `mpn.import_required=true`, `sku.import_required=false` (version 1.0.2)

### This PR Adds
- `sample_import_mpn_first.csv`: Test CSV with 3 rows (2 valid, 1 invalid)
- `staging_dry_run_result.json`: Dry-run validation output

## Test Results

### SDK Unit Tests (222 PASS)
```
✓ test/importNormalizer.test.ts (19)
  ✓ LP-2.1.0: should prefer MPN over SKU for product ID derivation
  ✓ LP-2.1.0: should derive product ID from MPN when no SKU
  ✓ LP-2.1.0: should fall back to SKU when MPN is empty
  ✓ LP-2.1.0: should require MPN for import
  ✓ LP-2.1.0: should not require SKU (optional)
```

### API Integration Tests (7 PASS)
```
✓ Integration Test 1: CSV with MPN-only rows passes validation in dry-run
✓ Integration Test 2: CSV with missing MPN yields blocking error
✓ Integration Test 3: CSV with invalid enum values yields unmapped warnings
```

### Dry-Run Result Summary
```json
{
  "totalRows": 3,
  "validRows": 2,
  "invalidRows": 1,
  "missingMpnCount": 1
}
```

| Row | MPN | SKU | productId | Valid |
|-----|-----|-----|-----------|-------|
| 2 | MPNA-001 | SKU-A1 | mpna-001 | ✅ |
| 3 | (empty) | SKU-B1 | sku-b1 | ❌ missing mpn |
| 4 | MPNC-003 | SKU-C3 | mpnc-003 | ✅ |

## deriveProductId Call Sites

All call sites already use correct `{ mpn, sku }` object syntax:
1. `packages/sdk/src/builders/importRowBuilder.ts:77`
2. `packages/sdk/scripts/import-dry-run.js:66`
3. `packages/sdk/test/importNormalizer.test.ts` (multiple test assertions)

## Registry Version
`attributeRegistry.json` version: **1.0.2**

## Risks & Notes

- No existing products scan was performed (failure policy not triggered)
- If imports reveal many products lacking MPN, a migration plan will be prepared

---
**Awaiting Lisa approval for merge.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added staging files for data import validation testing. Includes comprehensive dry-run processing report with summary statistics, per-row validations with field normalization tracking, and error reporting to enhance data import workflows and validation accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->