### PR TITLE
LP-ATTR-1.3.1: Clear selection after delete (success/failure)

### DIFF
--- a/packages/web/src/pages/Settings/AttributesConsole.tsx
+++ b/packages/web/src/pages/Settings/AttributesConsole.tsx
@@ -614,23 +614,34 @@ export default function AttributesConsole() {
   }, [selectedId, updateAttribute]);
 
   // Handle delete action (hard delete)
+  // LP-ATTR-1.3.1: Clear selection on BOTH success AND failure to prevent stale UI state
   const handleDelete = useCallback(async () => {
     if (!selectedId || !deleteAttribute) return;
     setSaving(true);
+    const deletingId = selectedId; // Capture before clearing
     try {
-      await deleteAttribute(selectedId);
-      toastSuccess(`Attribute '${selectedId}' has been deleted.`);
+      await deleteAttribute(deletingId);
+      toastSuccess(`Attribute '${deletingId}' has been deleted.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete attribute';
+      // LP-ATTR-1.3.1: Even on failure (e.g., 404), clear selection to prevent stuck UI
+      // The attribute may already be deleted, or there was a transient error.
+      // Either way, forcing the user to re-select ensures a clean state.
+      console.warn(`[AttributesConsole] Delete failed for '${deletingId}':`, message);
+      toastError(message);
+    } finally {
+      // LP-ATTR-1.3.1: Always clear selection and reset form after delete attempt
       setShowDeleteModal(false);
       setSelectedId(null);
       setFormData({ ...DEFAULT_ATTR });
       setIsDirty(false);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete attribute';
-      toastError(message);
-    } finally {
       setSaving(false);
+      // Refresh the list to ensure we have current server state
+      if (refresh) {
+        refresh().catch(err => console.warn('[AttributesConsole] Refresh after delete failed:', err));
+      }
     }
-  }, [selectedId, deleteAttribute]);
+  }, [selectedId, deleteAttribute, refresh]);
 
   // Show loading state
   if (loading && attributes.length === 0) {

--- a/packages/web/test/unit/AttributeConsole.shell.spec.tsx
+++ b/packages/web/test/unit/AttributeConsole.shell.spec.tsx
@@ -546,4 +546,170 @@ describe('AttributesConsole Shell', () => {
       });
     });
   });
+
+  // LP-ATTR-1.3.1: Delete State Cleanup Tests
+  describe('Delete State Cleanup (LP-ATTR-1.3.1)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockUseAttributes.deleteAttribute.mockReset();
+      mockUseAttributes.refresh.mockReset();
+    });
+
+    it('clears selection after successful delete', async () => {
+      mockUseAttributes.deleteAttribute.mockResolvedValueOnce(undefined);
+      mockUseAttributes.refresh.mockResolvedValueOnce(undefined);
+
+      render(<AttributesConsole />);
+
+      // Select an attribute
+      fireEvent.click(screen.getByTestId('list-item-color'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attribute-detail-panel')).toBeInTheDocument();
+      });
+
+      // Open kebab menu and click delete
+      fireEvent.click(screen.getByTestId('kebab-button'));
+      fireEvent.click(screen.getByTestId('menu-delete'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+      });
+
+      // Type attribute ID to enable confirm
+      fireEvent.change(screen.getByTestId('confirm-input'), { target: { value: 'color' } });
+
+      // Click confirm
+      fireEvent.click(screen.getByTestId('modal-confirm'));
+
+      // Wait for delete to complete
+      await waitFor(() => {
+        expect(mockUseAttributes.deleteAttribute).toHaveBeenCalledWith('color');
+      });
+
+      // Modal should close and detail panel should show empty state
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+        expect(screen.getByTestId('attribute-detail-panel-empty')).toBeInTheDocument();
+      });
+
+      // Refresh should have been called
+      expect(mockUseAttributes.refresh).toHaveBeenCalled();
+    });
+
+    it('clears selection after delete failure (404)', async () => {
+      mockUseAttributes.deleteAttribute.mockRejectedValueOnce(new Error('Not found: 404'));
+      mockUseAttributes.refresh.mockResolvedValueOnce(undefined);
+
+      render(<AttributesConsole />);
+
+      // Select an attribute
+      fireEvent.click(screen.getByTestId('list-item-color'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attribute-detail-panel')).toBeInTheDocument();
+      });
+
+      // Open kebab menu and click delete
+      fireEvent.click(screen.getByTestId('kebab-button'));
+      fireEvent.click(screen.getByTestId('menu-delete'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+      });
+
+      // Type attribute ID to enable confirm
+      fireEvent.change(screen.getByTestId('confirm-input'), { target: { value: 'color' } });
+
+      // Click confirm
+      fireEvent.click(screen.getByTestId('modal-confirm'));
+
+      // Wait for delete to fail
+      await waitFor(() => {
+        expect(mockUseAttributes.deleteAttribute).toHaveBeenCalledWith('color');
+      });
+
+      // Despite error, modal should close and detail panel should show empty state
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+        expect(screen.getByTestId('attribute-detail-panel-empty')).toBeInTheDocument();
+      });
+
+      // Refresh should still be called to sync server state
+      expect(mockUseAttributes.refresh).toHaveBeenCalled();
+    });
+
+    it('clears selection after generic delete failure', async () => {
+      mockUseAttributes.deleteAttribute.mockRejectedValueOnce(new Error('Network error'));
+      mockUseAttributes.refresh.mockResolvedValueOnce(undefined);
+
+      render(<AttributesConsole />);
+
+      // Select an attribute
+      fireEvent.click(screen.getByTestId('list-item-size'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attribute-detail-panel')).toBeInTheDocument();
+      });
+
+      // Open kebab menu and click delete
+      fireEvent.click(screen.getByTestId('kebab-button'));
+      fireEvent.click(screen.getByTestId('menu-delete'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+      });
+
+      // Type attribute ID to enable confirm
+      fireEvent.change(screen.getByTestId('confirm-input'), { target: { value: 'size' } });
+
+      // Click confirm
+      fireEvent.click(screen.getByTestId('modal-confirm'));
+
+      // Wait for delete to fail
+      await waitFor(() => {
+        expect(mockUseAttributes.deleteAttribute).toHaveBeenCalledWith('size');
+      });
+
+      // Despite error, selection should still be cleared (LP-ATTR-1.3.1 fix)
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+        expect(screen.getByTestId('attribute-detail-panel-empty')).toBeInTheDocument();
+      });
+    });
+
+    it('allows selecting another attribute after delete failure', async () => {
+      mockUseAttributes.deleteAttribute.mockRejectedValueOnce(new Error('Server error'));
+      mockUseAttributes.refresh.mockResolvedValueOnce(undefined);
+
+      render(<AttributesConsole />);
+
+      // Select color attribute
+      fireEvent.click(screen.getByTestId('list-item-color'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('header-id')).toHaveTextContent('color');
+      });
+
+      // Try to delete (will fail)
+      fireEvent.click(screen.getByTestId('kebab-button'));
+      fireEvent.click(screen.getByTestId('menu-delete'));
+      await waitFor(() => expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument());
+      fireEvent.change(screen.getByTestId('confirm-input'), { target: { value: 'color' } });
+      fireEvent.click(screen.getByTestId('modal-confirm'));
+
+      // Wait for failure and cleanup
+      await waitFor(() => {
+        expect(screen.getByTestId('attribute-detail-panel-empty')).toBeInTheDocument();
+      });
+
+      // Now select a different attribute - should work fine
+      fireEvent.click(screen.getByTestId('list-item-size'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attribute-detail-panel')).toBeInTheDocument();
+        expect(screen.getByTestId('header-id')).toHaveTextContent('size');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fixes stale UI state after delete failures by moving cleanup logic to a `finally` block, ensuring selection is cleared on **both success AND failure**.

## Problem
When a delete operation failed (e.g., 404 because attribute was already deleted, network error), the UI remained in a stale selection state:
- Modal stayed visible or closed incorrectly
- Selected attribute ID was not cleared
- Form data remained populated with deleted attribute
- User couldn't cleanly select another attribute

## Solution
- Move all cleanup logic (`setShowDeleteModal(false)`, `setSelectedId(null)`, `setFormData`, `setIsDirty(false)`) to `finally` block in `handleDelete`
- Always call `refresh()` after delete attempts to sync server state
- Add warning log for delete failures to aid debugging

## Changes
- `packages/web/src/pages/Settings/AttributesConsole.tsx`: Refactored `handleDelete` callback
- `packages/web/test/unit/AttributeConsole.shell.spec.tsx`: Added 4 unit tests

## Tests Added
1. ✅ `clears selection after successful delete`
2. ✅ `clears selection after delete failure (404)`
3. ✅ `clears selection after generic delete failure`
4. ✅ `allows selecting another attribute after delete failure`

## Test Results
```
✓ test/unit/AttributeConsole.shell.spec.tsx  (26 tests) 697ms
Test Files  1 passed (1)
Tests  26 passed (26)
```

## Labels
`lp:ATTR-1.3.1` `state:cleanup` `ui:attributes`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens delete UX/state handling and adds tests to prevent stale selection.
> 
> - Refactors `handleDelete` in `packages/web/src/pages/Settings/AttributesConsole.tsx` to move cleanup into `finally`: always close delete modal, clear `selectedId`, reset form (`DEFAULT_ATTR`), clear dirty state, and call `refresh()` after any delete attempt; captures `deletingId` for toasts/logs and logs failures with `console.warn`; updates hook deps to include `refresh`.
> - Adds 4 unit tests in `packages/web/test/unit/AttributeConsole.shell.spec.tsx` validating selection and UI cleanup on successful delete, 404 failure, generic failure, and ability to reselect another attribute after failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2ac336a68e281cfaa8d625c0032452be87b0663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete attribute workflow with better state cleanup and error handling for both success and failure scenarios.
  * List now automatically refreshes after delete operations to display the latest server state.

* **Tests**
  * Added comprehensive test coverage for delete attribute workflows, including success and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->