### PR TITLE
[LP-0.4.3] Fix Attribute Pagination Limit

### DIFF
--- a/packages/api/src/services/attributesService.ts
+++ b/packages/api/src/services/attributesService.ts
@@ -26,9 +26,9 @@ import {
 // Firestore collection paths
 const ATTRIBUTES_COLLECTION = 'settings/attributes/keys';
 
-// Default pagination limit
-const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 100;
+// Default pagination limit - LP-0.4.3: raised from 50 to 1000 to avoid truncation
+const DEFAULT_LIMIT = 1000;
+const MAX_LIMIT = 1000;
 
 /**
  * Service error with HTTP status code

--- a/packages/web/src/hooks/useAttributes.ts
+++ b/packages/web/src/hooks/useAttributes.ts
@@ -158,7 +158,8 @@ export function useAttributes() {
     setError(null);
     try {
       const headers = await getAuthHeaders();
-      const url = `${API_BASE}/api/admin/settings/attributes`;
+      // LP-0.4.3: Explicitly request limit=200 to ensure all attributes are fetched
+      const url = `${API_BASE}/api/admin/settings/attributes?limit=200`;
       const body = await fetchJSON<ListResult>(url, {
         method: 'GET',
         headers,


### PR DESCRIPTION
## Summary

Fixes a regression where not all attributes were being returned due to pagination limits truncating the attribute list.

## Changes

### API (`packages/api/src/services/attributesService.ts`)
- Increased `DEFAULT_LIMIT` from 50 to 1000
- Increased `MAX_LIMIT` from 100 to 1000

### Web (`packages/web/src/hooks/useAttributes.ts`)  
- Added explicit `limit=200` parameter to the fetch URL

## Context

This addresses the issue where new attributes like `primary_color`, `material`, `sports_team`, `platform_height`, and `shoe_height_map` weren't appearing because the API was truncating results at 50 items.

## Testing

- [x] Local verification of attribute fetch
- [ ] Verify all 68 attributes appear on Settings Page in Staging

## Related

- LP-0.4.3: Fix Attribute Pagination Limit & Sync Registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased default and maximum attribute retrieval limits to 1000 per request to allow larger data batches and reduce pagination overhead.
  * Updated the app to request larger attribute pages (now fetching 200 items per call) so attribute lists load with fewer requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->