### PR TITLE
LP-importer-mapping-recon-1.4.3 — importer mappings + LaunchMediaTab SCOM pricing

### DIFF
--- a/HOMER_LP-1.4.2_HES.md
+++ b/HOMER_LP-1.4.2_HES.md
@@ -1,0 +1,251 @@
+# HOMER LP-importer-mapping-recon-1.4.2 — HES (HOMER Execution Summary)
+
+**From**: Homer  
+**To**: Lisa  
+**LP**: LP-importer-mapping-recon-1.4.2
+
+---
+
+## Summary
+
+Fixed runtime crash in Product Page components when `media_status` contains an unknown value (e.g., `"sdfsdfgdf-23rcwsdf34-sdf34r-"`). Added defensive fallback pattern to both `ProductHeader` and `LaunchMediaTab` components.
+
+---
+
+## Actions Executed
+
+| Timestamp | Action |
+|-----------|--------|
+| 2025-12-29T02:10:00Z | Created branch `lp/importer-mapping-recon/1.4.2-media-status-guard` from aoss-main |
+| 2025-12-29T02:10:05Z | Read `ProductHeader.tsx` and `LaunchMediaTab.tsx` to identify crash point |
+| 2025-12-29T02:10:10Z | Applied defensive fallback to `ProductHeader.tsx` |
+| 2025-12-29T02:10:15Z | Applied defensive fallback to `LaunchMediaTab.tsx` |
+| 2025-12-29T02:10:20Z | Searched for other `mediaStatusConfig` usages (found none unguarded) |
+| 2025-12-29T02:10:30Z | Created unit test file `mediaStatusGuard.lp142.test.tsx` with 10 tests |
+| 2025-12-29T02:11:00Z | Ran LP-1.4.2 tests - 10 tests passed |
+| 2025-12-29T02:11:30Z | Built web package successfully |
+| 2025-12-29T02:12:00Z | Committed changes |
+| 2025-12-29T02:12:30Z | Pushed branch to origin |
+| 2025-12-29T02:13:00Z | Created PR #374 |
+| 2025-12-29T02:13:30Z | Requested CodeRabbit review |
+| 2025-12-29T02:16:00Z | All CI checks passed |
+| 2025-12-29T02:16:30Z | Merged PR #374 to aoss-main |
+| 2025-12-29T02:19:00Z | Staging deployment completed |
+| 2025-12-29T02:20:00Z | Verified product page loads without crash |
+
+---
+
+## Commits / Branches / PRs
+
+| Item | Value |
+|------|-------|
+| Repo | twgallo13/ROPI-V2.1 |
+| Branch | lp/importer-mapping-recon/1.4.2-media-status-guard |
+| Work Commit | `a80950b` |
+| Merge Commit | `79ab7c5a1d2bf71dcc095750f85a2c790c1c1d72` |
+| PR | https://github.com/twgallo13/ROPI-V2.1/pull/374 |
+
+---
+
+## CI / Workflow Runs
+
+| Workflow | Run ID | Status | Link |
+|----------|--------|--------|------|
+| Deploy pre-check (pull_request) | 20563113269 | ✅ SUCCESS | [Link](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563113269) |
+| Deploy pre-check (push) | 20563113274 | ✅ SUCCESS | [Link](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563113274) |
+| E2E Tests | 20563113259 | ✅ SUCCESS | [Link](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563113259) |
+| Deploy AOSS PR Preview | 20563113265 | ✅ SUCCESS | [Link](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563113265) |
+| Deploy AOSS Staging | 20563182798 | ✅ SUCCESS | [Link](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563182798) |
+| CodeRabbit | - | ✅ SUCCESS | Review completed |
+
+---
+
+## Files Changed
+
+| File | Change Type | Lines |
+|------|-------------|-------|
+| `packages/web/src/components/product/ProductHeader.tsx` | MODIFIED | +3 -1 |
+| `packages/web/src/components/product/LaunchMediaTab.tsx` | MODIFIED | +3 -2 |
+| `packages/web/test/unit/mediaStatusGuard.lp142.test.tsx` | NEW | +240 |
+
+---
+
+## Code Changes
+
+### ProductHeader.tsx (Before)
+```tsx
+const mediaStatus = mediaStatusConfig[product.media_status ?? 'missing'];
+```
+
+### ProductHeader.tsx (After - LP-1.4.2)
+```tsx
+// LP-1.4.2: Defensive fallback for unknown media_status values
+const mediaStatusKey = product.media_status ?? 'missing';
+const mediaStatus = mediaStatusConfig[mediaStatusKey] || mediaStatusConfig['missing'];
+```
+
+### LaunchMediaTab.tsx (Before)
+```tsx
+const mediaStatus = product.media_status ?? 'missing';
+const statusDisplay = mediaStatusConfig[mediaStatus];
+```
+
+### LaunchMediaTab.tsx (After - LP-1.4.2)
+```tsx
+// LP-0.4.1.1: media_status is read-only from external workflow, not computed locally
+// LP-1.4.2: Defensive fallback for unknown media_status values
+const mediaStatusKey = product.media_status ?? 'missing';
+const statusDisplay = mediaStatusConfig[mediaStatusKey as keyof typeof mediaStatusConfig] || mediaStatusConfig['missing'];
+```
+
+---
+
+## DB / API Snapshot
+
+### Product 211737-90h1-8 (Has Unknown media_status)
+
+```json
+{
+  "attributes": {
+    "media_status": "sdfsdfgdf-23rcwsdf34-sdf34r-",
+    "closure_type": "Mid",
+    "fit": "True to Size",
+    "platform_height": "1-2\"",
+    "heel_height": "Flat",
+    "heel_type": "Flat",
+    "website": ["shiekh.com"],
+    "material": ["Polyester"],
+    "age_group": "Adult",
+    "gender": "Men's",
+    "department": "Footwear",
+    "class": "Casual",
+    "category": "Athletic",
+    "sports_team": "Los Angeles Dodgers",
+    "collection_name": "All Star"
+  },
+  "dimensions": {
+    "height": 4,
+    "length": 4,
+    "width": 4,
+    "weight": 4
+  }
+}
+```
+
+**Note**: The `media_status` value `"sdfsdfgdf-23rcwsdf34-sdf34r-"` is an unknown value that would have crashed the UI before LP-1.4.2.
+
+---
+
+## Staging Evidence
+
+| Item | Value |
+|------|-------|
+| Staging URL | https://ropi-aoss-staging.web.app/products/211737-90h1-8 |
+| Deploy run ID | 20563182798 |
+| Deploy link | https://github.com/twgallo13/ROPI-V2.1/actions/runs/20563182798 |
+| Page opened | ✅ Simple Browser opened at staging URL |
+
+---
+
+## Attribute Verification Table (Product 211737-90h1-8)
+
+| Attribute | Firestore Value | Renders? | Status |
+|-----------|-----------------|----------|--------|
+| Website | `["shiekh.com"]` | ✅ | LP-1.4.1 |
+| Fit | `"True to Size"` | ✅ | LP-1.4.1 |
+| Platform Height | `"1-2\""` | ✅ | LP-1.4.1 |
+| Heel Height | `"Flat"` | ✅ | LP-1.4.1 |
+| Media Status | `"sdfsdfgdf-23rcwsdf34-sdf34r-"` | ✅ (shows "Missing" fallback) | LP-1.4.2 |
+| Closure Type | `"Mid"` | ✅ | LP-1.4.1 |
+| Height | `4` | ✅ | LP-1.4.1 |
+| Length | `4` | ✅ | LP-1.4.1 |
+| Width | `4` | ✅ | LP-1.4.1 |
+| Weight | `4` | ✅ | LP-1.4.1 |
+
+---
+
+## Unit Test Results
+
+| Test Suite | Tests | Status |
+|------------|-------|--------|
+| mediaStatusGuard.lp142.test.tsx | 10 | ✅ PASSED |
+
+### Test Cases Covered
+
+1. ✅ ProductHeader renders with known media_status (complete)
+2. ✅ ProductHeader renders with undefined media_status (fallback to missing)
+3. ✅ ProductHeader renders with unknown string media_status (LP-1.4.2 fix)
+4. ✅ ProductHeader applies correct CSS class for unknown media_status
+5. ✅ LaunchMediaTab renders with known media_status (partial)
+6. ✅ LaunchMediaTab renders with undefined media_status (fallback to missing)
+7. ✅ LaunchMediaTab renders with unknown string media_status (LP-1.4.2 fix)
+8. ✅ LaunchMediaTab uses fallback className for unknown media_status
+9. ✅ ProductHeader handles empty string media_status
+10. ✅ LaunchMediaTab handles numeric-like string media_status
+
+---
+
+## CodeRabbit Review
+
+| Item | Value |
+|------|-------|
+| Status | ✅ Review completed |
+| Summary | "UI components now gracefully handle unknown or missing media status values without crashing" |
+| Comments | None (clean approval) |
+
+---
+
+## Verification Steps
+
+### Step 1: Identify Crash Point
+- Searched for `mediaStatusConfig` usages
+- Found crash in `ProductHeader.tsx` line 82 and `LaunchMediaTab.tsx` line 76
+- Both were accessing config without fallback: `mediaStatusConfig[key]`
+
+### Step 2: Apply Fix
+- Added defensive fallback: `mediaStatusConfig[key] || mediaStatusConfig['missing']`
+- Ensures unknown values fall back to 'missing' display instead of `undefined`
+
+### Step 3: Verify Tests
+- Created 10 new unit tests specifically for unknown media_status handling
+- All tests pass
+
+### Step 4: Verify Staging
+- Product 211737-90h1-8 has `media_status: "sdfsdfgdf-23rcwsdf34-sdf34r-"` (unknown value)
+- Page loads without crash
+- Media status displays as "Missing" (fallback) instead of crashing
+
+---
+
+## Current State
+
+**VERIFIED SUCCESS** ✅
+
+### Rationale
+
+1. ✅ PR #374 created with defensive fixes and unit tests
+2. ✅ All CI runs passed (E2E, Deploy pre-check, Preview, CodeRabbit)
+3. ✅ Staging deployment completed (Run ID: 20563182798)
+4. ✅ Product page for 211737-90h1-8 opens without runtime errors
+5. ✅ Media status renders using fallback for unknown values
+6. ✅ 10 new unit tests pass
+
+---
+
+## Note on 451-9204-BLK18
+
+Product 451-9204-BLK18 does not exist in Firestore. The verification was performed using product 211737-90h1-8 which has the problematic `media_status: "sdfsdfgdf-23rcwsdf34-sdf34r-"` value that would have caused the crash.
+
+---
+
+## Explicit Closure
+
+| Item | Value |
+|------|-------|
+| Final merge SHA on aoss-main | `79ab7c5a1d2bf71dcc095750f85a2c790c1c1d72` |
+| Final staging deploy run ID | 20563182798 |
+| Staging URL | https://ropi-aoss-staging.web.app |
+
+---
+
+**LP-1.4.2 COMPLETE** ✅

--- a/packages/sdk/dist/index.js
+++ b/packages/sdk/dist/index.js
@@ -1550,6 +1550,14 @@ var LEGACY_TO_REGISTRY = {
   "closure_type": "closure_type",
   "cutType": "cut_type",
   "cut_type": "cut_type",
+  // LP-1.4.3 aliases
+  "heelHeight": "heel_height",
+  "heel_height": "heel_height",
+  "platformHeight": "platform_height",
+  "platform_height": "platform_height",
+  "hideImageUntilDate": "hide_image_date",
+  "hide_image_date": "hide_image_date",
+  "drawing": "drawing",
   // ======================================================================
   // Sizing / Measurements (category: measurements)
   // ======================================================================
@@ -1784,6 +1792,16 @@ var DEFAULT_COLUMN_MAPPINGS = [
   { sourceColumn: ["Closure Type", "closure", "closure_type"], targetField: "closure_type", transform: "trim" },
   { sourceColumn: ["Cut Type", "cut_type"], targetField: "cut_type", transform: "trim" },
   { sourceColumn: ["Fit", "fit"], targetField: "fit", transform: "trim" },
+  // ======================================================================
+  // Additional fields added in LP-1.4.3
+  // ======================================================================
+  { sourceColumn: ["Drawing", "drawing"], targetField: "drawing", transform: "trim" },
+  { sourceColumn: ["Hide Image Until Date", "Hide Image Date", "hide_image_until_date", "hide_image_date"], targetField: "hide_image_date", transform: "date" },
+  { sourceColumn: ["Heel Height", "heelHeight", "heel_height"], targetField: "heel_height", transform: "trim" },
+  { sourceColumn: ["Platform Height", "platformHeight", "platform_height"], targetField: "platform_height", transform: "trim" },
+  // SCOM Pricing (RetailOps)
+  { sourceColumn: ["SCOM Regular Price", "scom_regular_price"], targetField: "scom_regular_price", transform: "number" },
+  { sourceColumn: ["SCOM Sale Price", "scom_sale_price"], targetField: "scom_sale_price", transform: "number" },
   // ======================================================================
   // Sports & Collections (category: classification)
   // LP-1.4.0: Added sports_team and collection_name mappings

--- a/packages/sdk/dist/index.mjs
+++ b/packages/sdk/dist/index.mjs
@@ -1548,6 +1548,14 @@ var LEGACY_TO_REGISTRY = {
   "closure_type": "closure_type",
   "cutType": "cut_type",
   "cut_type": "cut_type",
+  // LP-1.4.3 aliases
+  "heelHeight": "heel_height",
+  "heel_height": "heel_height",
+  "platformHeight": "platform_height",
+  "platform_height": "platform_height",
+  "hideImageUntilDate": "hide_image_date",
+  "hide_image_date": "hide_image_date",
+  "drawing": "drawing",
   // ======================================================================
   // Sizing / Measurements (category: measurements)
   // ======================================================================
@@ -1782,6 +1790,16 @@ var DEFAULT_COLUMN_MAPPINGS = [
   { sourceColumn: ["Closure Type", "closure", "closure_type"], targetField: "closure_type", transform: "trim" },
   { sourceColumn: ["Cut Type", "cut_type"], targetField: "cut_type", transform: "trim" },
   { sourceColumn: ["Fit", "fit"], targetField: "fit", transform: "trim" },
+  // ======================================================================
+  // Additional fields added in LP-1.4.3
+  // ======================================================================
+  { sourceColumn: ["Drawing", "drawing"], targetField: "drawing", transform: "trim" },
+  { sourceColumn: ["Hide Image Until Date", "Hide Image Date", "hide_image_until_date", "hide_image_date"], targetField: "hide_image_date", transform: "date" },
+  { sourceColumn: ["Heel Height", "heelHeight", "heel_height"], targetField: "heel_height", transform: "trim" },
+  { sourceColumn: ["Platform Height", "platformHeight", "platform_height"], targetField: "platform_height", transform: "trim" },
+  // SCOM Pricing (RetailOps)
+  { sourceColumn: ["SCOM Regular Price", "scom_regular_price"], targetField: "scom_regular_price", transform: "number" },
+  { sourceColumn: ["SCOM Sale Price", "scom_sale_price"], targetField: "scom_sale_price", transform: "number" },
   // ======================================================================
   // Sports & Collections (category: classification)
   // LP-1.4.0: Added sports_team and collection_name mappings

--- a/packages/sdk/src/normalization/importNormalizer.ts
+++ b/packages/sdk/src/normalization/importNormalizer.ts
@@ -186,6 +186,16 @@ export const DEFAULT_COLUMN_MAPPINGS: ColumnMapping[] = [
   { sourceColumn: ['Closure Type', 'closure', 'closure_type'], targetField: 'closure_type', transform: 'trim' },
   { sourceColumn: ['Cut Type', 'cut_type'], targetField: 'cut_type', transform: 'trim' },
   { sourceColumn: ['Fit', 'fit'], targetField: 'fit', transform: 'trim' },
+  // ======================================================================
+  // Additional fields added in LP-1.4.3
+  // ======================================================================
+  { sourceColumn: ['Drawing', 'drawing'], targetField: 'drawing', transform: 'trim' },
+  { sourceColumn: ['Hide Image Until Date', 'Hide Image Date', 'hide_image_until_date', 'hide_image_date'], targetField: 'hide_image_date', transform: 'date' },
+  { sourceColumn: ['Heel Height', 'heelHeight', 'heel_height'], targetField: 'heel_height', transform: 'trim' },
+  { sourceColumn: ['Platform Height', 'platformHeight', 'platform_height'], targetField: 'platform_height', transform: 'trim' },
+  // SCOM Pricing (RetailOps)
+  { sourceColumn: ['SCOM Regular Price', 'scom_regular_price'], targetField: 'scom_regular_price', transform: 'number' },
+  { sourceColumn: ['SCOM Sale Price', 'scom_sale_price'], targetField: 'scom_sale_price', transform: 'number' },
   
   // ======================================================================
   // Sports & Collections (category: classification)

--- a/packages/sdk/src/normalization/legacyToRegistryMap.ts
+++ b/packages/sdk/src/normalization/legacyToRegistryMap.ts
@@ -81,6 +81,14 @@ export const LEGACY_TO_REGISTRY: Record<string, string> = {
   'closure_type': 'closure_type',
   'cutType': 'cut_type',
   'cut_type': 'cut_type',
+  // LP-1.4.3 aliases
+  'heelHeight': 'heel_height',
+  'heel_height': 'heel_height',
+  'platformHeight': 'platform_height',
+  'platform_height': 'platform_height',
+  'hideImageUntilDate': 'hide_image_date',
+  'hide_image_date': 'hide_image_date',
+  'drawing': 'drawing',
 
   // ======================================================================
   // Sizing / Measurements (category: measurements)

--- a/packages/web/src/components/product/LaunchMediaTab.tsx
+++ b/packages/web/src/components/product/LaunchMediaTab.tsx
@@ -143,9 +143,15 @@ function LaunchMediaTab({ product, onUpdate }: LaunchMediaTabProps) {
                    (product.attributes?.map as unknown as boolean) ?? false;
   const promoValue = product.promo ?? 
                      (product.attributes?.promo as string) ?? '';
-  const scomRegularPriceValue = product.scom_regular_price ?? 
+  // LP-1.4.3: Prefer pricing.scom_* (canonical place from Firestore). Fallback to previous shapes for compatibility.
+  // Note: Product type has top-level fields, but Firestore may store in pricing object
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pricingObj = (product as any).pricing as Record<string, unknown> | undefined;
+  const scomRegularPriceValue = (pricingObj?.scom_regular_price as string | number) ??
+                                product.scom_regular_price ??
                                 (product.attributes?.scom_regular_price as string) ?? '';
-  const scomSalePriceValue = product.scom_sale_price ?? 
+  const scomSalePriceValue = (pricingObj?.scom_sale_price as string | number) ??
+                             product.scom_sale_price ??
                              (product.attributes?.scom_sale_price as string) ?? '';
   const standardShippingValue = product.standard_shipping_override ?? 
                                 (product.attributes?.standard_shipping_override as string) ?? '';


### PR DESCRIPTION
## Problem

Several CSV columns used by retail ops were not being mapped or displayed in the Product Editor:
- Drawing, Hide Image Until Date, Heel Height, Platform Height
- SCOM Regular Price / SCOM Sale Price

## Fix

### 1. Importer (SDK) updates:
- Add `DEFAULT_COLUMN_MAPPINGS` entries for `drawing`, `hide_image_date`, `heel_height`, `platform_height`, `scom_regular_price`, `scom_sale_price`.
- Add legacy camelCase/snake_case aliases in `legacyToRegistryMap.ts`.

### 2. Web UI updates:
- `LaunchMediaTab`: prefer `pricing.scom_regular_price` / `pricing.scom_sale_price` as canonical pricing location.
  - Fall back to previous top-level or attribute shapes for compatibility.
- This avoids duplicating pricing and keeps pricing data in `pricing.*`.

## Files Changed

| File | Change |
|------|--------|
| `packages/sdk/src/normalization/importNormalizer.ts` | Add column mappings for drawing, hide_image_date, heel_height, platform_height, scom_regular_price, scom_sale_price |
| `packages/sdk/src/normalization/legacyToRegistryMap.ts` | Add legacy aliases for LP-1.4.3 fields |
| `packages/web/src/components/product/LaunchMediaTab.tsx` | Read SCOM pricing from `pricing.*` with fallback |

## Testing & verification

- Run SDK dry-run and validator on `Ropi test import4` and confirm normalized object includes new fields.
- Run import on staging; verify Firestore product doc contains:
  - `attributes.heel_height`, `attributes.platform_height`, `attributes.drawing`, `attributes.hide_image_date`
  - `pricing.scom_regular_price`, `pricing.scom_sale_price`
- Verify Product Editor Launch/Attributes tabs display the fields on staging for product `211737-90h1-8`.

## Acceptance checklist

- [ ] SDK dry-run shows new normalized fields
- [ ] Validator exit code 0
- [ ] Import processed (status processed)
- [ ] Firestore and API snapshot show fields
- [ ] LaunchMediaTab and ProductAttributesTab display fields
- [ ] PR labeled: `state:in-progress`, `lp:importer-mapping-recon-1.4.3`, `type:fix`, `cleanup:required`
- [ ] HES provided with evidence

## LP Reference

- LP: LP-importer-mapping-recon-1.4.3
- Parent: LP-importer-mapping-recon-1.4.2 (PR #374)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of media status handling with defensive fallbacks for unknown values.
  * Enhanced pricing data lookup with improved fallback logic.

* **New Features**
  * Added support for additional product metadata: drawing details, heel height, platform height, and hide image until date.
  * Expanded pricing data sources with new pricing fields.

* **Tests**
  * Added comprehensive unit test coverage validating media status handling for various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->