### PR TITLE
[LP-0.4.2.1] Registry v1.1.2 - Attribute Definitions Verified

### DIFF
--- a/packages/sdk/config/attributeRegistry.json
+++ b/packages/sdk/config/attributeRegistry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.2",
   "attributes": [
     {
       "attribute_id": "sku",


### PR DESCRIPTION
## LP-0.4.2.1: Hardening the Attribute Registry

### Summary
Registry version bump to 1.1.2 with verified attribute definitions.

### Verified Attributes
All requested attributes exist with correct, detailed definitions:

| Attribute | Category | Data Type | Status |
|-----------|----------|-----------|--------|
| `primary_color` | color | select | ✅ Active |
| `material` | materials_construction | multiSelect | ✅ Active |
| `sports_team` | sport_league | text | ✅ Active |
| `platform_height` | materials_construction | select | ✅ Active |
| `shoe_height_map` | materials_construction | select | ✅ Active |
| `outsole_material` | materials_construction | select | ⚠️ Deprecated |

### Changes
- Version bump: 1.1.1 → 1.1.2
- Verified all Tab 2 and Fast Fashion attributes have complete definitions
- Confirmed `outsole_material` has `status: deprecated`

### Root Cause Analysis
The "Missing from Registry" warnings in the Product Editor indicate attributes missing from **Firestore**, not from the JSON registry. A `syncAttributeRegistry` re-run may be needed post-deploy.

### Testing
- [ ] Build passes CI
- [ ] Deploy to staging
- [ ] Run `syncAttributeRegistry` to sync registry to Firestore
- [ ] Verify no "Missing from Registry" warnings in Product Editor

---
**Labels:** `state:review`, `lp:0.4.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to reflect maintenance release.

---

**Note:** This release contains no user-facing changes or new functionality—it is a maintenance update only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->