### PR TITLE
[LP-0.4.4] Fix Website Selector Crash

### DIFF
--- a/packages/web/src/components/product/DescriptionsTab.tsx
+++ b/packages/web/src/components/product/DescriptionsTab.tsx
@@ -136,6 +136,9 @@ function DescriptionsTab({ product, onUpdate }: DescriptionsTabProps) {
       {/* Site-Specific Descriptions */}
       {activeWebsites.map(site => {
         const config = WEBSITE_CONFIG[site];
+        // LP-0.4.4: Guard against undefined config (crash fix)
+        if (!config) return null;
+        
         const aiContent = mockAIContent[site];
         const currentValue = getSiteDescription(config.key);
         const hasAccepted = acceptedSites.has(site);


### PR DESCRIPTION
## Summary

Fixes app crash when modifying the website attribute in the Product Editor.

## Root Cause

**Crash Location:** [packages/web/src/components/product/DescriptionsTab.tsx](packages/web/src/components/product/DescriptionsTab.tsx#L140) (line 140, now line 143 after fix)

**Error:** `Cannot read property 'key' of undefined`

When a website value doesn't exist in the `WEBSITE_CONFIG` lookup table (e.g., due to case mismatch like `Karmaloop.com` vs `karmaloop.com`, or custom values), `WEBSITE_CONFIG[site]` returns `undefined`, and subsequently accessing `config.key` throws the error.

## Fix

Added guard clause before accessing `config` properties:
```tsx
const config = WEBSITE_CONFIG[site];
// LP-0.4.4: Guard against undefined config (crash fix)
if (!config) return null;
```

## Registry Note

The registry already has `website` with `data_type: "multiSelect"` - no registry changes needed.

## Testing

- [x] Verified guard clause prevents crash
- [ ] Verify website selector works in Staging

LP-0.4.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stability issue in the product descriptions section that could cause the application to crash when certain site configuration data was unavailable. The application now gracefully handles missing configuration entries to prevent unexpected crashes and improve overall reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->