### PR TITLE
LP-ATTR-1.3.0-FIX-REGISTRY-VALIDATION — registry-driven import required validation

### DIFF
--- a/packages/api/src/services/attributeValidator.ts
+++ b/packages/api/src/services/attributeValidator.ts
@@ -388,11 +388,11 @@ function validateMultiSelect(
 
 /**
  * Non-attribute columns (skip validation)
+ * LP-ATTR-1.3.0: Removed name, Brand from skip list (now validated attributes)
  */
 const SKIP_COLUMNS = new Set([
-  'mpn', 'MPN', 'sku', 'SKU', 'title', 'name', 'Product Name',
   'description', 'Description', 'price', 'Price', 'MSRP', 'quantity', 'Quantity',
-  'image', 'images', 'url', 'barcode', 'upc', 'UPC', 'Brand',
+  'image', 'images', 'url', 'barcode', 'upc', 'UPC',
 ]);
 
 /**
@@ -406,7 +406,14 @@ const COLUMN_TO_ATTRIBUTE: Record<string, string> = {
   'Title': 'name',
   'name': 'name',
   'Name': 'name',
-  // Core attributes
+  // Core identifiers
+  'MPN': 'mpn',
+  'mpn': 'mpn',
+  'SKU': 'sku',
+  'sku': 'sku',
+  'Brand': 'brand',
+  'brand': 'brand',
+  // Classification attributes
   'Gender': 'gender',
   'gender': 'gender',
   'Department': 'department',
@@ -465,12 +472,16 @@ export function validateRow(
   normalizedValues['mpn'] = mpn;
   
   // Track required attributes that are missing
+  // LP-ATTR-1.3.0: Build set of required attributes from registry
   const requiredAttrs = new Set<string>();
   registryMap.forEach((def, _id) => {
     if (def.import_required) {
       requiredAttrs.add(def.attribute_id);
     }
   });
+  
+  // LP-ATTR-1.3.0: MPN is already validated and present, so mark as seen
+  requiredAttrs.delete('mpn');
   
   // Validate each column
   for (const [col, rawVal] of Object.entries(row)) {

--- a/packages/api/src/services/attributeValidator.ts
+++ b/packages/api/src/services/attributeValidator.ts
@@ -397,8 +397,16 @@ const SKIP_COLUMNS = new Set([
 
 /**
  * Map common column names to attribute IDs
+ * LP-ATTR-1.3.0: Add title → name mapping for Product Name normalization
  */
 const COLUMN_TO_ATTRIBUTE: Record<string, string> = {
+  // LP-ATTR-1.3.0: Product Name normalization
+  'Product Name': 'name',
+  'title': 'name',
+  'Title': 'name',
+  'name': 'name',
+  'Name': 'name',
+  // Core attributes
   'Gender': 'gender',
   'gender': 'gender',
   'Department': 'department',

--- a/packages/api/src/services/productCommitService.ts
+++ b/packages/api/src/services/productCommitService.ts
@@ -55,9 +55,10 @@ function convertRowToProduct(row: ImportEngineRow): Product {
   const now = new Date().toISOString();
 
   // Build core fields (filter out undefined values)
+  // LP-ATTR-1.3.0: Use 'name' field, fallback to legacy 'title' for backward compatibility
   const core: ProductCore = {
     sku: normalized.sku || '',
-    title: normalized.title || '',
+    title: normalized.name || normalized.title || '',
     brand: normalized.brand || '',
     ...(normalized.description && { description: normalized.description }),
     status: 'draft', // New imports start as drafts

--- a/packages/api/test/attributeValidator.unit.test.ts
+++ b/packages/api/test/attributeValidator.unit.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Attribute Validator Unit Tests
+ * LP-ATTR-1.3.0 — Registry-driven Required Field Validation
+ * 
+ * Tests the attribute validator's registry-driven required field logic
+ * and column-to-attribute mapping (especially title → name).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  validateRow,
+  loadRegistryMap,
+  clearRegistryCache,
+  type AttributeDefinition,
+} from '../src/services/attributeValidator';
+
+// Mock firebase-admin with registry data
+vi.mock('firebase-admin', () => {
+  const mockRegistry: Record<string, AttributeDefinition> = {
+    'mpn': {
+      id: 'mpn',
+      attribute_id: 'mpn',
+      label: 'MPN',
+      data_type: 'string',
+      import: true,
+      import_required: true, // Only MPN is required
+    },
+    'name': {
+      id: 'name',
+      attribute_id: 'name',
+      label: 'Product Name',
+      data_type: 'string',
+      import: true,
+      import_required: false, // Name is NOT required
+    },
+    'brand': {
+      id: 'brand',
+      attribute_id: 'brand',
+      label: 'Brand',
+      data_type: 'string',
+      import: true,
+      import_required: false, // Brand is NOT required
+    },
+    'category': {
+      id: 'category',
+      attribute_id: 'category',
+      label: 'Category',
+      data_type: 'select',
+      allowed_values: ['Footwear', 'Apparel'],
+      import: true,
+      import_required: false,
+    },
+  };
+
+  const mockFirestore = () => ({
+    collection: () => ({
+      doc: () => ({
+        collection: () => ({
+          get: async () => ({
+            forEach: (cb: (doc: any) => void) => {
+              Object.entries(mockRegistry).forEach(([id, data]) => {
+                cb({
+                  id,
+                  data: () => data,
+                });
+              });
+            },
+          }),
+        }),
+      }),
+    }),
+  });
+
+  return {
+    default: {
+      firestore: mockFirestore,
+    },
+    firestore: mockFirestore,
+  };
+});
+
+describe('LP-ATTR-1.3.0: Attribute Validator Unit Tests', () => {
+  let registryMap: Map<string, AttributeDefinition>;
+  
+  beforeEach(async () => {
+    clearRegistryCache();
+    registryMap = await loadRegistryMap();
+  });
+  
+  afterEach(() => {
+    clearRegistryCache();
+  });
+
+  describe('Registry-driven required field validation', () => {
+    it('should require only MPN (import_required: true)', () => {
+      const row = { MPN: 'TEST-001' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.errors.length).toBe(0);
+    });
+    
+    it('should reject row missing MPN', () => {
+      const row = { 'Product Name': 'Test Product', Brand: 'Test Brand' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('invalid');
+      expect(result.errors[0].code).toBe('missing_mpn');
+    });
+    
+    it('should NOT require Product Name (import_required: false)', () => {
+      const row = { MPN: 'TEST-001' }; // No Product Name
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.errors.length).toBe(0);
+    });
+    
+    it('should NOT require Brand (import_required: false)', () => {
+      const row = { MPN: 'TEST-001' }; // No Brand
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.errors.length).toBe(0);
+    });
+  });
+
+  describe('Column-to-attribute mapping (title → name)', () => {
+    it('should map "Product Name" column to "name" attribute', () => {
+      const row = { MPN: 'TEST-001', 'Product Name': 'My Product' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.normalizedValues['name']).toBe('My Product');
+    });
+    
+    it('should map "title" column to "name" attribute', () => {
+      const row = { MPN: 'TEST-001', 'title': 'Title Product' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.normalizedValues['name']).toBe('Title Product');
+    });
+    
+    it('should map "Title" column to "name" attribute', () => {
+      const row = { MPN: 'TEST-001', 'Title': 'Capitalized Title' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.normalizedValues['name']).toBe('Capitalized Title');
+    });
+    
+    it('should map "name" column to "name" attribute', () => {
+      const row = { MPN: 'TEST-001', 'name': 'Direct Name' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.normalizedValues['name']).toBe('Direct Name');
+    });
+  });
+
+  describe('Mixed validation scenarios', () => {
+    it('should validate row with MPN and optional fields', () => {
+      const row = {
+        MPN: 'TEST-001',
+        'Product Name': 'Test Product',
+        Brand: 'Test Brand',
+        Category: 'Footwear',
+      };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.normalizedValues).toMatchObject({
+        mpn: 'TEST-001',
+        name: 'Test Product',
+        brand: 'Test Brand',
+        category: 'Footwear',
+      });
+    });
+    
+    it('should validate MPN-only row without blocking errors', () => {
+      const row = { MPN: 'MPNA-001' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.errors.length).toBe(0);
+      expect(result.normalizedValues).toEqual({ mpn: 'MPNA-001' });
+    });
+  });
+
+  describe('Registry attribute flags', () => {
+    it('should respect import: true flag', () => {
+      const row = { MPN: 'TEST-001', Category: 'Footwear' };
+      const result = validateRow(row, 1, registryMap);
+      
+      expect(result.status).toBe('valid');
+      expect(result.normalizedValues['category']).toBe('Footwear');
+    });
+    
+    it('should check allowed_values for enum types', () => {
+      const row = { MPN: 'TEST-001', Category: 'InvalidCategory' };
+      const result = validateRow(row, 1, registryMap);
+      
+      // Should have warning for invalid enum value
+      expect(result.status).toBe('valid_with_warnings');
+      expect(result.warnings.some(w => w.code === 'enum_unknown')).toBe(true);
+    });
+  });
+});

--- a/packages/api/test/attributeValidator.unit.test.ts
+++ b/packages/api/test/attributeValidator.unit.test.ts
@@ -45,7 +45,7 @@ vi.mock('firebase-admin', () => {
       id: 'category',
       attribute_id: 'category',
       label: 'Category',
-      data_type: 'select',
+      data_type: 'enum', // Use 'enum' for allowed_values validation
       allowed_values: ['Footwear', 'Apparel'],
       import: true,
       import_required: false,

--- a/packages/api/test/importService.integration.test.ts
+++ b/packages/api/test/importService.integration.test.ts
@@ -56,6 +56,31 @@ vi.mock('firebase-admin', () => {
       data_type: 'string',
       import: true,
     },
+    // LP-ATTR-1.3.0: Add name and brand attributes for registry-driven validation tests
+    'name': {
+      id: 'name',
+      attribute_id: 'name',
+      label: 'Product Name',
+      data_type: 'text',
+      import: true,
+      import_required: false, // Not required for import
+    },
+    'brand': {
+      id: 'brand',
+      attribute_id: 'brand',
+      label: 'Brand',
+      data_type: 'text',
+      import: true,
+      import_required: false, // Not required for import
+    },
+    'mpn': {
+      id: 'mpn',
+      attribute_id: 'mpn',
+      label: 'MPN',
+      data_type: 'text',
+      import: true,
+      import_required: true, // Only MPN is required
+    },
   };
 
   const mockFirestore = () => ({
@@ -229,4 +254,75 @@ GX7918,SKU-002,Adidas Ultraboost,Women`;
       });
     });
   });
+  
+  // LP-ATTR-1.3.0: Registry-driven required validation tests
+  describe('LP-ATTR-1.3.0: Registry-driven Required Validation', () => {
+    it('should allow import with MPN only (no Product Name or Brand)', async () => {
+      const rows = [
+        { MPN: 'MPNA-001' },
+        { MPN: 'MPNB-002', SKU: 'SKU-B2' },
+      ];
+      
+      const result = await validateBatch(rows);
+      
+      // Both rows should be valid (no blocking errors for missing name/brand)
+      expect(result.validRows).toBe(2);
+      expect(result.invalidRows).toBe(0);
+      
+      // Verify no MISSING_REQUIRED_FIELD errors for name or brand
+      result.rows.forEach(row => {
+        expect(row.errors.some(e => 
+          e.code === 'missing_required' && 
+          (e.attribute === 'name' || e.attribute === 'brand')
+        )).toBe(false);
+      });
+    });
+    
+    it('should map Product Name column to name attribute', async () => {
+      const rows = [
+        { MPN: 'TEST-001', 'Product Name': 'Test Product' },
+      ];
+      
+      const result = await validateBatch(rows);
+      
+      expect(result.rows[0].status).toBe('valid');
+      expect(result.rows[0].normalizedValues['name']).toBe('Test Product');
+    });
+    
+    it('should map title column to name attribute', async () => {
+      const rows = [
+        { MPN: 'TEST-002', 'title': 'Another Product' },
+      ];
+      
+      const result = await validateBatch(rows);
+      
+      expect(result.rows[0].status).toBe('valid');
+      expect(result.rows[0].normalizedValues['name']).toBe('Another Product');
+    });
+    
+    it('should only require MPN as import_required attribute', async () => {
+      // Row with MPN but missing Product Name and Brand
+      const rows = [
+        { MPN: 'MPNA-001', Category: 'Test' },
+      ];
+      
+      const result = await validateBatch(rows);
+      
+      // Should be valid with no blocking errors
+      expect(result.rows[0].status).toBe('valid');
+      expect(result.rows[0].errors.length).toBe(0);
+    });
+    
+    it('should reject rows missing MPN (import_required: true)', async () => {
+      const rows = [
+        { 'Product Name': 'Product Without MPN', Brand: 'Test Brand' },
+      ];
+      
+      const result = await validateBatch(rows);
+      
+      expect(result.rows[0].status).toBe('invalid');
+      expect(result.rows[0].errors[0].code).toBe('missing_mpn');
+    });
+  });
 });
+

--- a/packages/sdk/src/normalization/importNormalizer.ts
+++ b/packages/sdk/src/normalization/importNormalizer.ts
@@ -12,6 +12,7 @@ import type { ImportSourceColumns, ImportNormalizedFields, ColumnMapping } from 
  * Maps common RO column names to AOSS normalized fields
  * 
  * LP-2.1.0: MPN-first — MPN is required, SKU is optional
+ * LP-ATTR-1.3.0: Registry-driven required validation — only MPN is import_required
  * MPN is the canonical product identifier per Product Schema / Attribute Registry
  */
 export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
@@ -20,8 +21,10 @@ export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
   { sourceColumn: 'mpn', targetField: 'mpn', required: true, transform: 'trim' },
   { sourceColumn: 'Manufacturer Part Number', targetField: 'mpn', required: true, transform: 'trim' },
   { sourceColumn: 'SKU', targetField: 'sku', required: false, transform: 'trim' },
-  { sourceColumn: 'Product Name', targetField: 'title', required: true, transform: 'trim' },
-  { sourceColumn: 'Brand', targetField: 'brand', required: true, transform: 'trim' },
+  // LP-ATTR-1.3.0: Product Name maps to 'name' attribute (not 'title')
+  { sourceColumn: 'Product Name', targetField: 'name', required: false, transform: 'trim' },
+  // LP-ATTR-1.3.0: Brand is not import_required per registry
+  { sourceColumn: 'Brand', targetField: 'brand', required: false, transform: 'trim' },
   { sourceColumn: 'Description', targetField: 'description', transform: 'trim' },
   
   // Attributes

--- a/packages/sdk/src/schema/importEngine.ts
+++ b/packages/sdk/src/schema/importEngine.ts
@@ -44,11 +44,14 @@ export interface ImportSourceColumns {
  * Normalized product fields mapped from source columns
  * Per AOSS Section 3.2 — Import Normalization Rules
  * LP-2.1.0: MPN is the canonical product identifier
+ * LP-ATTR-1.3.0: Product Name uses 'name' field (legacy 'title' for backward compat)
  */
 export interface ImportNormalizedFields {
   // Core fields — MPN is primary identifier (LP-2.1.0)
   mpn?: string;
   sku?: string;
+  // LP-ATTR-1.3.0: Prefer 'name' over 'title' (title kept for backward compatibility)
+  name?: string;
   title?: string;
   brand?: string;
   description?: string;


### PR DESCRIPTION
Fix importer required-field validation by consulting the authoritative attribute registry (`import_required`).
Also normalize import mapping: 'Product Name' -> 'name' and respect registry for required checks.
Includes unit and integration tests + staging dry-run verification steps.

## Changes
- Updated `attributeValidator.ts` to map title/Product Name columns to `name` attribute
- Fixed SKIP_COLUMNS to allow validation of name and brand attributes
- Updated SDK mapping (`DEFAULT_COLUMN_MAPPINGS`) to use `name` instead of `title` and mark brand as non-required
- Added unit tests for registry-driven validation logic
- Added integration tests for MPN-only imports
- Updated `productCommitService.ts` to support both `name` and legacy `title` fields

## Tests
- ✅ All 12 unit tests passing (attributeValidator.unit.test.ts)
- ✅ All 12 integration tests passing (importService.integration.test.ts)

## Acceptance Criteria
- [x] Server-side required logic consults the attribute registry (import_required) for import validation
- [x] title mapping is normalized to name and not treated as a separate attribute
- [x] Dry-run with MPN-only rows passes (no blocking missing field errors for Product Name or Brand)
- [x] Unit and integration tests added and passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements registry-driven required-field validation and standardizes product naming across the stack.
> 
> - Attribute validator now builds required set from the registry (`import_required`), removes `mpn` from required after validating, validates `name`/`brand` (removed from `SKIP_COLUMNS`), and maps `Product Name`/`title` → `name`.
> - `productCommitService` uses `normalized.name || normalized.title` for `core.title` to maintain backward compatibility.
> - SDK normalization updates: map `Product Name` → `name`, mark `Brand` as non-required; schema adds `name` to `ImportNormalizedFields`.
> - Adds focused unit and integration tests covering MPN-only imports, column-to-attribute mapping, and enum validation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f47430fb034ff632e0daac6e9e5300deb5715c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **New Features**
  * Added support for a new "name" field in product data with backward compatibility to existing "title" field.
  * Enhanced column name recognition to accept multiple variations (Product Name, title, Name) mapping to the same attribute.

* **Improvements**
  * Streamlined import requirements—only MPN is now required; Product Name and Brand are now optional.
  * Registry-driven attribute validation for more flexible and dynamic field handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->