### PR TITLE
LP-importer-mapping-recon-1.1.0 — SDK: canonicalize mappings to registry attribute IDs & add RICS descriptions

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -92,7 +92,16 @@ export {
   isEmptyRow,
   validateRequiredFields,
   DEFAULT_COLUMN_MAPPINGS,
+  // LP-importer-mapping-recon-1.1.0: Canonical registry ID helpers
+  normalizeTargetFieldToRegistry,
+  sourceColumnMatchesHeader,
 } from './normalization/importNormalizer';
+
+// LP-importer-mapping-recon-1.1.0: Export legacy-to-registry translation map
+export {
+  LEGACY_TO_REGISTRY,
+  REGISTRY_TO_LEGACY,
+} from './normalization/legacyToRegistryMap';
 
 // Export import row builder
 export {

--- a/packages/sdk/src/normalization/importNormalizer.ts
+++ b/packages/sdk/src/normalization/importNormalizer.ts
@@ -1,66 +1,151 @@
 /**
  * Import Normalization Rules
  * Per AOSS Section 3.2 — Import Normalization Rules
+ * LP-importer-mapping-recon-1.1.0: Canonicalize mappings to registry attribute IDs
  * 
  * Transforms raw RetailOps CSV data into normalized product fields.
+ * Uses canonical Attribute Registry IDs for all targetField values.
  */
 
 import type { ImportSourceColumns, ImportNormalizedFields, ColumnMapping } from '../schema/importEngine';
+import { LEGACY_TO_REGISTRY } from './legacyToRegistryMap';
+
+/**
+ * Helper to normalize a targetField to its canonical registry attribute_id.
+ * Accepts either canonical registry IDs or legacy camelCase keys and ensures
+ * callers of the normalizer always get registry IDs.
+ * 
+ * @param targetField - The field to normalize (legacy or registry format)
+ * @returns Canonical registry attribute_id
+ */
+export function normalizeTargetFieldToRegistry(targetField: string): string {
+  if (!targetField) return targetField;
+  
+  // If it's a known legacy key, translate it
+  const mapped = LEGACY_TO_REGISTRY[targetField];
+  if (mapped) {
+    return mapped;
+  }
+  
+  // Otherwise assume it's already canonical
+  return targetField;
+}
+
+/**
+ * Helper to check if a CSV header matches a sourceColumn definition.
+ * Supports both string and array sourceColumn formats (LP-1.1.0).
+ * 
+ * @param sourceColumn - String or array of aliases to match
+ * @param header - CSV header to check
+ * @returns True if header matches any alias (case-insensitive)
+ */
+export function sourceColumnMatchesHeader(
+  sourceColumn: string | string[],
+  header: string
+): boolean {
+  const normalizedHeader = header.toLowerCase().trim();
+  
+  if (Array.isArray(sourceColumn)) {
+    return sourceColumn.some(alias => alias.toLowerCase().trim() === normalizedHeader);
+  }
+  
+  return sourceColumn.toLowerCase().trim() === normalizedHeader;
+}
 
 /**
  * Default column mappings for RetailOps CSV
  * Maps common RO column names to AOSS normalized fields
  * 
  * LP-2.1.0: MPN-first — MPN is required, SKU is optional
- * MPN is the canonical product identifier per Product Schema / Attribute Registry
+ * LP-importer-mapping-recon-1.1.0: Use canonical Attribute Registry IDs for targetField
+ * 
+ * Note: sourceColumn may be a string or an array of aliases.
+ * targetField must be the canonical Attribute Registry attribute_id.
+ * Source of truth: evidence/importer-mapping-recon/attribute-registry.json (v1.1.4)
  */
 export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
-  // Core fields — MPN is required (LP-2.1.0), SKU is optional
-  { sourceColumn: 'MPN', targetField: 'mpn', required: true, transform: 'trim' },
-  { sourceColumn: 'mpn', targetField: 'mpn', required: true, transform: 'trim' },
-  { sourceColumn: 'Manufacturer Part Number', targetField: 'mpn', required: true, transform: 'trim' },
-  { sourceColumn: 'SKU', targetField: 'sku', required: false, transform: 'trim' },
-  // LP-ATTR-1.3.1: Product Name maps to the registry attribute 'name' (not 'title').
-  // Make Product Name and Brand optional; the registry (import_required) is authoritative.
-  { sourceColumn: 'Product Name', targetField: 'name', required: false, transform: 'trim' },
-  { sourceColumn: 'Brand', targetField: 'brand', required: false, transform: 'trim' },
-  { sourceColumn: 'Description', targetField: 'description', transform: 'trim' },
+  // ======================================================================
+  // Core Identifiers (category: sku_core)
+  // MPN is required (LP-2.1.0), SKU is optional
+  // ======================================================================
+  { sourceColumn: ['MPN', 'mpn', 'Manufacturer Part Number'], targetField: 'mpn', required: true, transform: 'trim' },
+  { sourceColumn: ['SKU', 'sku', 'Style'], targetField: 'sku', required: false, transform: 'trim' },
+  { sourceColumn: ['Product Name', 'Name', 'name', 'Title'], targetField: 'name', required: false, transform: 'trim' },
+  { sourceColumn: ['Brand', 'brand'], targetField: 'brand', required: false, transform: 'trim' },
+  { sourceColumn: ['Description', 'description'], targetField: 'description', transform: 'trim' },
+  { sourceColumn: ['Style ID', 'styleId', 'style_id'], targetField: 'style_id', transform: 'trim' },
+  { sourceColumn: ['GTIN', 'gtin', 'UPC', 'upc'], targetField: 'gtin', transform: 'trim' },
   
-  // Attributes
-  { sourceColumn: 'Department', targetField: 'department', transform: 'trim' },
-  { sourceColumn: 'Class', targetField: 'class', transform: 'trim' },
-  { sourceColumn: 'Category', targetField: 'category', transform: 'trim' },
-  { sourceColumn: 'Subcategory', targetField: 'subcategory', transform: 'trim' },
-  { sourceColumn: 'Gender', targetField: 'gender', transform: 'lowercase' },
-  { sourceColumn: 'Age Group', targetField: 'ageGroup', transform: 'trim' },
-  { sourceColumn: 'Color', targetField: 'color', transform: 'trim' },
-  { sourceColumn: 'Size', targetField: 'size', transform: 'trim' },
-  { sourceColumn: 'Material', targetField: 'material', transform: 'trim' },
+  // ======================================================================
+  // Classification (category: classification)
+  // ======================================================================
+  { sourceColumn: ['Department', 'department'], targetField: 'department', transform: 'trim' },
+  { sourceColumn: ['Class', 'class'], targetField: 'class', transform: 'trim' },
+  { sourceColumn: ['Category', 'category'], targetField: 'category', transform: 'trim' },
+  { sourceColumn: ['Subcategory', 'subcategory'], targetField: 'subcategory', transform: 'trim' },
   
-  // LP-0.2.0: RICS field mappings
-  { sourceColumn: 'RICS Category', targetField: 'ricsCategory', transform: 'trim' },
-  { sourceColumn: 'RICS Color', targetField: 'ricsColor', transform: 'trim' },
-  { sourceColumn: 'rics_category', targetField: 'ricsCategory', transform: 'trim' },
-  { sourceColumn: 'rics_color', targetField: 'ricsColor', transform: 'trim' },
+  // ======================================================================
+  // Identity / Demographic (category: identity_demographic)
+  // ======================================================================
+  { sourceColumn: ['Gender', 'gender'], targetField: 'gender', transform: 'lowercase' },
+  { sourceColumn: ['Age Group', 'ageGroup', 'age_group'], targetField: 'age_group', transform: 'trim' },
   
+  // ======================================================================
+  // Colors (category: color)
+  // Registry: primary_color, descriptive_color
+  // ======================================================================
+  { sourceColumn: ['Color', 'Primary Color', 'color', 'primary_color'], targetField: 'primary_color', transform: 'trim' },
+  { sourceColumn: ['Descriptive Color', 'DescriptiveColor', 'descriptive_color'], targetField: 'descriptive_color', transform: 'trim' },
+  
+  // ======================================================================
+  // Materials & Construction (category: materials_construction)
+  // ======================================================================
+  { sourceColumn: ['Material', 'material'], targetField: 'material', transform: 'trim' },
+  { sourceColumn: ['Closure Type', 'closure', 'closure_type'], targetField: 'closure_type', transform: 'trim' },
+  { sourceColumn: ['Cut Type', 'cut_type'], targetField: 'cut_type', transform: 'trim' },
+  
+  // ======================================================================
+  // Sizing / Measurements (category: measurements)
+  // ======================================================================
+  { sourceColumn: ['Size', 'size'], targetField: 'size', transform: 'trim' },
+  { sourceColumn: ['Shoe Width', 'shoe_width'], targetField: 'shoe_width', transform: 'trim' },
+  { sourceColumn: ['Weight', 'weight'], targetField: 'weight', transform: 'number' },
+  
+  // ======================================================================
+  // RICS Reference Fields (category: rics_reference)
+  // Note: rics_category and rics_color are reference fields (not in registry)
+  // ======================================================================
+  { sourceColumn: ['RICS Category', 'rics_category', 'ricsCategory'], targetField: 'rics_category', transform: 'trim' },
+  { sourceColumn: ['RICS Color', 'rics_color', 'ricsColor'], targetField: 'rics_color', transform: 'trim' },
+  { sourceColumn: ['RICS Long Description', 'RICS Long Desc', 'rics_long_desc'], targetField: 'rics_long_desc', transform: 'trim' },
+  { sourceColumn: ['RICS Short Description', 'RICS Short Desc', 'rics_short_description'], targetField: 'rics_short_description', transform: 'trim' },
+  
+  // ======================================================================
   // Pricing
-  { sourceColumn: 'MSRP', targetField: 'msrp', transform: 'number' },
-  { sourceColumn: 'Cost', targetField: 'cost', transform: 'number' },
-  { sourceColumn: 'Retail Price', targetField: 'retailPrice', transform: 'number' },
-  { sourceColumn: 'Currency', targetField: 'currency', transform: 'uppercase', defaultValue: 'USD' },
+  // ======================================================================
+  { sourceColumn: ['MSRP', 'msrp'], targetField: 'msrp', transform: 'number' },
+  { sourceColumn: ['Cost', 'cost'], targetField: 'cost', transform: 'number' },
+  { sourceColumn: ['Retail Price', 'retailPrice', 'retail_price'], targetField: 'retail_price', transform: 'number' },
+  { sourceColumn: ['Currency', 'currency'], targetField: 'currency', transform: 'uppercase', defaultValue: 'USD' },
   
-  // Inventory
-  { sourceColumn: 'Quantity', targetField: 'quantity', transform: 'number', defaultValue: 0 },
-  { sourceColumn: 'Warehouse', targetField: 'warehouse', transform: 'trim' },
-  { sourceColumn: 'Location', targetField: 'location', transform: 'trim' },
+  // ======================================================================
+  // Inventory / Logistics
+  // ======================================================================
+  { sourceColumn: ['Quantity', 'Qty', 'quantity'], targetField: 'quantity', transform: 'number', defaultValue: 0 },
+  { sourceColumn: ['Warehouse', 'warehouse'], targetField: 'warehouse', transform: 'trim' },
+  { sourceColumn: ['Location', 'location'], targetField: 'location', transform: 'trim' },
   
-  // Dates
-  { sourceColumn: 'First Received', targetField: 'firstReceived', transform: 'date' },
-  { sourceColumn: 'Launch Date', targetField: 'launchDate', transform: 'date' },
+  // ======================================================================
+  // Lifecycle / Dates (category: lifecycle)
+  // ======================================================================
+  { sourceColumn: ['First Received', 'firstReceived', 'first_received'], targetField: 'first_received', transform: 'date' },
+  { sourceColumn: ['Launch Date', 'launchDate', 'launch_date'], targetField: 'launch_date', transform: 'date' },
   
-  // Media (pipe-separated URLs)
-  { sourceColumn: 'Images', targetField: 'images', transform: 'array' },
-  { sourceColumn: 'Primary Image', targetField: 'primaryImage', transform: 'trim' },
+  // ======================================================================
+  // Media
+  // ======================================================================
+  { sourceColumn: ['Images', 'images', 'image_urls'], targetField: 'images', transform: 'array' },
+  { sourceColumn: ['Primary Image', 'primaryImage', 'primary_image'], targetField: 'primary_image', transform: 'trim' },
 ];
 
 /**
@@ -120,11 +205,53 @@ function applyTransform(
 }
 
 /**
+ * Find the value from sourceColumns for a given sourceColumn definition.
+ * Supports both string and array sourceColumn formats (LP-1.1.0).
+ * 
+ * @param sourceColumns - Raw CSV columns
+ * @param sourceColumn - String or array of aliases to match
+ * @returns The value from the first matching header, or undefined
+ */
+function findSourceValue(
+  sourceColumns: ImportSourceColumns,
+  sourceColumn: string | string[]
+): string | number | null | undefined {
+  if (Array.isArray(sourceColumn)) {
+    // Try each alias in order
+    for (const alias of sourceColumn) {
+      // Check both exact match and case-insensitive match
+      if (sourceColumns[alias] !== undefined) {
+        return sourceColumns[alias];
+      }
+      // Try case-insensitive match
+      const key = Object.keys(sourceColumns).find(
+        k => k.toLowerCase().trim() === alias.toLowerCase().trim()
+      );
+      if (key && sourceColumns[key] !== undefined) {
+        return sourceColumns[key];
+      }
+    }
+    return undefined;
+  }
+  
+  // Single string sourceColumn
+  if (sourceColumns[sourceColumn] !== undefined) {
+    return sourceColumns[sourceColumn];
+  }
+  // Try case-insensitive match
+  const key = Object.keys(sourceColumns).find(
+    k => k.toLowerCase().trim() === sourceColumn.toLowerCase().trim()
+  );
+  return key ? sourceColumns[key] : undefined;
+}
+
+/**
  * Normalize a single row from RetailOps CSV
+ * LP-importer-mapping-recon-1.1.0: Use canonical registry IDs for all targetField values
  * 
  * @param sourceColumns - Raw CSV columns
  * @param mappings - Column mapping configuration (defaults to DEFAULT_COLUMN_MAPPINGS)
- * @returns Normalized fields
+ * @returns Normalized fields with canonical registry attribute IDs
  */
 export function normalizeImportRow(
   sourceColumns: ImportSourceColumns,
@@ -133,7 +260,8 @@ export function normalizeImportRow(
   const normalized: ImportNormalizedFields = {};
 
   for (const mapping of mappings) {
-    const sourceValue = sourceColumns[mapping.sourceColumn];
+    // LP-1.1.0: Support array sourceColumn
+    const sourceValue = findSourceValue(sourceColumns, mapping.sourceColumn as string | string[]);
     
     // Apply transformation
     let normalizedValue = applyTransform(sourceValue, mapping.transform);
@@ -143,9 +271,11 @@ export function normalizeImportRow(
       normalizedValue = mapping.defaultValue;
     }
     
-    // Set normalized field if we have a value
+    // Set normalized field using canonical registry ID
+    // LP-1.1.0: Ensure targetField is canonical registry attribute_id
     if (normalizedValue !== undefined) {
-      normalized[mapping.targetField] = normalizedValue;
+      const canonicalTarget = normalizeTargetFieldToRegistry(mapping.targetField);
+      normalized[canonicalTarget] = normalizedValue;
     }
   }
 
@@ -185,10 +315,11 @@ export function isEmptyRow(sourceColumns: ImportSourceColumns): boolean {
 
 /**
  * Validate required fields are present after normalization
+ * LP-importer-mapping-recon-1.1.0: Use canonical registry IDs
  * 
  * @param normalized - Normalized fields
  * @param mappings - Column mappings (to check required fields)
- * @returns Array of missing required field names (deduplicated)
+ * @returns Array of missing required field names (deduplicated, canonical registry IDs)
  */
 export function validateRequiredFields(
   normalized: ImportNormalizedFields,
@@ -198,9 +329,11 @@ export function validateRequiredFields(
   
   for (const mapping of mappings) {
     if (mapping.required) {
-      const value = normalized[mapping.targetField];
+      // Use canonical registry ID for field lookup
+      const canonicalTarget = normalizeTargetFieldToRegistry(mapping.targetField);
+      const value = normalized[canonicalTarget];
       if (value === undefined || value === null || value === '') {
-        missingFields.add(mapping.targetField);
+        missingFields.add(canonicalTarget);
       }
     }
   }

--- a/packages/sdk/src/normalization/legacyToRegistryMap.ts
+++ b/packages/sdk/src/normalization/legacyToRegistryMap.ts
@@ -1,0 +1,156 @@
+/**
+ * Legacy to Registry Attribute ID Mapping
+ * LP-importer-mapping-recon-1.1.0
+ * 
+ * Temporary translation map: legacy normalized keys => canonical Attribute Registry IDs.
+ * Update if registry attribute IDs change. This file is consulted by importNormalizer
+ * to preserve backwards compatibility while we migrate consumers to registry IDs.
+ * 
+ * Source of truth: evidence/importer-mapping-recon/attribute-registry.json (v1.1.4)
+ */
+
+export const LEGACY_TO_REGISTRY: Record<string, string> = {
+  // ======================================================================
+  // SKU / Identifiers (category: sku_core, identifiers)
+  // ======================================================================
+  'mpn': 'mpn',
+  'MPN': 'mpn',
+  'manufacturerPartNumber': 'mpn',
+  'sku': 'sku',
+  'SKU': 'sku',
+  'name': 'name',
+  'productName': 'name',
+  'title': 'name', // legacy alias
+  'brand': 'brand',
+  'styleId': 'style_id',
+  'style_id': 'style_id',
+  'gtin': 'gtin',
+  'upc': 'gtin',
+  'slug': 'slug',
+
+  // ======================================================================
+  // Colors (category: color)
+  // Registry: primary_color, descriptive_color
+  // ======================================================================
+  'color': 'primary_color',
+  'primaryColor': 'primary_color',
+  'primary_color': 'primary_color',
+  'mainColor': 'primary_color',
+  'main_color': 'primary_color',
+
+  'descriptiveColor': 'descriptive_color',
+  'descriptive_color': 'descriptive_color',
+
+  // ======================================================================
+  // RICS Reference Fields (category: rics_reference)
+  // Note: Registry only has rics_long_desc, rics_short_description
+  // ricsCategory and ricsColor are not in registry - kept for legacy CSV import
+  // ======================================================================
+  'ricsLongDesc': 'rics_long_desc',
+  'ricsLongDescription': 'rics_long_desc',
+  'rics_long_desc': 'rics_long_desc',
+  'ricsShortDesc': 'rics_short_description',
+  'ricsShortDescription': 'rics_short_description',
+  'rics_short_description': 'rics_short_description',
+  // Legacy RICS fields not in registry - map to themselves (unmapped reference)
+  'ricsCategory': 'rics_category',
+  'rics_category': 'rics_category',
+  'ricsColor': 'rics_color',
+  'rics_color': 'rics_color',
+
+  // ======================================================================
+  // Classification (category: classification)
+  // ======================================================================
+  'category': 'category',
+  'class': 'class',
+  'department': 'department',
+  'subcategory': 'subcategory',
+
+  // ======================================================================
+  // Identity / Demographic (category: identity_demographic)
+  // ======================================================================
+  'gender': 'gender',
+  'ageGroup': 'age_group',
+  'age_group': 'age_group',
+
+  // ======================================================================
+  // Materials & Construction (category: materials_construction)
+  // ======================================================================
+  'material': 'material',
+  'closureType': 'closure_type',
+  'closure_type': 'closure_type',
+  'cutType': 'cut_type',
+  'cut_type': 'cut_type',
+
+  // ======================================================================
+  // Sizing / Measurements (category: measurements)
+  // ======================================================================
+  'size': 'size',
+  'shoeWidth': 'shoe_width',
+  'shoe_width': 'shoe_width',
+  'weight': 'weight',
+  'height': 'height',
+  'width': 'width',
+  'length': 'length',
+
+  // ======================================================================
+  // Lifecycle / Dates (category: lifecycle)
+  // ======================================================================
+  'launchDate': 'launch_date',
+  'launch_date': 'launch_date',
+  'firstReceived': 'first_received',
+  'first_received': 'first_received',
+  'lastReceived': 'last_received',
+  'last_received': 'last_received',
+
+  // ======================================================================
+  // Pricing
+  // Note: msrp, cost, retailPrice kept as-is (not in registry as separate attributes)
+  // ======================================================================
+  'msrp': 'msrp',
+  'cost': 'cost',
+  'retailPrice': 'retail_price',
+  'retail_price': 'retail_price',
+
+  // ======================================================================
+  // Inventory / Logistics
+  // ======================================================================
+  'quantity': 'quantity',
+  'warehouse': 'warehouse',
+  'location': 'location',
+
+  // ======================================================================
+  // Media
+  // ======================================================================
+  'images': 'images',
+  'primaryImage': 'primary_image',
+  'primary_image': 'primary_image',
+
+  // ======================================================================
+  // Website / Assignment (category: sku_core)
+  // ======================================================================
+  'website': 'website',
+  'websites': 'website',
+
+  // ======================================================================
+  // Descriptions (category: copy)
+  // ======================================================================
+  'description': 'description',
+  'shortDescription': 'short_description',
+  'short_description': 'short_description',
+  'longDescription': 'long_description',
+  'long_description': 'long_description',
+};
+
+/**
+ * Reverse mapping: Registry ID => primary legacy key
+ * Used for consumers expecting legacy keys
+ */
+export const REGISTRY_TO_LEGACY: Record<string, string> = Object.entries(LEGACY_TO_REGISTRY)
+  .reduce((acc, [legacy, registry]) => {
+    // Only store first occurrence (primary legacy key)
+    if (!acc[registry]) {
+      acc[registry] = legacy;
+    }
+    return acc;
+  }, {} as Record<string, string>);

--- a/packages/sdk/src/schema/importEngine.ts
+++ b/packages/sdk/src/schema/importEngine.ts
@@ -157,10 +157,11 @@ export interface ImportBatch {
 /**
  * CSV column mapping configuration
  * Maps RetailOps CSV columns to normalized field names
+ * LP-importer-mapping-recon-1.1.0: sourceColumn can be string or array of aliases
  */
 export interface ColumnMapping {
-  sourceColumn: string; // CSV column name
-  targetField: string; // Normalized field name
+  sourceColumn: string | string[]; // CSV column name(s) - string or array of aliases
+  targetField: string; // Normalized field name (canonical Attribute Registry ID)
   transform?: 'trim' | 'uppercase' | 'lowercase' | 'number' | 'date' | 'array';
   required?: boolean;
   defaultValue?: string | number;

--- a/packages/sdk/test/importNormalizer.lp-1.1.0.test.ts
+++ b/packages/sdk/test/importNormalizer.lp-1.1.0.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Import Normalizer Tests - LP-importer-mapping-recon-1.1.0
+ * 
+ * Tests for canonical registry IDs and array sourceColumn support.
+ * Validates:
+ * - DEFAULT_COLUMN_MAPPINGS uses registry attribute_ids
+ * - sourceColumn array aliases work correctly
+ * - LEGACY_TO_REGISTRY translation map coverage
+ * - Normalized output uses canonical registry IDs
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeImportRow,
+  DEFAULT_COLUMN_MAPPINGS,
+  normalizeTargetFieldToRegistry,
+  sourceColumnMatchesHeader,
+} from '../src/normalization/importNormalizer';
+import { LEGACY_TO_REGISTRY, REGISTRY_TO_LEGACY } from '../src/normalization/legacyToRegistryMap';
+import type { ImportSourceColumns } from '../src/schema/importEngine';
+
+describe('Import Normalizer - LP-importer-mapping-recon-1.1.0: Canonical Registry IDs', () => {
+  describe('DEFAULT_COLUMN_MAPPINGS structure', () => {
+    it('should have MPN mapping with array sourceColumn', () => {
+      const mpnMapping = DEFAULT_COLUMN_MAPPINGS.find(m => m.targetField === 'mpn');
+      expect(mpnMapping).toBeDefined();
+      expect(Array.isArray(mpnMapping?.sourceColumn)).toBe(true);
+      expect(mpnMapping?.sourceColumn).toContain('MPN');
+      expect(mpnMapping?.sourceColumn).toContain('mpn');
+      expect(mpnMapping?.sourceColumn).toContain('Manufacturer Part Number');
+    });
+
+    it('should have primary_color as targetField (not color)', () => {
+      const colorMapping = DEFAULT_COLUMN_MAPPINGS.find(m => m.targetField === 'primary_color');
+      expect(colorMapping).toBeDefined();
+      expect(Array.isArray(colorMapping?.sourceColumn)).toBe(true);
+      expect(colorMapping?.sourceColumn).toContain('Color');
+      expect(colorMapping?.sourceColumn).toContain('Primary Color');
+    });
+
+    it('should have descriptive_color as targetField', () => {
+      const descColorMapping = DEFAULT_COLUMN_MAPPINGS.find(m => m.targetField === 'descriptive_color');
+      expect(descColorMapping).toBeDefined();
+      expect(Array.isArray(descColorMapping?.sourceColumn)).toBe(true);
+      expect(descColorMapping?.sourceColumn).toContain('Descriptive Color');
+    });
+
+    it('should have rics_long_desc as targetField (registry ID)', () => {
+      const ricsLongMapping = DEFAULT_COLUMN_MAPPINGS.find(m => m.targetField === 'rics_long_desc');
+      expect(ricsLongMapping).toBeDefined();
+      expect(Array.isArray(ricsLongMapping?.sourceColumn)).toBe(true);
+    });
+
+    it('should have rics_short_description as targetField (registry ID)', () => {
+      const ricsShortMapping = DEFAULT_COLUMN_MAPPINGS.find(m => m.targetField === 'rics_short_description');
+      expect(ricsShortMapping).toBeDefined();
+      expect(Array.isArray(ricsShortMapping?.sourceColumn)).toBe(true);
+    });
+
+    it('should not have duplicate targetFields in mappings', () => {
+      const targetFields = DEFAULT_COLUMN_MAPPINGS.map(m => m.targetField);
+      const uniqueTargets = new Set(targetFields);
+      expect(uniqueTargets.size).toBe(targetFields.length);
+    });
+
+    it('should have all required identifiers as canonical IDs', () => {
+      const identifierMappings = DEFAULT_COLUMN_MAPPINGS.filter(m =>
+        ['mpn', 'sku', 'name', 'brand', 'gtin', 'style_id'].includes(m.targetField)
+      );
+      expect(identifierMappings.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe('sourceColumnMatchesHeader', () => {
+    it('should match single string sourceColumn (case-insensitive)', () => {
+      expect(sourceColumnMatchesHeader('MPN', 'MPN')).toBe(true);
+      expect(sourceColumnMatchesHeader('MPN', 'mpn')).toBe(true);
+      expect(sourceColumnMatchesHeader('MPN', 'Mpn')).toBe(true);
+    });
+
+    it('should match array sourceColumn aliases', () => {
+      const aliases = ['MPN', 'mpn', 'Manufacturer Part Number'];
+      expect(sourceColumnMatchesHeader(aliases, 'MPN')).toBe(true);
+      expect(sourceColumnMatchesHeader(aliases, 'mpn')).toBe(true);
+      expect(sourceColumnMatchesHeader(aliases, 'Manufacturer Part Number')).toBe(true);
+      expect(sourceColumnMatchesHeader(aliases, 'manufacturer part number')).toBe(true);
+    });
+
+    it('should not match non-matching headers', () => {
+      const aliases = ['MPN', 'mpn'];
+      expect(sourceColumnMatchesHeader(aliases, 'SKU')).toBe(false);
+      expect(sourceColumnMatchesHeader(aliases, 'UPC')).toBe(false);
+    });
+  });
+
+  describe('normalizeTargetFieldToRegistry', () => {
+    it('should translate legacy color to primary_color', () => {
+      expect(normalizeTargetFieldToRegistry('color')).toBe('primary_color');
+      expect(normalizeTargetFieldToRegistry('primaryColor')).toBe('primary_color');
+    });
+
+    it('should translate legacy descriptiveColor to descriptive_color', () => {
+      expect(normalizeTargetFieldToRegistry('descriptiveColor')).toBe('descriptive_color');
+    });
+
+    it('should translate legacy ricsLongDesc to rics_long_desc', () => {
+      expect(normalizeTargetFieldToRegistry('ricsLongDesc')).toBe('rics_long_desc');
+      expect(normalizeTargetFieldToRegistry('ricsLongDescription')).toBe('rics_long_desc');
+    });
+
+    it('should translate legacy ricsShortDesc to rics_short_description', () => {
+      expect(normalizeTargetFieldToRegistry('ricsShortDesc')).toBe('rics_short_description');
+      expect(normalizeTargetFieldToRegistry('ricsShortDescription')).toBe('rics_short_description');
+    });
+
+    it('should keep already-canonical IDs unchanged', () => {
+      expect(normalizeTargetFieldToRegistry('primary_color')).toBe('primary_color');
+      expect(normalizeTargetFieldToRegistry('descriptive_color')).toBe('descriptive_color');
+      expect(normalizeTargetFieldToRegistry('rics_long_desc')).toBe('rics_long_desc');
+    });
+
+    it('should handle core identifiers', () => {
+      expect(normalizeTargetFieldToRegistry('mpn')).toBe('mpn');
+      expect(normalizeTargetFieldToRegistry('sku')).toBe('sku');
+      expect(normalizeTargetFieldToRegistry('name')).toBe('name');
+      expect(normalizeTargetFieldToRegistry('brand')).toBe('brand');
+    });
+  });
+
+  describe('normalizeImportRow - canonical output', () => {
+    it('should normalize Color column to primary_color registry ID', () => {
+      const csvRow: ImportSourceColumns = { 'Color': 'Red' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('primary_color');
+      expect(normalized['primary_color']).toBe('Red');
+      expect(normalized).not.toHaveProperty('color'); // Legacy key not present
+    });
+
+    it('should normalize Primary Color column to primary_color', () => {
+      const csvRow: ImportSourceColumns = { 'Primary Color': 'Blue' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized['primary_color']).toBe('Blue');
+    });
+
+    it('should normalize Descriptive Color column to descriptive_color', () => {
+      const csvRow: ImportSourceColumns = { 'Descriptive Color': 'Fire Red / Black' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('descriptive_color');
+      expect(normalized['descriptive_color']).toBe('Fire Red / Black');
+    });
+
+    it('should normalize MPN aliases to mpn registry ID', () => {
+      // Test each MPN alias separately to avoid TypeScript index signature issues
+      const csvRow1: ImportSourceColumns = { 'MPN': 'ABC123' };
+      const csvRow2: ImportSourceColumns = { 'mpn': 'ABC123' };
+      const csvRow3: ImportSourceColumns = { 'Manufacturer Part Number': 'ABC123' };
+
+      for (const csvRow of [csvRow1, csvRow2, csvRow3]) {
+        const normalized = normalizeImportRow(csvRow);
+        expect(normalized).toHaveProperty('mpn');
+        expect(normalized['mpn']).toBe('ABC123');
+      }
+    });
+
+    it('should normalize RICS Long Description to rics_long_desc', () => {
+      const csvRow: ImportSourceColumns = { 'RICS Long Description': 'Long descriptive text' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('rics_long_desc');
+      expect(normalized['rics_long_desc']).toBe('Long descriptive text');
+    });
+
+    it('should normalize RICS Short Description to rics_short_description', () => {
+      const csvRow: ImportSourceColumns = { 'RICS Short Description': 'Short desc' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('rics_short_description');
+      expect(normalized['rics_short_description']).toBe('Short desc');
+    });
+
+    it('should normalize RICS Category to rics_category', () => {
+      const csvRow: ImportSourceColumns = { 'RICS Category': 'Footwear' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('rics_category');
+      expect(normalized['rics_category']).toBe('Footwear');
+    });
+
+    it('should normalize RICS Color to rics_color', () => {
+      const csvRow: ImportSourceColumns = { 'RICS Color': 'BLK' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('rics_color');
+      expect(normalized['rics_color']).toBe('BLK');
+    });
+
+    it('should normalize Launch Date to launch_date', () => {
+      const csvRow: ImportSourceColumns = { 'Launch Date': '2024-01-15' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('launch_date');
+    });
+
+    it('should normalize First Received to first_received', () => {
+      const csvRow: ImportSourceColumns = { 'First Received': '2024-01-01' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('first_received');
+    });
+
+    it('should normalize Age Group to age_group', () => {
+      const csvRow: ImportSourceColumns = { 'Age Group': 'Adult' };
+      const normalized = normalizeImportRow(csvRow);
+      expect(normalized).toHaveProperty('age_group');
+      expect(normalized['age_group']).toBe('Adult');
+    });
+  });
+
+  describe('Legacy backward compatibility', () => {
+    it('should handle legacy CSV with old camelCase headers', () => {
+      const legacyCsv: ImportSourceColumns = {
+        'MPN': 'LEGACY-001',
+        'color': 'Red', // lowercase
+        'DescriptiveColor': 'Crimson Red', // camelCase variant
+      };
+      const normalized = normalizeImportRow(legacyCsv);
+      
+      // Should normalize to registry IDs
+      expect(normalized['mpn']).toBe('LEGACY-001');
+      expect(normalized['primary_color']).toBe('Red');
+      expect(normalized['descriptive_color']).toBe('Crimson Red');
+    });
+
+    it('should handle mixed case headers via case-insensitive matching', () => {
+      const mixedCaseCsv: ImportSourceColumns = {
+        'mpn': 'MIX-001',
+        'BRAND': 'Test Brand',
+        'Product name': 'Test Product',
+      };
+      const normalized = normalizeImportRow(mixedCaseCsv);
+      
+      expect(normalized['mpn']).toBe('MIX-001');
+      // Note: Headers need to match alias list (case-insensitive)
+    });
+  });
+
+  describe('LEGACY_TO_REGISTRY coverage', () => {
+    it('should have mappings for primary color variants', () => {
+      expect(LEGACY_TO_REGISTRY['color']).toBe('primary_color');
+      expect(LEGACY_TO_REGISTRY['primaryColor']).toBe('primary_color');
+      expect(LEGACY_TO_REGISTRY['primary_color']).toBe('primary_color');
+    });
+
+    it('should have mappings for descriptive color variants', () => {
+      expect(LEGACY_TO_REGISTRY['descriptiveColor']).toBe('descriptive_color');
+      expect(LEGACY_TO_REGISTRY['descriptive_color']).toBe('descriptive_color');
+    });
+
+    it('should have mappings for RICS fields', () => {
+      expect(LEGACY_TO_REGISTRY['ricsLongDesc']).toBe('rics_long_desc');
+      expect(LEGACY_TO_REGISTRY['ricsShortDesc']).toBe('rics_short_description');
+      expect(LEGACY_TO_REGISTRY['ricsCategory']).toBe('rics_category');
+      expect(LEGACY_TO_REGISTRY['ricsColor']).toBe('rics_color');
+    });
+
+    it('should have mappings for core identifiers', () => {
+      expect(LEGACY_TO_REGISTRY['mpn']).toBe('mpn');
+      expect(LEGACY_TO_REGISTRY['MPN']).toBe('mpn');
+      expect(LEGACY_TO_REGISTRY['sku']).toBe('sku');
+      expect(LEGACY_TO_REGISTRY['name']).toBe('name');
+      expect(LEGACY_TO_REGISTRY['brand']).toBe('brand');
+    });
+
+    it('should have mappings for date fields', () => {
+      expect(LEGACY_TO_REGISTRY['launchDate']).toBe('launch_date');
+      expect(LEGACY_TO_REGISTRY['firstReceived']).toBe('first_received');
+    });
+  });
+
+  describe('REGISTRY_TO_LEGACY reverse mapping', () => {
+    it('should have reverse mappings for common registry IDs', () => {
+      expect(REGISTRY_TO_LEGACY['primary_color']).toBeDefined();
+      expect(REGISTRY_TO_LEGACY['descriptive_color']).toBeDefined();
+      expect(REGISTRY_TO_LEGACY['rics_long_desc']).toBeDefined();
+      expect(REGISTRY_TO_LEGACY['mpn']).toBeDefined();
+    });
+  });
+
+  describe('Complete CSV row normalization', () => {
+    it('should normalize a complete RetailOps CSV row with all field types', () => {
+      const completeCsv: ImportSourceColumns = {
+        'MPN': 'NK-AIR-MAX-270-BLK',
+        'SKU': 'AIR270BLK10',
+        'Product Name': 'Nike Air Max 270',
+        'Brand': 'Nike',
+        'Description': 'Classic air max sneaker',
+        'Department': 'Footwear',
+        'Category': 'Sneakers',
+        'Gender': 'Men\'s',
+        'Age Group': 'Adult',
+        'Color': 'Black',
+        'Descriptive Color': 'Black/White/Anthracite',
+        'Material': 'Mesh',
+        'Size': '10',
+        'MSRP': '150.00',
+        'Cost': '75.00',
+        'Quantity': '25',
+        'RICS Category': 'Athletic Footwear',
+        'RICS Color': 'BLK',
+        'Launch Date': '2024-03-01',
+        'First Received': '2024-02-15',
+        'Images': 'https://example.com/1.jpg|https://example.com/2.jpg',
+        'Primary Image': 'https://example.com/main.jpg',
+      };
+
+      const normalized = normalizeImportRow(completeCsv);
+
+      // Core identifiers
+      expect(normalized['mpn']).toBe('NK-AIR-MAX-270-BLK');
+      expect(normalized['sku']).toBe('AIR270BLK10');
+      expect(normalized['name']).toBe('Nike Air Max 270');
+      expect(normalized['brand']).toBe('Nike');
+
+      // Colors (canonical registry IDs)
+      expect(normalized['primary_color']).toBe('Black');
+      expect(normalized['descriptive_color']).toBe('Black/White/Anthracite');
+
+      // Classification
+      expect(normalized['department']).toBe('Footwear');
+      expect(normalized['category']).toBe('Sneakers');
+      expect(normalized['gender']).toBe("men's"); // lowercase transform
+
+      // Demographics
+      expect(normalized['age_group']).toBe('Adult');
+
+      // RICS fields
+      expect(normalized['rics_category']).toBe('Athletic Footwear');
+      expect(normalized['rics_color']).toBe('BLK');
+
+      // Pricing
+      expect(normalized['msrp']).toBe(150);
+      expect(normalized['cost']).toBe(75);
+
+      // Inventory
+      expect(normalized['quantity']).toBe(25);
+
+      // Dates (canonical registry IDs)
+      expect(normalized['launch_date']).toBeDefined();
+      expect(normalized['first_received']).toBeDefined();
+
+      // Media
+      expect(normalized['images']).toEqual([
+        'https://example.com/1.jpg',
+        'https://example.com/2.jpg',
+      ]);
+      expect(normalized['primary_image']).toBe('https://example.com/main.jpg');
+    });
+  });
+});


### PR DESCRIPTION
## LP Identity

**LP:** `LP-importer-mapping-recon-1.1.0`  
**Branch:** `lp/importer-mapping-recon/1.1.0-sdk-canonicalize`

## Summary

Canonicalize `DEFAULT_COLUMN_MAPPINGS` to use **Attribute Registry attribute_ids** as `targetField` values and add array `sourceColumn` support for multiple CSV header aliases.

## Changes

### 1. `packages/sdk/src/normalization/legacyToRegistryMap.ts` (NEW)

Temporary translation map for backward compatibility:

| Legacy Key | Registry attribute_id |
|------------|----------------------|
| `color`, `primaryColor` | `primary_color` |
| `descriptiveColor` | `descriptive_color` |
| `ricsLongDesc` | `rics_long_desc` |
| `ricsShortDesc` | `rics_short_description` |
| `ricsCategory` | `rics_category` |
| `ricsColor` | `rics_color` |
| `launchDate` | `launch_date` |
| `firstReceived` | `first_received` |
| `ageGroup` | `age_group` |

Also exports `REGISTRY_TO_LEGACY` reverse mapping.

### 2. `packages/sdk/src/normalization/importNormalizer.ts`

- **DEFAULT_COLUMN_MAPPINGS** now uses canonical registry attribute_ids
- **sourceColumn** supports `string | string[]` for alias arrays
- Added `normalizeTargetFieldToRegistry()` helper function
- Added `sourceColumnMatchesHeader()` helper function
- `normalizeImportRow()` outputs canonical registry IDs

### 3. `packages/sdk/src/schema/importEngine.ts`

- `ColumnMapping.sourceColumn` type updated to `string | string[]`

### 4. `packages/sdk/src/index.ts`

- Export new helpers: `normalizeTargetFieldToRegistry`, `sourceColumnMatchesHeader`
- Export translation maps: `LEGACY_TO_REGISTRY`, `REGISTRY_TO_LEGACY`

### 5. `packages/sdk/test/importNormalizer.lp-1.1.0.test.ts` (NEW)

36 unit tests covering:
- DEFAULT_COLUMN_MAPPINGS structure validation
- sourceColumnMatchesHeader array matching
- normalizeTargetFieldToRegistry translation
- Complete CSV row normalization with canonical IDs
- LEGACY_TO_REGISTRY coverage
- Backward compatibility with legacy CSV headers

## Registry Source

`evidence/importer-mapping-recon/attribute-registry.json` (v1.1.4)

## Testing

```bash
cd packages/sdk && pnpm test
# Test Files  13 passed (13)
# Tests  352 passed (352)
```

All existing tests continue to pass. New LP-1.1.0 tests: **36 passed**.

## Backward Compatibility

The `LEGACY_TO_REGISTRY` map provides a translation layer. Consumers expecting old keys can use `normalizeTargetFieldToRegistry()` to translate.

## Migration Notes

After consumers are updated to expect registry IDs, the legacy map can be deprecated.

## Labels

- `state:in-progress`
- `lp:importer-mapping-recon-1.1.0`
- `type:refactor`
- `cleanup:required`
- `blocked:coderabbit-review`

## Acceptance Criteria

- [x] DEFAULT_COLUMN_MAPPINGS uses registry attribute_ids for targetField
- [x] sourceColumn accepts arrays of aliases
- [x] LEGACY_TO_REGISTRY covers primary legacy keys
- [x] Unit tests pass (352 total, 36 new)
- [x] CI green
- [ ] CodeRabbit feedback resolved
- [ ] `blocked:coderabbit-review` removed by Lisa after review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple column aliases in CSV imports for more flexible header matching
  * Publicly exposed legacy↔registry translation maps and canonicalization helpers

* **Improvements**
  * Normalization now uses canonical registry IDs for consistent field handling and better backwards compatibility

* **Tests**
  * Comprehensive test suite covering alias matching, legacy-to-canonical translations, and end-to-end CSV normalization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->