### PR TITLE
LP-importer-mapping-recon-1.4.6.7 — Header fallback for last_received

### DIFF
--- a/docs/lisa/HOMER_LP-1.4.6.7_HES.md
+++ b/docs/lisa/HOMER_LP-1.4.6.7_HES.md
@@ -1,0 +1,238 @@
+# HOMER Execution Summary (HES) — LP-importer-mapping-recon-1.4.6.7
+
+**Homer** — Autonomous Execution Agent  
+**LP**: LP-importer-mapping-recon-1.4.6.7 — Header fallback for `last_received`  
+**Date**: 2025-12-29  
+**PR**: #386  
+**Branch**: `lp/importer-mapping-recon/1.4.6.7-header-fallback`  
+**Status**: ✅ Implementation Complete — Awaiting Staging Verification
+
+---
+
+## Executive Summary
+
+Implemented UI fix for product header `last_received` display. The header now reads from `attributes.last_received` (normalized ISO) with fallback to `core.lastReceived` (vendor format), ensuring the date always renders when data is available.
+
+**Root Cause** (LP-1.4.6.4 diagnosis):  
+- Product normalization succeeded: `attributes.last_received = 2025-12-18T00:00:00.000Z` exists in Firestore.
+- Product header displayed `—` because it only read from top-level `product.last_received` (which was absent).
+- The UI did not check `attributes.last_received`.
+
+**Solution**:  
+- Add `formatForDisplayYYYYMMDD()` to `dateUtils` for deterministic YYYY-MM-DD display.
+- Update `ProductHeader` to prioritize `attributes.last_received`, fallback to `product.last_received`.
+- Add comprehensive unit tests.
+
+---
+
+## Files Changed
+
+### 1. `packages/web/src/utils/dateUtils.ts`
+
+**Change**: Added `formatForDisplayYYYYMMDD()` function.
+
+**Purpose**:  
+- Deterministic UTC-based formatter for header date fields.
+- Accepts vendor formats (MM/DD/YYYY, MM-DD-YYYY, MM/DD/YY) and ISO timestamps.
+- Returns `YYYY-MM-DD` for concise display.
+
+**Code**:
+```typescript
+export function formatForDisplayYYYYMMDD(input: string | undefined | null): string | undefined {
+  if (!input) return undefined;
+  const iso = parseToIsoDateString(input);
+  if (!iso) return undefined;
+  const dt = new Date(iso);
+  const yyyy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+```
+
+---
+
+### 2. `packages/web/src/components/product/ProductHeader.tsx`
+
+**Changes**:
+- Import `formatForDisplayYYYYMMDD` from `dateUtils`.
+- Add fallback logic in component body:
+  ```typescript
+  const rawLastFromAttributes = product?.attributes?.last_received;
+  const rawLastFromCore = product?.last_received;
+  const rawLast = rawLastFromAttributes ?? rawLastFromCore;
+  const lastDisplay = formatForDisplayYYYYMMDD(rawLast) ?? '—';
+  ```
+- Update JSX to use `lastDisplay` and add `data-testid`:
+  ```tsx
+  <span className="product-header__value" data-testid="header-last-received">
+    {lastDisplay}
+  </span>
+  ```
+
+**Behavior**:
+- Reads `attributes.last_received` first.
+- Falls back to `core.last_received` if attributes absent.
+- Formats with `formatForDisplayYYYYMMDD()`.
+- Renders `—` if unparseable or missing.
+
+---
+
+### 3. `packages/web/src/components/product/__tests__/ProductHeader.date.test.tsx`
+
+**New Test File**: Comprehensive unit tests for header date display fallback.
+
+**Test Cases** (8 total, all pass ✅):
+1. Display date from `attributes.last_received` (ISO format) → `2025-12-18`
+2. Display date from `core.last_received` when attributes absent (vendor format) → `2025-12-18`
+3. Prefer `attributes.last_received` over `core` field
+4. Display `—` when both absent
+5. Display `—` when last_received is unparseable
+6. Handle two-digit year vendor format (`12/18/25`)
+7. Handle hyphen-separated vendor format (`12-18-2025`)
+8. Display `—` when `attributes.last_received` is empty string
+
+**Test Results**:
+```
+✓ src/components/product/__tests__/ProductHeader.date.test.tsx (8 tests) 67ms
+```
+
+---
+
+## Unit Test Output
+
+**File**: `/tmp/web-tests-productHeader-date-output.txt`
+
+```
+✓ src/components/product/__tests__/ProductHeader.date.test.tsx  (8 tests) 67ms
+```
+
+**All tests pass**. No regressions introduced in ProductHeader date display logic.
+
+---
+
+## Commit & PR Details
+
+**Commit SHA**: `7d7d52b`  
+**Commit Message**:
+```
+feat(web): LP-1.4.6.7 header fallback to attributes.last_received
+
+- Add formatForDisplayYYYYMMDD() to dateUtils for deterministic YYYY-MM-DD display
+- Update ProductHeader to read from attributes.last_received with fallback to core last_received
+- Add data-testid='header-last-received' for testability
+- Add comprehensive unit tests covering ISO, vendor format, fallback, and edge cases
+- All 8 ProductHeader date tests pass
+
+LP-importer-mapping-recon-1.4.6.7
+```
+
+**PR**: [#386](https://github.com/twgallo13/ROPI-V2.1/pull/386)  
+**PR Title**: `LP-importer-mapping-recon-1.4.6.7 — Header fallback for last_received`  
+**Base Branch**: `aoss-main`  
+**Head Branch**: `lp/importer-mapping-recon/1.4.6.7-header-fallback`
+
+**Labels**: `type:fix`
+
+---
+
+## Staging Verification Plan
+
+### Pre-Verification (Completed in LP-1.4.6.4)
+- Firestore already contains normalized `attributes.last_received = 2025-12-18T00:00:00.000Z` for product `211737-90h1-8ab`.
+- Dry-run and apply logs saved:
+  - `/tmp/normalize-211737-90h1-8ab-dry.log`
+  - `/tmp/normalize-211737-90h1-8ab-apply.log`
+  - `/tmp/normalize-211737-90h1-8ab-firestore-full.json`
+
+### Post-Merge Verification (Required)
+
+After PR merges and staging deploys, perform these steps:
+
+#### 1. UI Verification (Authenticated Editor Session)
+
+**Product**: `211737-90h1-8ab`  
+**URL**: `https://ropi-aoss-staging.web.app/products/211737-90h1-8ab?tab=launch`
+
+**Steps**:
+1. Sign in as editor on staging (use credentials from LP-1.4.6.6).
+2. Navigate to product URL.
+3. Hard refresh (Ctrl/Cmd+Shift+R) to avoid stale client caches.
+4. Observe product header "LAST RECEIVED" field.
+
+**Expected Result**: Header displays `2025-12-18` (or formatted date based on `formatForDisplayYYYYMMDD`).
+
+**Artifacts to Collect**:
+- Screenshot: `/tmp/normalize-211737-90h1-8ab-ui-after-headerfix.png`
+- Header outerHTML: `/tmp/product-header-211737-90h1-8ab-after.html`
+- Console logs: `/tmp/ui-signed-in-211737-90h1-8ab-console-after.log`
+- Input values: append to `/tmp/ui-input-values.txt`
+
+#### 2. No Console Errors
+
+Confirm no errors related to date formatting appear in browser console during page load or save.
+
+#### 3. Firestore Proof
+
+Reuse existing Firestore dump (already present from LP-1.4.6.4):
+- `/tmp/normalize-211737-90h1-8ab-firestore-full.json`
+- Shows `attributes.last_received = 2025-12-18T00:00:00.000Z` and `_meta`.
+
+---
+
+## Acceptance Criteria
+
+- [x] Unit tests pass (8/8)
+- [x] PR created and labeled
+- [ ] CodeRabbit review success
+- [ ] On staging, header displays `2025-12-18` for product `211737-90h1-8ab`
+- [ ] No console errors during page load or save
+- [ ] Staging verification artifacts collected
+
+---
+
+## Governance
+
+**Rollback Plan**: Small, reversible UI change. If regression occurs (e.g., header displays incorrectly for other date fields), revert PR #386.
+
+**No Migration Required**: UI-only change. No Firestore writes or schema changes.
+
+---
+
+## Next Steps
+
+1. **CodeRabbit Review**: Request review via GitHub PR interface.
+2. **Merge**: After CodeRabbit approval, merge to `aoss-main`.
+3. **Staging Deploy**: Wait for automatic staging deployment.
+4. **Verification**: Execute staging verification plan (section above).
+5. **Final Report**: Return to Lisa with artifacts and completion status.
+
+---
+
+## Artifacts Generated
+
+### Implementation Artifacts
+- `packages/web/src/utils/dateUtils.ts` (modified)
+- `packages/web/src/components/product/ProductHeader.tsx` (modified)
+- `packages/web/src/components/product/__tests__/ProductHeader.date.test.tsx` (new)
+- Commit: `7d7d52b`
+- PR: #386
+
+### Test Artifacts
+- `/tmp/web-tests-productHeader-date-output.txt` (unit test results)
+
+### Pre-Verification Artifacts (from LP-1.4.6.4)
+- `/tmp/normalize-211737-90h1-8ab-dry.log`
+- `/tmp/normalize-211737-90h1-8ab-apply.log`
+- `/tmp/normalize-211737-90h1-8ab-firestore-full.json`
+- `/tmp/normalize-211737-90h1-8ab-ui-final.png` (before fix, shows `—`)
+
+### Staging Verification Artifacts (Post-Merge, Pending)
+- `/tmp/normalize-211737-90h1-8ab-ui-after-headerfix.png`
+- `/tmp/product-header-211737-90h1-8ab-after.html`
+- `/tmp/ui-signed-in-211737-90h1-8ab-console-after.log`
+- `/tmp/ui-input-values.txt` (updated)
+
+---
+
+**End of HES**

--- a/packages/web/src/components/product/ProductHeader.tsx
+++ b/packages/web/src/components/product/ProductHeader.tsx
@@ -1,4 +1,5 @@
 import type { Product } from '../../types/product';
+import { formatForDisplayYYYYMMDD } from '../../utils/dateUtils';
 import './ProductHeader.css';
 
 /**
@@ -84,6 +85,12 @@ function ProductHeader({ product, onSave, onPublish, onBack }: ProductHeaderProp
   const mediaStatus = mediaStatusConfig[mediaStatusKey] || mediaStatusConfig['missing'];
   const isActive = product.product_is_active ?? false;
 
+  // LP-1.4.6.7: Fallback to attributes.last_received when core field is absent
+  const rawLastFromAttributes = product?.attributes?.last_received;
+  const rawLastFromCore = product?.last_received;
+  const rawLast = rawLastFromAttributes ?? rawLastFromCore;
+  const lastDisplay = formatForDisplayYYYYMMDD(rawLast) ?? '—';
+
   return (
     <header className="product-header" role="banner" aria-label="Product Header">
       {/* Navigation Row */}
@@ -147,8 +154,8 @@ function ProductHeader({ product, onSave, onPublish, onBack }: ProductHeaderProp
         {/* Last Received Date */}
         <div className="product-header__field">
           <span className="product-header__label">Last Received</span>
-          <span className="product-header__value">
-            {formatDate(product.last_received)}
+          <span className="product-header__value" data-testid="header-last-received">
+            {lastDisplay}
           </span>
         </div>
 

--- a/packages/web/src/components/product/__tests__/ProductHeader.date.test.tsx
+++ b/packages/web/src/components/product/__tests__/ProductHeader.date.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Product Header Date Display Tests — LP-1.4.6.7
+ * 
+ * Tests for the header fallback logic that displays last_received from:
+ * 1. attributes.last_received (normalized ISO)
+ * 2. core last_received field (vendor format)
+ * 3. Empty state when both absent
+ * 
+ * @see packages/web/src/components/product/ProductHeader.tsx
+ * @see HOMER_LP-1.4.6.7_HES.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ProductHeader from '../ProductHeader';
+import type { Product } from '../../../types/product';
+
+// Minimal product mock for header testing
+const createProductMock = (overrides?: Partial<Product>): Product => ({
+  id: 'test-product-id',
+  sku: 'TEST-SKU',
+  mpn: 'TEST-MPN',
+  status: 'draft',
+  product_is_active: true,
+  total_inv: 0,
+  warehouse_inv: 0,
+  store_inv: 0,
+  media_status: 'missing',
+  websites: [],
+  ...overrides,
+} as Product);
+
+const mockHandlers = {
+  onSave: () => {},
+  onPublish: () => {},
+  onBack: () => {},
+};
+
+describe('ProductHeader - Last Received Display', () => {
+  it('should display date from attributes.last_received (ISO format)', () => {
+    const product = createProductMock({
+      attributes: {
+        last_received: '2025-12-18T00:00:00.000Z',
+      },
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('2025-12-18');
+  });
+
+  it('should display date from core last_received when attributes absent (vendor format)', () => {
+    const product = createProductMock({
+      last_received: '12/18/2025',
+      attributes: undefined,
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('2025-12-18');
+  });
+
+  it('should prefer attributes.last_received over core field', () => {
+    const product = createProductMock({
+      last_received: '12/26/2025', // vendor format in core
+      attributes: {
+        last_received: '2025-12-18T00:00:00.000Z', // ISO in attributes
+      },
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    // Should display attributes value, not core
+    expect(lastReceivedElement).toHaveTextContent('2025-12-18');
+  });
+
+  it('should display "—" when both attributes and core last_received are absent', () => {
+    const product = createProductMock({
+      last_received: undefined,
+      attributes: undefined,
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('—');
+  });
+
+  it('should display "—" when last_received is unparseable', () => {
+    const product = createProductMock({
+      attributes: {
+        last_received: 'invalid-date-string',
+      },
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('—');
+  });
+
+  it('should handle two-digit year vendor format (12/18/25)', () => {
+    const product = createProductMock({
+      last_received: '12/18/25',
+      attributes: undefined,
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('2025-12-18');
+  });
+
+  it('should handle hyphen-separated vendor format (12-18-2025)', () => {
+    const product = createProductMock({
+      last_received: '12-18-2025',
+      attributes: undefined,
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('2025-12-18');
+  });
+
+  it('should display "—" when attributes.last_received is empty string', () => {
+    const product = createProductMock({
+      attributes: {
+        last_received: '',
+      },
+    });
+
+    render(<ProductHeader product={product} {...mockHandlers} />);
+
+    const lastReceivedElement = screen.getByTestId('header-last-received');
+    expect(lastReceivedElement).toHaveTextContent('—');
+  });
+});

--- a/packages/web/src/utils/dateUtils.ts
+++ b/packages/web/src/utils/dateUtils.ts
@@ -175,3 +175,34 @@ export function formatForDisplay(
     day: 'numeric',
   });
 }
+
+/**
+ * Format a date for concise display in headers (YYYY-MM-DD format).
+ * 
+ * LP-1.4.6.7: Deterministic formatter for product header date fields.
+ * Accepts vendor formats (MM/DD/YYYY) and ISO timestamps, returns YYYY-MM-DD
+ * for consistent UI display. Uses UTC to avoid timezone ambiguity.
+ * 
+ * @param input - Date string in vendor or ISO format
+ * @returns Date string in YYYY-MM-DD format, or undefined if unparseable
+ * 
+ * @example
+ * formatForDisplayYYYYMMDD('2025-12-18T00:00:00.000Z') // '2025-12-18'
+ * formatForDisplayYYYYMMDD('12/18/2025')               // '2025-12-18'
+ * formatForDisplayYYYYMMDD('12/18/25')                 // '2025-12-18'
+ * formatForDisplayYYYYMMDD(undefined)                  // undefined
+ */
+export function formatForDisplayYYYYMMDD(input: string | undefined | null): string | undefined {
+  if (!input) return undefined;
+  
+  // Parse to ISO first (handles vendor and ISO formats)
+  const iso = parseToIsoDateString(input);
+  if (!iso) return undefined;
+  
+  // Extract YYYY-MM-DD from ISO timestamp (UTC-based)
+  const dt = new Date(iso);
+  const yyyy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}


### PR DESCRIPTION
## Summary

Implements deterministic UI fix for product header `last_received` display. The header now reads from `attributes.last_received` (normalized ISO) with fallback to `core.lastReceived` (vendor format), ensuring the date always renders when available.

## Context

- **Related LP**: LP-importer-mapping-recon-1.4.6.4
- **Diagnosis**: [HOMER_LP-1.4.6.4_HES.md](https://github.com/twgallo13/ROPI-V2.1/blob/aoss-main/docs/lisa/HOMER_LP-1.4.6.4_HES.md)
- **Root Cause**: Product header displayed `—` for `last_received` despite normalized value existing in `attributes.last_received`. Header component only read from top-level `product.last_received`.

## Changes

### 1. dateUtils Enhancement
- **File**: `packages/web/src/utils/dateUtils.ts`
- Added `formatForDisplayYYYYMMDD()` function
- Deterministic UTC-based YYYY-MM-DD formatter
- Accepts vendor formats (MM/DD/YYYY, MM-DD-YYYY, MM/DD/YY) and ISO timestamps
- Returns `YYYY-MM-DD` for concise header display

### 2. ProductHeader Fallback
- **File**: `packages/web/src/components/product/ProductHeader.tsx`
- Read from `product?.attributes?.last_received` first
- Fallback to `product?.last_received` if attributes absent
- Format with `formatForDisplayYYYYMMDD()` 
- Render `—` if unparseable
- Added `data-testid="header-last-received"` for testability

### 3. Unit Tests
- **File**: `packages/web/src/components/product/__tests__/ProductHeader.date.test.tsx`
- 8 comprehensive test cases
- **All tests pass** ✅
- Covers:
  - ISO format in attributes.last_received
  - Vendor format in core last_received
  - Preference for attributes over core
  - Empty state handling
  - Unparseable input
  - Two-digit year formats
  - Hyphen-separated formats

## Test Results

```
✓ src/components/product/__tests__/ProductHeader.date.test.tsx (8 tests) 67ms
```

## Verification

After merge and staging deploy:
1. Product `211737-90h1-8ab` should display `2025-12-18` in header
2. No console errors during page load
3. Firestore already contains normalized `attributes.last_received`

## Governance

- **Labels**: `lp:importer-mapping-recon-1.4.6.7`, `type:fix`, `p2-medium`, `blocked:coderabbit-review`, `cleanup:required`
- **Reviewers**: Web owner, QA
- **HES**: docs/lisa/HOMER_LP-1.4.6.7_HES.md (to be added)

## Rollback Plan

Small, reversible UI change. If regression occurs, revert this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Last Received date display with enhanced fallback mechanism when data is unavailable.
  * Better handling of vendor and ISO date formats with consistent YYYY-MM-DD display.
  * Shows em dash when no date data is available.

* **Tests**
  * Added comprehensive test coverage for date display logic across various scenarios and formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->