### PR TITLE
[LP-ATTR-1.2.2] Hide ValuesManager Save when no onSave; show parent Save toast

### DIFF
--- a/logs/lp-attr-1.2.1/lp-attr-1.2.1-code-audit.json
+++ b/logs/lp-attr-1.2.1/lp-attr-1.2.1-code-audit.json
@@ -1,0 +1,133 @@
+{
+  "audit": "LP-ATTR-1.2.1",
+  "title": "Attribute Edit (isDirty) & Save Values Wiring",
+  "date": "2025-01-13",
+  "auditor": "HOMER",
+  "scope": [
+    "AttributesConsole.tsx - parent state/handlers",
+    "AttributeDetailPanel.tsx - tab routing + ValuesTab",
+    "ValuesManager.tsx - values CRUD + Save button",
+    "AttributeHeader.tsx - Save button"
+  ],
+  "findings": {
+    "issue_A": {
+      "title": "ValuesManager internal isDirty never triggers parent isDirty",
+      "status": "FALSE_POSITIVE",
+      "evidence": {
+        "ValuesManager_internal_isDirty": "line 689: local isDirty calculated from isNew/isDeleted/originalValue",
+        "ValuesManager_onChange": "line 710-714: handleValueChange calls onChange(values)",
+        "ValuesTab_handleValuesChange": "AttributeDetailPanel.tsx line 185-191: calls onChange({...formData, allowed_values, synonyms})",
+        "onFormChange_is_passed": "AttributeDetailPanel.tsx line 499: onChange={onFormChange}",
+        "onFormChange_sets_isDirty": "AttributesConsole.tsx line 467-469: handleFormChange sets setIsDirty(true)"
+      },
+      "conclusion": "The chain IS wired correctly: ValuesManager.onChange -> handleValuesChange -> onFormChange -> setIsDirty(true). The parent isDirty SHOULD become true when values are edited."
+    },
+    "issue_B": {
+      "title": "ValuesManager 'Save Values' button has no onSave prop",
+      "status": "CONFIRMED_BUG",
+      "evidence": {
+        "ValuesManagerProps": "line 41: onSave?: (payload: ValuesPayload) => Promise<void> - OPTIONAL",
+        "ValuesTab_renders": "line 196-200: <ValuesManager values={initialValues} onChange={handleValuesChange} readOnly={false} />",
+        "onSave_not_passed": "ValuesTab does NOT pass onSave prop",
+        "handleSave_guards": "line 812: if (!onSave) return; - early return",
+        "button_disabled_check": "line 911: disabled={isDisabled || saving || !isDirty || duplicates.size > 0}"
+      },
+      "conclusion": "The 'Save Values' button calls handleSave which returns early because onSave is undefined. This is a confirmed bug.",
+      "impact": "MEDIUM - Users cannot use the 'Save Values' button in ValuesManager, but they CAN use the parent Save button in AttributeHeader which DOES work."
+    },
+    "issue_C": {
+      "title": "AttributeHeader Save button disabled when isDirty=false",
+      "status": "VERIFIED_CORRECT",
+      "evidence": {
+        "button_disabled": "AttributeHeader.tsx line 180: disabled={saving || !isDirty}",
+        "isDirty_passed": "AttributeDetailPanel.tsx line 543: isDirty={isDirty}",
+        "isDirty_from_parent": "AttributesConsole.tsx line 679: isDirty={isDirty}",
+        "isDirty_state": "AttributesConsole.tsx line 413: const [isDirty, setIsDirty] = useState(false)"
+      },
+      "conclusion": "This is correct behavior - Save should be disabled when no changes."
+    },
+    "issue_D": {
+      "title": "ValuesManager initialValues computed with useMemo + Date.now()",
+      "status": "POTENTIAL_ISSUE",
+      "evidence": {
+        "useMemo_deps": "AttributeDetailPanel.tsx line 169-182: useMemo depends on [formData.allowed_values, formData.synonyms]",
+        "id_generation": "line 179: id: `val-${idx}-${Date.now()}`",
+        "originalValue_not_set": "initialValues do not set originalValue, so isDirty in ValuesManager will be wrong"
+      },
+      "conclusion": "When formData changes, initialValues regenerates with new Date.now() IDs but no originalValue. This may cause ValuesManager's internal isDirty to be incorrect (always false for existing values)."
+    }
+  },
+  "facts_table": [
+    {
+      "assertion": "ValuesManager calls onChange when value edited",
+      "result": "TRUE",
+      "evidence": "line 710-714 handleValueChange -> onChange(values)"
+    },
+    {
+      "assertion": "ValuesTab.handleValuesChange calls parent onChange",
+      "result": "TRUE",
+      "evidence": "line 185-191 calls onChange({...formData, ...})"
+    },
+    {
+      "assertion": "onFormChange prop is passed from AttributeDetailPanel",
+      "result": "TRUE",
+      "evidence": "line 499: onChange={onFormChange}"
+    },
+    {
+      "assertion": "handleFormChange sets isDirty(true)",
+      "result": "TRUE",
+      "evidence": "AttributesConsole.tsx line 468: setIsDirty(true)"
+    },
+    {
+      "assertion": "isDirty is passed to AttributeHeader",
+      "result": "TRUE",
+      "evidence": "line 543: isDirty={isDirty}"
+    },
+    {
+      "assertion": "Save button in AttributeHeader enables when isDirty=true",
+      "result": "TRUE",
+      "evidence": "line 180: disabled={saving || !isDirty}"
+    },
+    {
+      "assertion": "ValuesManager receives onSave prop",
+      "result": "FALSE",
+      "evidence": "ValuesTab line 196-200 does not pass onSave"
+    },
+    {
+      "assertion": "'Save Values' button works without onSave",
+      "result": "FALSE",
+      "evidence": "line 812: if (!onSave) return"
+    }
+  ],
+  "root_cause_analysis": {
+    "primary_issue": "ValuesManager 'Save Values' button does nothing because onSave prop is not passed",
+    "secondary_issue": "ValuesManager internal isDirty may be incorrectly false because initialValues lack originalValue",
+    "not_an_issue": "Parent isDirty flow is correctly wired - the AttributeHeader Save button SHOULD work"
+  },
+  "recommended_fixes": [
+    {
+      "id": "FIX-A",
+      "priority": "HIGH",
+      "description": "Remove 'Save Values' button from ValuesManager since parent Save handles persistence",
+      "alternative": "OR: Wire onSave through ValuesTab to call parent handleSave",
+      "files": ["ValuesManager.tsx", "AttributeDetailPanel.tsx"]
+    },
+    {
+      "id": "FIX-B",
+      "priority": "MEDIUM",
+      "description": "Set originalValue in initialValues so ValuesManager isDirty is accurate",
+      "files": ["AttributeDetailPanel.tsx"]
+    },
+    {
+      "id": "FIX-C",
+      "priority": "LOW",
+      "description": "Add toast/feedback when parent Save succeeds",
+      "files": ["AttributesConsole.tsx"]
+    }
+  ],
+  "verification_needed": {
+    "test_1": "Edit a value in ValuesManager, check if parent isDirty becomes true",
+    "test_2": "Click Save button in header after editing values, verify API call made",
+    "test_3": "Click 'Save Values' button, confirm it does nothing (current bug)"
+  }
+}

--- a/packages/web/src/components/ValuesManager.tsx
+++ b/packages/web/src/components/ValuesManager.tsx
@@ -904,21 +904,25 @@ export default function ValuesManager({
           >
             📋 Bulk Add
           </button>
-          <button
-            type="button"
-            className={styles.btnPrimary}
-            onClick={handleSave}
-            disabled={isDisabled || saving || !isDirty || duplicates.size > 0}
-            data-testid="save-values-btn"
-          >
-            {saving ? (
-              <>
-                <span className={styles.spinner} /> Saving...
-              </>
-            ) : (
-              'Save Values'
-            )}
-          </button>
+          {/* LP-ATTR-1.2.2: Only render Save Values if onSave prop is provided.
+              If onSave is not passed, the parent Save will persist values. */}
+          {typeof onSave === 'function' && (
+            <button
+              type="button"
+              className={styles.btnPrimary}
+              onClick={handleSave}
+              disabled={isDisabled || saving || !isDirty || duplicates.size > 0}
+              data-testid="save-values-btn"
+            >
+              {saving ? (
+                <>
+                  <span className={styles.spinner} /> Saving...
+                </>
+              ) : (
+                'Save Values'
+              )}
+            </button>
+          )}
         </div>
       </div>
 

--- a/packages/web/test/ValuesManager.noSaveButton.test.tsx
+++ b/packages/web/test/ValuesManager.noSaveButton.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ValuesManager Save Button Visibility Tests
+ * 
+ * LP-ATTR-1.2.2: Tests that Save Values button is only rendered when onSave prop is provided.
+ * When onSave is not passed, the parent Save handles persistence.
+ * 
+ * Homer LP-ATTR-1.2.2
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ValuesManager, { type AllowedValue } from '../src/components/ValuesManager';
+
+describe('ValuesManager Save Button Visibility', () => {
+  const mockValues: AllowedValue[] = [
+    { id: 'val-1', value: 'Red', enabled: true, synonyms: [], originalValue: 'Red' },
+    { id: 'val-2', value: 'Blue', enabled: true, synonyms: [], originalValue: 'Blue' },
+  ];
+
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should NOT render Save Values button when onSave prop is NOT provided', () => {
+    render(
+      <ValuesManager
+        values={mockValues}
+        onChange={mockOnChange}
+        // onSave is NOT passed
+      />
+    );
+
+    // The Save Values button should not exist
+    const saveButton = screen.queryByTestId('save-values-btn');
+    expect(saveButton).toBeNull();
+  });
+
+  it('should render Save Values button when onSave prop IS provided', () => {
+    const mockOnSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ValuesManager
+        values={mockValues}
+        onChange={mockOnChange}
+        onSave={mockOnSave}
+      />
+    );
+
+    // The Save Values button should exist
+    const saveButton = screen.queryByTestId('save-values-btn');
+    expect(saveButton).not.toBeNull();
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toHaveTextContent('Save Values');
+  });
+
+  it('should call onSave when Save Values button is clicked', async () => {
+    const mockOnSave = vi.fn().mockResolvedValue(undefined);
+    
+    // Add a new value to make isDirty true
+    const dirtyValues: AllowedValue[] = [
+      ...mockValues,
+      { id: 'val-3', value: 'Green', enabled: true, synonyms: [], isNew: true },
+    ];
+
+    render(
+      <ValuesManager
+        values={dirtyValues}
+        onChange={mockOnChange}
+        onSave={mockOnSave}
+      />
+    );
+
+    const saveButton = screen.getByTestId('save-values-btn');
+    expect(saveButton).toBeInTheDocument();
+    
+    // Button should be enabled when there are changes (isDirty = true due to isNew)
+    expect(saveButton).not.toBeDisabled();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledTimes(1);
+    });
+
+    // Check that onSave was called with the expected payload structure
+    expect(mockOnSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowed_values: expect.arrayContaining(['Red', 'Blue', 'Green']),
+        synonyms: expect.any(Object),
+      })
+    );
+  });
+
+  it('should still show Bulk Add button regardless of onSave prop', () => {
+    render(
+      <ValuesManager
+        values={mockValues}
+        onChange={mockOnChange}
+        // onSave is NOT passed
+      />
+    );
+
+    // Bulk Add should always be present
+    const bulkAddButton = screen.queryByTestId('bulk-add-btn');
+    expect(bulkAddButton).toBeInTheDocument();
+    expect(bulkAddButton).toHaveTextContent('Bulk Add');
+  });
+
+  it('should disable Save Values button when no changes (isDirty = false)', () => {
+    const mockOnSave = vi.fn().mockResolvedValue(undefined);
+
+    // Values with originalValue matching value (not dirty)
+    const cleanValues: AllowedValue[] = [
+      { id: 'val-1', value: 'Red', enabled: true, synonyms: [], originalValue: 'Red' },
+    ];
+
+    render(
+      <ValuesManager
+        values={cleanValues}
+        onChange={mockOnChange}
+        onSave={mockOnSave}
+      />
+    );
+
+    const saveButton = screen.getByTestId('save-values-btn');
+    expect(saveButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## LP-ATTR-1.2.2: Values Save UX Fix

### Summary
Remove the confusing ValuesManager 'Save Values' button when no `onSave` prop is provided. The parent Save button is the canonical persistence path.

### Changes
- **ValuesManager.tsx**: Only render the 'Save Values' button when `onSave` prop is provided
- **Unit tests**: Added 5 tests to verify:
  - Button NOT rendered when `onSave` is undefined
  - Button IS rendered when `onSave` is provided
  - `onSave` is called when button is clicked
  - Bulk Add button always renders regardless of `onSave`
  - Button is disabled when no changes (isDirty = false)

### Context from LP-ATTR-1.2.1 Audit
The code audit discovered that `ValuesTab` renders `ValuesManager` without passing `onSave`:
```tsx
<ValuesManager
  values={initialValues}
  onChange={handleValuesChange}
  readOnly={false}
  // onSave is NOT passed!
/>
```

In `ValuesManager.tsx`, `handleSave` early-returns when `onSave` is undefined:
```tsx
```

**Root cause**: The Save Values button existed but did nothing because the parent never passed `onSave`.

**Solution**: Hide the button when `onSave` is not provided, making the parent Save button (which DOES work correctly) the clear path for persistence.

### Toasts
Toast notifications already exist in `AttributesConsole.tsx handleSave`:
- Line 540: `toastSuccess(\`Created attribute '${created.attribute_id}'\`)`
- Line 545: `toastSuccess(\`Updated attribute '${selectedId}'\`)`

### Testing
- ✅ All 5 new unit tests pass
- Pre-existing test failures are unrelated to this change (Firebase mock issues, nav config mismatches)

### Rollback
Revert commit and redeploy hosting if issues arise. No database changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Save Values button appeared without functional save capability. The button now only displays when properly configured.

* **Tests**
  * Added test coverage validating Save Values button visibility and behavior, including state management and user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->