### PR TITLE
LP-1.4.6.6 — Fix E2E Auth Tests on Preview

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       # Credentials
       VITE_E2E_ADMIN_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-admin@example.com' || 'theo@shiekh.com' }}
-      VITE_E2E_USER_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-user@example.com' || 'user@shiekh.com' }}
+      VITE_E2E_USER_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-user@example.com' || 'e2e-user@shiekh.com' }}
       VITE_E2E_UNVERIFIED_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-unverified@example.com' || 'unverified@shiekh.com' }}
       VITE_E2E_ADMIN_PASSWORD: ${{ contains(inputs.base_url, 'emulator') && 'test-password-123' || secrets.E2E_ADMIN_PASSWORD }}
       VITE_E2E_USER_PASSWORD: ${{ contains(inputs.base_url, 'emulator') && 'test-password-123' || secrets.E2E_USER_PASSWORD }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       # Credentials
       VITE_E2E_ADMIN_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-admin@example.com' || 'theo@shiekh.com' }}
-      VITE_E2E_USER_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-user@example.com' || 'e2e-user@shiekh.com' }}
+      VITE_E2E_USER_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-user@example.com' || 'user@shiekh.com' }}
       VITE_E2E_UNVERIFIED_EMAIL: ${{ contains(inputs.base_url, 'emulator') && 'test-unverified@example.com' || 'unverified@shiekh.com' }}
       VITE_E2E_ADMIN_PASSWORD: ${{ contains(inputs.base_url, 'emulator') && 'test-password-123' || secrets.E2E_ADMIN_PASSWORD }}
       VITE_E2E_USER_PASSWORD: ${{ contains(inputs.base_url, 'emulator') && 'test-password-123' || secrets.E2E_USER_PASSWORD }}

--- a/docs/lisa/HOMER_LP-1.4.6.6_HES.md
+++ b/docs/lisa/HOMER_LP-1.4.6.6_HES.md
@@ -37,59 +37,79 @@ at helpers.ts:100
 
 ## 2. Root Cause Analysis
 
-### Candidate Causes
+### ✅ Root Cause Identified
 
-1. **Preview auth redirect not completing** — Firebase Auth may not redirect/refresh properly on ephemeral PR preview URLs (`https://ropi-aoss-staging--pr-XXX-*.web.app`).
+**Async Auth State Propagation Timing Issue**
 
-2. **Selector mismatch** — The `[data-testid="user-menu-trigger"]` selector may not exist or may have a different name in the deployed build.
+The `signInWithEmail()` helper in `helpers.ts` was waiting for `[data-testid="user-menu-trigger"]` immediately after form submission, but Firebase auth state propagation is asynchronous:
 
-3. **CI credential sync issue** — GitHub Actions secrets may have different passwords than the test accounts configured in Firebase Auth.
+```
+Timeline:
+1. signInWithEmail() submits form
+2. Firebase signInWithEmailAndPassword() resolves → Auth completes server-side
+3. SignInModal shows success message, schedules modal close (500ms)
+4. helpers.ts IMMEDIATELY waits for user-menu-trigger → PROBLEM
+5. onAuthStateChanged() fires asynchronously → Sets currentUser
+6. AuthProvider updates state → loading=false, currentUser set
+7. TopBar re-renders → user-menu-trigger appears
+```
 
-### Investigation Tasks
+**On PR preview URLs, step 5-7 take longer due to:**
+- Cold start latency on ephemeral Firebase Hosting URLs
+- Network latency to Firebase Auth servers
+- No cached auth state
 
-- [ ] Check if `data-testid="user-menu-trigger"` exists in `UserMenu.tsx` or equivalent component
-- [ ] Verify Firebase Auth authorized domains include PR preview URL pattern
-- [ ] Compare CI secrets with Firebase Auth user passwords
-- [ ] Test sign-in flow manually on a PR preview URL
-- [ ] Check if auth state persistence works on preview domains
+The 15s timeout in step 4 expired before steps 5-7 completed.
+
+### Code Locations
+
+| Component | Location | Issue |
+|-----------|----------|-------|
+| `signInWithEmail()` | [helpers.ts#L100](packages/web/e2e/helpers.ts#L100) | Waited for user-menu-trigger immediately after submit |
+| `TopBar` | [TopBar.tsx#L68](packages/web/src/components/layout/TopBar.tsx#L68) | Shows user-menu only when `currentUser` is set AND `loading=false` |
+| `AuthProvider` | [AuthProvider.tsx#L111](packages/web/src/contexts/AuthProvider.tsx#L111) | `onAuthStateChanged` callback is async |
+| `SignInModal` | [SignInModal.tsx#L112](packages/web/src/components/Auth/SignInModal.tsx#L112) | Shows success message before modal closes |
 
 ---
 
-## 3. Proposed Fixes
+## 3. Implemented Fix
 
-### Fix 1: Verify and Update User Menu Test ID
+### Fix: Proper Auth State Sequencing
 
-Check the actual test ID in the codebase and update `helpers.ts` if needed.
+Updated `packages/web/e2e/helpers.ts` `signInWithEmail()` function to properly sequence the async auth flow:
 
 ```typescript
-// helpers.ts line 100 - current
-await page.locator('[data-testid="user-menu-trigger"]').waitFor({ state: 'visible', timeout: 15000 });
+// LP-1.4.6.6: Wait for success message first (confirms Firebase auth completed)
+const successAlert = page.locator('.signin-alert-success');
+await successAlert.waitFor({ state: 'visible', timeout: 15000 });
 
-// If selector changed, update to match actual component
+// Wait for modal to close (it auto-closes after 500ms delay on success)
+await modal.waitFor({ state: 'hidden', timeout: 5000 });
+
+// LP-1.4.6.6: Wait for TopBar loading state to clear
+const loadingIndicator = page.locator('.topbar-loading');
+await loadingIndicator.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
+  // Loading indicator may already be hidden - that's OK
+});
+
+// LP-1.4.6.6: Now wait for user menu with extended timeout
+await page.locator('[data-testid="user-menu-trigger"]').waitFor({ 
+  state: 'visible', 
+  timeout: 20000 
+});
 ```
 
-### Fix 2: Add Preview URL to Firebase Auth Authorized Domains
+**Key Changes:**
+1. Wait for success message first (confirms Firebase auth completed server-side)
+2. Wait for modal to close (confirms app acknowledged success)
+3. Handle TopBar loading state gracefully
+4. Extended timeout for user-menu-trigger from 15s to 20s
 
-Ensure Firebase Auth accepts the PR preview URL pattern:
-- `ropi-aoss-staging--pr-*.web.app`
-- Or use wildcard if supported
+### Commit
 
-### Fix 3: Sync CI Credentials
-
-Reset Firebase Auth passwords for test users and update GitHub Actions secrets:
-- `VITE_E2E_ADMIN_PASSWORD`
-- `VITE_E2E_USER_PASSWORD`
-- `VITE_E2E_UNVERIFIED_PASSWORD`
-
-### Fix 4: Add Auth State Check Before Selector Wait
-
-Add explicit wait for auth state to settle before checking for user menu:
-
-```typescript
-// Wait for Firebase auth to complete
-await page.waitForFunction(() => {
-  return window.__firebaseAuth?.currentUser !== undefined;
-}, { timeout: 10000 });
+```
+fix(e2e): improve auth state sync for PR preview URLs
+6d892ed
 ```
 
 ---
@@ -130,11 +150,16 @@ If fixes cause new issues:
 | PR | Description | Status |
 |----|-------------|--------|
 | #383 | LP-1.4.6.5 Production Rollout (docs-only, E2E skipped) | MERGED |
-| TBD | LP-1.4.6.6 E2E Auth Fix | IN PROGRESS |
+| #384 | LP-1.4.6.6 E2E Auth Fix | IN PROGRESS |
+
+### Commits
+
+- `6d892ed` — fix(e2e): improve auth state sync for PR preview URLs
 
 ### Workflow Runs
 
 - Failing E2E run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20569480914
+- Fix verification: (pending CI)
 
 ---
 

--- a/docs/lisa/HOMER_LP-1.4.6.6_HES.md
+++ b/docs/lisa/HOMER_LP-1.4.6.6_HES.md
@@ -1,0 +1,144 @@
+# LP-1.4.6.6 — Fix E2E Auth Tests on Preview
+
+## Homer Execution Summary (HES) — LP-importer-mapping-recon-1.4.6.6
+
+**LP:** LP-importer-mapping-recon-1.4.6.6  
+**Type:** Fix  
+**Priority:** P1-High  
+**Status:** In Progress  
+**Created:** 2025-12-29  
+**Owner:** Homer (Execution Agent)  
+**Approver:** Lisa (Repository Governance AI & DVA)
+
+---
+
+## 1. Background & Problem Statement
+
+E2E smoke tests on PR previews are failing due to authentication issues. After sign-in, the `[data-testid="user-menu-trigger"]` element never becomes visible, causing `TimeoutError` after 15 seconds.
+
+### Failing Tests
+
+| Test | Location | Error |
+|------|----------|-------|
+| `should allow email/password sign-in for regular user @smoke` | `auth.spec.ts:30` | TimeoutError waiting for user-menu-trigger |
+| `should allow email/password sign-in for admin user @smoke` | `auth.spec.ts:43` | TimeoutError waiting for user-menu-trigger |
+
+### Error Details
+
+```
+TimeoutError: locator.waitFor: Timeout 15000ms exceeded.
+Call log:
+  - waiting for locator('[data-testid="user-menu-trigger"]') to be visible
+
+at helpers.ts:100
+```
+
+---
+
+## 2. Root Cause Analysis
+
+### Candidate Causes
+
+1. **Preview auth redirect not completing** — Firebase Auth may not redirect/refresh properly on ephemeral PR preview URLs (`https://ropi-aoss-staging--pr-XXX-*.web.app`).
+
+2. **Selector mismatch** — The `[data-testid="user-menu-trigger"]` selector may not exist or may have a different name in the deployed build.
+
+3. **CI credential sync issue** — GitHub Actions secrets may have different passwords than the test accounts configured in Firebase Auth.
+
+### Investigation Tasks
+
+- [ ] Check if `data-testid="user-menu-trigger"` exists in `UserMenu.tsx` or equivalent component
+- [ ] Verify Firebase Auth authorized domains include PR preview URL pattern
+- [ ] Compare CI secrets with Firebase Auth user passwords
+- [ ] Test sign-in flow manually on a PR preview URL
+- [ ] Check if auth state persistence works on preview domains
+
+---
+
+## 3. Proposed Fixes
+
+### Fix 1: Verify and Update User Menu Test ID
+
+Check the actual test ID in the codebase and update `helpers.ts` if needed.
+
+```typescript
+// helpers.ts line 100 - current
+await page.locator('[data-testid="user-menu-trigger"]').waitFor({ state: 'visible', timeout: 15000 });
+
+// If selector changed, update to match actual component
+```
+
+### Fix 2: Add Preview URL to Firebase Auth Authorized Domains
+
+Ensure Firebase Auth accepts the PR preview URL pattern:
+- `ropi-aoss-staging--pr-*.web.app`
+- Or use wildcard if supported
+
+### Fix 3: Sync CI Credentials
+
+Reset Firebase Auth passwords for test users and update GitHub Actions secrets:
+- `VITE_E2E_ADMIN_PASSWORD`
+- `VITE_E2E_USER_PASSWORD`
+- `VITE_E2E_UNVERIFIED_PASSWORD`
+
+### Fix 4: Add Auth State Check Before Selector Wait
+
+Add explicit wait for auth state to settle before checking for user menu:
+
+```typescript
+// Wait for Firebase auth to complete
+await page.waitForFunction(() => {
+  return window.__firebaseAuth?.currentUser !== undefined;
+}, { timeout: 10000 });
+```
+
+---
+
+## 4. Test Plan
+
+1. Run E2E auth tests locally against staging
+2. Create a test PR and run E2E workflow
+3. Verify both smoke tests pass:
+   - `should allow email/password sign-in for regular user @smoke`
+   - `should allow email/password sign-in for admin user @smoke`
+4. Confirm no regression in other E2E tests
+
+---
+
+## 5. Rollback Plan
+
+If fixes cause new issues:
+1. Revert the commits in this LP
+2. Re-apply `skip-e2e:docs` label to affected PRs
+3. Document new findings
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Both E2E auth smoke tests pass on PR preview
+- [ ] No timeout errors on `user-menu-trigger` selector
+- [ ] CI workflow completes with success status
+- [ ] CodeRabbit approves changes
+
+---
+
+## 7. Evidence & Artifacts
+
+### Related PRs
+
+| PR | Description | Status |
+|----|-------------|--------|
+| #383 | LP-1.4.6.5 Production Rollout (docs-only, E2E skipped) | MERGED |
+| TBD | LP-1.4.6.6 E2E Auth Fix | IN PROGRESS |
+
+### Workflow Runs
+
+- Failing E2E run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20569480914
+
+---
+
+## 8. Contacts
+
+- **Homer:** Execution Agent
+- **Lisa:** Repository Governance AI & DVA

--- a/docs/lisa/HOMER_LP-1.4.6.6_HES.md
+++ b/docs/lisa/HOMER_LP-1.4.6.6_HES.md
@@ -39,78 +39,79 @@ at helpers.ts:100
 
 ### ✅ Root Cause Identified
 
-**Async Auth State Propagation Timing Issue**
+**Invalid Firebase Auth Credentials in GitHub Secrets**
 
-The `signInWithEmail()` helper in `helpers.ts` was waiting for `[data-testid="user-menu-trigger"]` immediately after form submission, but Firebase auth state propagation is asynchronous:
+After improving error diagnostics, the actual error is now visible:
 
 ```
-Timeline:
-1. signInWithEmail() submits form
-2. Firebase signInWithEmailAndPassword() resolves → Auth completes server-side
-3. SignInModal shows success message, schedules modal close (500ms)
-4. helpers.ts IMMEDIATELY waits for user-menu-trigger → PROBLEM
-5. onAuthStateChanged() fires asynchronously → Sets currentUser
-6. AuthProvider updates state → loading=false, currentUser set
-7. TopBar re-renders → user-menu-trigger appears
+Error: Sign-in failed with error: Firebase: Error (auth/invalid-credential).
 ```
 
-**On PR preview URLs, step 5-7 take longer due to:**
-- Cold start latency on ephemeral Firebase Hosting URLs
-- Network latency to Firebase Auth servers
-- No cached auth state
+This means the passwords stored in GitHub Actions secrets do not match the passwords in Firebase Auth for the test users:
+- `E2E_ADMIN_PASSWORD` → `theo@shiekh.com`
+- `E2E_USER_PASSWORD` → `user@shiekh.com`
 
-The 15s timeout in step 4 expired before steps 5-7 completed.
+The original "timeout" errors were a symptom of the sign-in failing (no success message ever appeared because auth failed).
 
-### Code Locations
+### Timeline Analysis
 
-| Component | Location | Issue |
-|-----------|----------|-------|
-| `signInWithEmail()` | [helpers.ts#L100](packages/web/e2e/helpers.ts#L100) | Waited for user-menu-trigger immediately after submit |
-| `TopBar` | [TopBar.tsx#L68](packages/web/src/components/layout/TopBar.tsx#L68) | Shows user-menu only when `currentUser` is set AND `loading=false` |
-| `AuthProvider` | [AuthProvider.tsx#L111](packages/web/src/contexts/AuthProvider.tsx#L111) | `onAuthStateChanged` callback is async |
-| `SignInModal` | [SignInModal.tsx#L112](packages/web/src/components/Auth/SignInModal.tsx#L112) | Shows success message before modal closes |
+```
+1. signInWithEmail() submits form with credentials from GitHub secrets
+2. Firebase Auth rejects: auth/invalid-credential
+3. SignInModal shows ERROR message (not success)
+4. Original code waited only for success message → Timeout
+5. User-menu-trigger never appears because user is not authenticated
+```
+
+### Configuration Mismatch
+
+| Component | Value | Status |
+|-----------|-------|--------|
+| `VITE_E2E_ADMIN_EMAIL` | `theo@shiekh.com` | ✅ Hardcoded in workflow |
+| `VITE_E2E_USER_EMAIL` | `user@shiekh.com` | ✅ Hardcoded in workflow |
+| `E2E_ADMIN_PASSWORD` | `secrets.E2E_ADMIN_PASSWORD` | ❌ Invalid |
+| `E2E_USER_PASSWORD` | `secrets.E2E_USER_PASSWORD` | ❌ Invalid |
 
 ---
 
-## 3. Implemented Fix
+## 3. Implemented Fixes
 
-### Fix: Proper Auth State Sequencing
+### Fix 1: Improved Error Diagnostics (Complete)
 
-Updated `packages/web/e2e/helpers.ts` `signInWithEmail()` function to properly sequence the async auth flow:
+Updated `packages/web/e2e/helpers.ts` to capture and report the actual auth error:
 
 ```typescript
-// LP-1.4.6.6: Wait for success message first (confirms Firebase auth completed)
-const successAlert = page.locator('.signin-alert-success');
-await successAlert.waitFor({ state: 'visible', timeout: 15000 });
+// Wait for either outcome with extended timeout
+const outcome = await Promise.race([
+  successAlert.waitFor({ state: 'visible', timeout: 20000 }).then(() => 'success'),
+  errorAlert.waitFor({ state: 'visible', timeout: 20000 }).then(() => 'error'),
+]).catch(() => 'timeout');
 
-// Wait for modal to close (it auto-closes after 500ms delay on success)
-await modal.waitFor({ state: 'hidden', timeout: 5000 });
-
-// LP-1.4.6.6: Wait for TopBar loading state to clear
-const loadingIndicator = page.locator('.topbar-loading');
-await loadingIndicator.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
-  // Loading indicator may already be hidden - that's OK
-});
-
-// LP-1.4.6.6: Now wait for user menu with extended timeout
-await page.locator('[data-testid="user-menu-trigger"]').waitFor({ 
-  state: 'visible', 
-  timeout: 20000 
-});
+if (outcome === 'error') {
+  const errorMessage = await errorAlert.textContent();
+  throw new Error(`Sign-in failed with error: ${errorMessage}`);
+}
 ```
 
-**Key Changes:**
-1. Wait for success message first (confirms Firebase auth completed server-side)
-2. Wait for modal to close (confirms app acknowledged success)
-3. Handle TopBar loading state gracefully
-4. Extended timeout for user-menu-trigger from 15s to 20s
+### Fix 2: Credential Sync Required (Manual)
 
-### Commit
+**Action Required by Repository Owner:**
 
-```
-fix(e2e): improve auth state sync for PR preview URLs
-6d892ed
-```
+1. Reset passwords for E2E test users in Firebase Auth Console:
+   - `theo@shiekh.com` (admin)
+   - `user@shiekh.com` (regular user)
+   - `unverified@shiekh.com` (unverified user)
+
+2. Update GitHub Actions secrets with new passwords:
+   - `E2E_ADMIN_PASSWORD`
+   - `E2E_USER_PASSWORD`
+   - `E2E_UNVERIFIED_PASSWORD`
+
+### Commits
+
+- `6d892ed` — fix(e2e): improve auth state sync for PR preview URLs
+- `1fe0fda` — docs: update HES with root cause analysis
+- `1521dc4` — fix(e2e): improve auth error diagnostics
 
 ---
 
@@ -136,8 +137,11 @@ If fixes cause new issues:
 
 ## 6. Acceptance Criteria
 
+- [x] Improved error diagnostics show actual auth failure reason
+- [x] Error message clearly shows `auth/invalid-credential`
+- [ ] Firebase Auth passwords reset for test users (manual step)
+- [ ] GitHub secrets updated with new passwords (manual step)
 - [ ] Both E2E auth smoke tests pass on PR preview
-- [ ] No timeout errors on `user-menu-trigger` selector
 - [ ] CI workflow completes with success status
 - [ ] CodeRabbit approves changes
 
@@ -150,20 +154,41 @@ If fixes cause new issues:
 | PR | Description | Status |
 |----|-------------|--------|
 | #383 | LP-1.4.6.5 Production Rollout (docs-only, E2E skipped) | MERGED |
-| #384 | LP-1.4.6.6 E2E Auth Fix | IN PROGRESS |
+| #384 | LP-1.4.6.6 E2E Auth Fix | IN PROGRESS — Awaiting credential sync |
 
 ### Commits
 
 - `6d892ed` — fix(e2e): improve auth state sync for PR preview URLs
+- `1fe0fda` — docs: update HES with root cause analysis
+- `1521dc4` — fix(e2e): improve auth error diagnostics
 
 ### Workflow Runs
 
-- Failing E2E run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20569480914
-- Fix verification: (pending CI)
+- Original failing run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20569480914
+- Diagnostic run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20570363549
+  - Revealed: `Firebase: Error (auth/invalid-credential)`
 
 ---
 
-## 8. Contacts
+## 8. Next Steps (Manual)
+
+**Repository Owner Action Required:**
+
+1. **Firebase Console** → Authentication → Users
+   - Find `theo@shiekh.com` and reset password
+   - Find `user@shiekh.com` and reset password
+   - Find `unverified@shiekh.com` and reset password
+
+2. **GitHub Repository Settings** → Secrets and variables → Actions
+   - Update `E2E_ADMIN_PASSWORD` with new password for `theo@shiekh.com`
+   - Update `E2E_USER_PASSWORD` with new password for `user@shiekh.com`
+   - Update `E2E_UNVERIFIED_PASSWORD` with new password for `unverified@shiekh.com`
+
+3. **Re-run E2E tests** on PR #384 to verify fix
+
+---
+
+## 9. Contacts
 
 - **Homer:** Execution Agent
 - **Lisa:** Repository Governance AI & DVA

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -101,10 +101,25 @@ export async function signInWithEmail(
   // Submit form
   await page.locator('[data-testid="signin-submit"]').click();
   
-  // LP-1.4.6.6: Wait for success message first (confirms Firebase auth completed)
-  // This appears before the modal closes and indicates auth succeeded server-side
+  // LP-1.4.6.6: Wait for auth response (either success or error)
+  // This helps diagnose auth failures on preview URLs
   const successAlert = page.locator('.signin-alert-success');
-  await successAlert.waitFor({ state: 'visible', timeout: 15000 });
+  const errorAlert = page.locator('.signin-alert-error');
+  
+  // Wait for either outcome with extended timeout for preview URLs
+  const outcome = await Promise.race([
+    successAlert.waitFor({ state: 'visible', timeout: 20000 }).then(() => 'success'),
+    errorAlert.waitFor({ state: 'visible', timeout: 20000 }).then(() => 'error'),
+  ]).catch(() => 'timeout');
+  
+  if (outcome === 'error') {
+    const errorMessage = await errorAlert.textContent();
+    throw new Error(`Sign-in failed with error: ${errorMessage}`);
+  }
+  
+  if (outcome === 'timeout') {
+    throw new Error('Sign-in timed out - no success or error message appeared');
+  }
   
   // Wait for modal to close (it auto-closes after 500ms delay on success)
   await modal.waitFor({ state: 'hidden', timeout: 5000 });

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -69,7 +69,12 @@ export const TEST_USERS = {
  * 2. Wait for modal to appear
  * 3. Fill email and password fields
  * 4. Submit the form
- * 5. Wait for modal to close and user menu to appear
+ * 5. Wait for success message (confirms Firebase auth completed)
+ * 6. Wait for modal to close
+ * 7. Wait for auth state to propagate (loading clears, user-menu appears)
+ * 
+ * LP-1.4.6.6: Enhanced waiting logic to handle async auth state propagation
+ * on PR preview URLs where latency may be higher.
  */
 export async function signInWithEmail(
   page: Page,
@@ -96,11 +101,24 @@ export async function signInWithEmail(
   // Submit form
   await page.locator('[data-testid="signin-submit"]').click();
   
-  // Wait for user menu to appear (indicates successful sign-in)
-  await page.locator('[data-testid="user-menu-trigger"]').waitFor({ state: 'visible', timeout: 15000 });
+  // LP-1.4.6.6: Wait for success message first (confirms Firebase auth completed)
+  // This appears before the modal closes and indicates auth succeeded server-side
+  const successAlert = page.locator('.signin-alert-success');
+  await successAlert.waitFor({ state: 'visible', timeout: 15000 });
   
   // Wait for modal to close (it auto-closes after 500ms delay on success)
   await modal.waitFor({ state: 'hidden', timeout: 5000 });
+  
+  // LP-1.4.6.6: Wait for TopBar loading state to clear
+  // TopBar shows "Loading..." while auth state propagates via onAuthStateChanged
+  const loadingIndicator = page.locator('.topbar-loading');
+  await loadingIndicator.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
+    // Loading indicator may already be hidden or never shown - that's OK
+  });
+  
+  // LP-1.4.6.6: Now wait for user menu to appear with extended timeout
+  // This confirms the full auth state has propagated to the UI
+  await page.locator('[data-testid="user-menu-trigger"]').waitFor({ state: 'visible', timeout: 20000 });
 }
 
 /**


### PR DESCRIPTION
## LP-1.4.6.6 — Fix E2E Auth Tests on Preview

### Problem

E2E smoke tests on PR previews are failing due to authentication issues. After sign-in, the `[data-testid="user-menu-trigger"]` element never becomes visible, causing `TimeoutError` after 15 seconds.

### Failing Tests

| Test | Location | Error |
|------|----------|-------|
| `should allow email/password sign-in for regular user @smoke` | `auth.spec.ts:30` | TimeoutError |
| `should allow email/password sign-in for admin user @smoke` | `auth.spec.ts:43` | TimeoutError |

### Root Cause Candidates

1. **Preview auth redirect not completing** — Firebase Auth may not redirect/refresh properly on ephemeral PR preview URLs
2. **Selector mismatch** — `[data-testid="user-menu-trigger"]` may not exist in the current build
3. **CI credential sync issue** — GitHub Actions secrets may have different passwords

### Proposed Fixes

1. Verify `data-testid="user-menu-trigger"` exists in UserMenu component
2. Add PR preview URL pattern to Firebase Auth authorized domains
3. Sync CI credentials with Firebase Auth user passwords
4. Add explicit auth state wait before checking for user menu

### Test Plan

- [ ] Run E2E auth tests locally against staging
- [ ] Create test PR and verify E2E workflow passes
- [ ] Confirm both smoke tests pass

### Rollback

Revert commits and re-apply `skip-e2e:docs` label to affected PRs.

### Related

- PR #383 (LP-1.4.6.5) — Merged with E2E skipped (docs-only)
- Failing E2E run: https://github.com/twgallo13/ROPI-V2.1/actions/runs/20569480914

---

**LP:** LP-importer-mapping-recon-1.4.6.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive HES incident document covering background, root cause, remediation steps, test/rollback plans, acceptance criteria, timelines, and verification artifacts.

* **Tests**
  * Hardened end-to-end authentication checks with robust success/error/timeout handling and improved post-sign-in verification to reduce flaky auth-related failures.

* **Chores**
  * Updated e2e test configuration to use a new default test user email for non-emulator runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->