### PR TITLE
[LP-0.4.5] Registry v1.1.3 - Material allow_custom_values

### DIFF
--- a/packages/sdk/config/attributeRegistry.json
+++ b/packages/sdk/config/attributeRegistry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.1.3",
   "attributes": [
     {
       "attribute_id": "sku",
@@ -342,6 +342,7 @@
       "external_header": "Material",
       "category": "materials_construction",
       "data_type": "multiSelect",
+      "allow_custom_values": true,
       "allowed_values": [
         "Acrylic", "Canvas", "Cotton", "Cotton-Blend", "Cotton-Rich", "Crocodile", "Dacron", "Denim",
         "Down", "Egyptian-Cotton", "Fabric", "Fabric-And-Leather", "Faux-Fur", "Fleece", "Fur", "Gore-Tex",


### PR DESCRIPTION
## Summary

Registry v1.1.3 update to fix Material attribute UI.

## Changes

### Registry (`packages/sdk/config/attributeRegistry.json`)
- **Version**: 1.1.2 → 1.1.3
- **Material attribute**: Added `"allow_custom_values": true` to enable typing custom materials
- Material `data_type` already was `multiSelect` (confirmed correct)

### ProductHeader Ghost Value Investigation
After investigation, the ProductHeader code is **correct** - no fallback to `['shiekhshoes.com']` exists. The header:
- Shows `product.websites` values directly from Firestore
- Displays "No websites" when array is empty/undefined

If ghost values appear, they exist in the actual Firestore document data.

## Deployment Steps
1. Merge this PR
2. Deploy to Staging (auto via CI)
3. After deployment, call sync endpoint or run locally:
   ```
   POST /api/syncAttributeRegistry?dryRun=false
   ```

LP-0.4.5 / PVS-0.4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Material attribute now supports custom values in addition to predefined options, allowing greater flexibility when specifying materials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->