### PR TITLE
infra(deploy): remove || true tolerance, add fail-fast, add Cache-Control header (LP-0.1.3)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,6 +11,7 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     environment: staging
+    timeout-minutes: 60  # LP-0.1.3.fix: Job-level timeout to prevent runaway deploys
 
     steps:
       - name: Checkout code
@@ -120,11 +121,12 @@ jobs:
           firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee --json
 
           # Deploy functions and hosting to stable staging
-          echo "Deploying Cloud Functions..."
-          firebase deploy --only functions --project ropi-bccee --json
+          # LP-0.1.3.fix: Add timeouts to prevent runaway deploys
+          echo "Deploying Cloud Functions (20m timeout)..."
+          timeout 20m firebase deploy --only functions --project ropi-bccee --json
 
-          echo "Deploying hosting..."
-          firebase deploy --only hosting:aoss-staging --project ropi-bccee --json
+          echo "Deploying hosting (10m timeout)..."
+          timeout 10m firebase deploy --only hosting:aoss-staging --project ropi-bccee --json
           echo "Stable staging URL: https://ropi-aoss-staging.web.app"
 
       - name: Smoke check stable staging

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -116,14 +116,12 @@ jobs:
           set -euo pipefail
           echo "Using GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
 
-          # Deploy preview channel (keep existing behavior)
-          firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee --json || true
+          # LP-0.1.3: Deploy preview channel (fail-fast, no tolerance)
+          firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee --json
 
           # Deploy functions and hosting to stable staging
           echo "Deploying Cloud Functions..."
-          firebase deploy --only functions --project ropi-bccee --json || {
-            echo "::warning::Functions deployment had issues, continuing with hosting..."
-          }
+          firebase deploy --only functions --project ropi-bccee --json
 
           echo "Deploying hosting..."
           firebase deploy --only hosting:aoss-staging --project ropi-bccee --json

--- a/firebase.json
+++ b/firebase.json
@@ -27,6 +27,26 @@
         "**/.*",
         "**/node_modules/**"
       ],
+      "headers": [
+        {
+          "source": "/index.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache, no-store, must-revalidate"
+            }
+          ]
+        },
+        {
+          "source": "**/*.@(js|css)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        }
+      ],
       "rewrites": [
         {
           "source": "/api/importCSV",


### PR DESCRIPTION
## Summary
**LP-0.1.3** - Harden deploy-staging workflow and fix stale cache issues

### Problem
1. Deploy workflow uses `|| true` which masks failures and allows partial deploys
2. Browser caches `index.html` causing users to see stale versions after deploy

### Solution

#### .github/workflows/deploy-staging.yml
- **Removed** `|| true` tolerance from preview channel deploy
- **Removed** `|| { warning }` tolerance from functions deploy
- All deploy steps now **fail-fast** on error, preventing inconsistent staging state

#### firebase.json
- **Added** Cache-Control header for `/index.html`:
  ```
  Cache-Control: no-cache, no-store, must-revalidate
  ```
- **Added** Cache-Control header for `*.js/*.css`:
  ```
  Cache-Control: public, max-age=31536000, immutable
  ```

### Rationale
- **Fail-fast**: Prevents partial deploys that leave staging in inconsistent state
- **Cache-Control**:
  - `index.html` is never served stale → users always get fresh app shell
  - Static assets (hashed `.js`, `.css`) are cached for 1 year → optimal performance
  - This is the industry standard for SPA deployment

### Verification
- `firebase.json` passes JSON validation
- Workflow syntax is valid YAML

---
**Labels**: `state:in-progress`, `lp:0.1.3`, `type:infra`, `cleanup:required`
**Blocking**: CodeRabbit review required before merge
**Approval**: Do NOT merge until Lisa applies `state:approved`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now fails fast on errors and includes per-step timeouts to prevent stalled deploys.

* **Performance**
  * Static asset caching improved: HTML served fresh (no-cache) while JS/CSS are cached long-term and marked immutable for faster repeat visits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->