### PR TITLE
fix(mock): Remove shiekhshoes.com ghost defaults, bump registry v1.1.4

### DIFF
--- a/packages/sdk/config/attributeRegistry.json
+++ b/packages/sdk/config/attributeRegistry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "1.1.4",
   "attributes": [
     {
       "attribute_id": "sku",

--- a/packages/web/src/data/mock-product.json
+++ b/packages/web/src/data/mock-product.json
@@ -4,7 +4,7 @@
   "styleId": "AIR-MAX-270",
   "name": "Nike Air Max 270 - Black/White",
   "status": "in-progress",
-  "websites": ["shiekh.com", "shiekhshoes.com"],
+  "websites": ["shiekh.com"],
   "brand": "Nike",
   "category": "Athletic Footwear",
   "department": "Men",
@@ -26,11 +26,6 @@
       "main": "Experience ultimate comfort with the Nike Air Max 270. Featuring Nike's largest heel Air unit yet, this shoe delivers incredible cushioning and a striking look.",
       "seoTitle": "Nike Air Max 270 Black/White - Men's Running Shoes | Shiekh",
       "metaDescription": "Shop the Nike Air Max 270 in Black/White. Premium comfort meets iconic style. Free shipping on orders over $75."
-    },
-    "shiekhshoes.com": {
-      "main": "",
-      "seoTitle": "",
-      "metaDescription": ""
     }
   },
   "media": {
@@ -42,7 +37,7 @@
     ]
   },
   "exportReadiness": {
-    "overall": 65,
+    "overall": 75,
     "byWebsite": {
       "shiekh.com": {
         "score": 75,
@@ -51,16 +46,6 @@
           "attributes": true,
           "descriptions": true,
           "media": true,
-          "pricing": false
-        }
-      },
-      "shiekhshoes.com": {
-        "score": 35,
-        "checklist": {
-          "coreInfo": true,
-          "attributes": true,
-          "descriptions": false,
-          "media": false,
           "pricing": false
         }
       }


### PR DESCRIPTION
## LP-0.4.6: Purge Hardcoded Defaults & Force Registry Update

### Problem
Ghost `shiekhshoes.com` website values appearing in staging when mock data fallback is used.

### Root Cause
- `packages/web/src/data/mock-product.json` contained hardcoded `shiekhshoes.com` in:
  - `websites` array (line 7)
  - `descriptions` object (line 30)
  - `exportReadiness.byWebsite` object (lines 57+)
- This mock data is used as fallback in `useProduct.ts` when Firestore unavailable

### Changes
1. **mock-product.json**
   - Remove `shiekhshoes.com` from `websites` array → now `["shiekh.com"]` only
   - Remove empty `shiekhshoes.com` description object
   - Remove `shiekhshoes.com` from `exportReadiness.byWebsite`
   - Update `overall` exportReadiness score to 75 (single valid site)

2. **attributeRegistry.json**
   - Bump version from `1.1.3` → `1.1.4`

### Verification
```bash
grep -n \"shiekhshoes.com\" packages/web/src/data/mock-product.json
# Returns empty (exit code 1) - all ghost values removed
```

### Testing
- Local build: N/A (JSON changes only)
- CI: Should pass
- Staging: Verify registry version shows `1.1.4` in bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK configuration version to 1.1.4.
  * Updated mock product data and export readiness metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->