### PR TITLE
LP-1.3.2 — Products list search & filter fixes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -141,7 +141,59 @@
           "order": "DESCENDING"
         }
       ]
-    }
-  ],
-  "fieldOverrides": []
-}
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "department",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]

--- a/packages/api/src/endpoints/products.ts
+++ b/packages/api/src/endpoints/products.ts
@@ -265,26 +265,74 @@ export async function listProductsHandler(req: Request, res: Response) {
         }
       }
 
-      const snapshot = await query.get();
-      let docs = snapshot.docs;
+      let docs: admin.firestore.QueryDocumentSnapshot[] = [];
+      let usedSearchFallback = false;
 
-      // Client-side search filtering (Firestore limitations)
-      // For production scale (>5k products), migrate to Algolia or Elasticsearch
+      // Improved search strategy:
+      // 1. If search query provided, try exact MPN/SKU match first (fast, indexed)
+      // 2. If no exact match, use larger window with client-side filtering
+      // 3. If no search, use standard paginated query
       if (searchQuery) {
-        docs = docs.filter(doc => {
-          const data = doc.data();
-          const searchFields = [
-            data.sku,
-            data.mpn,
-            data.name,
-            data.brand,
-            data.category,
-            data.department,
-            data.class,
-          ].filter(Boolean).map(v => String(v).toLowerCase());
+        // Try exact MPN match first (indexed query)
+        const mpnSnap = await db.collection('products')
+          .where('mpn', '==', searchQuery)
+          .limit(limit)
+          .get();
+        
+        if (!mpnSnap.empty) {
+          docs = mpnSnap.docs;
+        } else {
+          // Try case-insensitive MPN match (uppercase)
+          const mpnUpperSnap = await db.collection('products')
+            .where('mpn', '==', searchQuery.toUpperCase())
+            .limit(limit)
+            .get();
+          
+          if (!mpnUpperSnap.empty) {
+            docs = mpnUpperSnap.docs;
+          } else {
+            // Try exact SKU match
+            const skuSnap = await db.collection('products')
+              .where('sku', '==', searchQuery)
+              .limit(limit)
+              .get();
+            
+            if (!skuSnap.empty) {
+              docs = skuSnap.docs;
+            } else {
+              // Fallback: fetch larger window for client-side substring search
+              // Note: This works well for small catalogs (<500 products)
+              // For production scale, migrate to Algolia or Elasticsearch
+              usedSearchFallback = true;
+              const searchLimit = 500; // Larger window for search
+              
+              const fallbackSnap = await db.collection('products')
+                .orderBy(sortField, sortDir)
+                .limit(searchLimit)
+                .get();
+              
+              docs = fallbackSnap.docs.filter(doc => {
+                const data = doc.data();
+                const searchFields = [
+                  data.sku,
+                  data.mpn,
+                  data.name,
+                  data.brand,
+                  data.category,
+                  data.department,
+                  data.class,
+                  doc.id, // Also search by document ID
+                ].filter(Boolean).map(v => String(v).toLowerCase());
 
-          return searchFields.some(field => field.includes(searchQuery));
-        });
+                return searchFields.some(field => field.includes(searchQuery));
+              });
+            }
+          }
+        }
+      } else {
+        // No search query - use standard paginated query
+        const snapshot = await query.get();
+        docs = snapshot.docs;
       }
 
       const hasMore = docs.length > limit;
@@ -311,6 +359,25 @@ export async function listProductsHandler(req: Request, res: Response) {
       });
     } catch (error) {
       console.error('Error listing products:', error);
+      
+      // Check for Firestore composite index errors
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('requires an index') || msg.includes('create a composite index') || msg.includes('FAILED_PRECONDITION')) {
+        // Extract index URL if present in error message
+        const indexUrlMatch = msg.match(/https?:\/\/[^\s)]+/);
+        const indexUrl = indexUrlMatch ? indexUrlMatch[0] : undefined;
+        
+        console.error('Missing Firestore composite index. URL:', indexUrl || 'not provided');
+        
+        res.status(400).json({ 
+          error: 'MISSING_INDEX', 
+          message: 'This query requires a Firestore composite index. Please create the index and retry.',
+          indexUrl,
+          hint: 'Try removing filters or contact admin to create the required index.'
+        });
+        return;
+      }
+      
       res.status(500).json({ 
         error: 'INTERNAL_ERROR', 
         message: 'Failed to list products' 


### PR DESCRIPTION
## Summary

Fixes for Products List endpoint issues:
- 500 errors when filters are applied
- Search only finding results within current page (not all products)
- Missing products not appearing in search results

## Root Causes Identified

1. **Firestore composite index errors → 500 when filtering**
   - `listProductsHandler` builds queries with `where()` + `orderBy()`
   - Missing composite indexes cause Firestore SDK to throw errors
   - Previously returned generic 500, hiding the true cause

2. **Search was client-side filtering of page window only**
   - Handler fetched only `limit + 1` docs, then filtered
   - Products outside the page window were never searched
   - Searching `mpnb-002` would fail if it wasn't in the top 50 results

## Changes

### 1. MISSING_INDEX Error Detection
```typescript
// Now catches Firestore index errors and returns helpful 400 response
if (msg.includes('requires an index') || msg.includes('FAILED_PRECONDITION')) {
  res.status(400).json({ 
    error: 'MISSING_INDEX', 
    message: 'This query requires a Firestore composite index...',
    indexUrl,  // Link to create the index
    hint: 'Try removing filters or contact admin...'
  });
}
```

### 2. Improved Search Strategy
```
1. Try exact MPN match (indexed, fast)
2. Try uppercase MPN match (case-insensitive)
3. Try exact SKU match
4. Fallback: fetch 500 docs + client-side substring filter
```

### 3. Additional Composite Indexes
Added indexes for `createdAt` sorting:
- `brand` + `createdAt` (DESC)
- `status` + `createdAt` (DESC)
- `category` + `createdAt` (DESC)
- `department` + `createdAt` (DESC)

## Testing

After merge and deploy:
1. Test search for specific MPN (e.g., `mpnb-002`)
2. Test filtering by brand/status with different sort options
3. Verify 400 response with `indexUrl` if index is missing

## Labels

`state:in-progress`, `lp:1.3.2`, `type:fix`

## Notes

- The 500-doc fallback is suitable for staging (~30 products)
- For production scale (>500 products), recommend Algolia/Elasticsearch
- After deploying, run `firebase deploy --only firestore:indexes` to create new indexes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced product search with intelligent matching: prioritizes exact MPN and SKU matches, then falls back to substring search across product attributes (name, brand, category, department)
  * Optimized server-side search processing for faster results
  * Improved error guidance when search infrastructure needs configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->