### PR TITLE
docs(meta): canonicalize attributes meta path — LP-service-account-ropi-deploy-1.0.0

### DIFF
--- a/docs/ATTRIBUTE-REGISTRY.md
+++ b/docs/ATTRIBUTE-REGISTRY.md
@@ -98,7 +98,7 @@ Firestore: settings/attributes/keys/{attributeId}
 1. **Load Registry** — Reads `attributeRegistry.json` from SDK package
 2. **Validate** — Ensures all attributes have required fields
 3. **Upsert to Firestore** — Writes/updates each attribute to `settings/attributes/keys/{attributeId}`
-4. **Write Metadata** — Updates `settings/attributes/meta` with:
+4. **Write Metadata** — Updates `settings/attributesMeta` with:
    - `registry_version` — Version from JSON file
    - `lastSyncedAt` — ISO timestamp
    - `lastSyncedBy` — Actor (system, admin email, etc.)
@@ -206,7 +206,7 @@ function ProductEditor() {
 
 6. **Verify**
    - Check Firestore: `settings/attributes/keys/new_field` exists
-   - Check Firestore: `settings/attributes/meta.registry_version` matches JSON
+   - Check Firestore: `settings/attributesMeta.registry_version` matches JSON
    - Open Product Editor and verify new field appears
 
 ## Validation Rules
@@ -278,7 +278,7 @@ match /settings/attributes/keys/{attributeId} {
 }
 ```
 
-### `settings/attributes/meta`
+### `settings/attributesMeta`
 
 ```javascript
 {
@@ -322,7 +322,7 @@ The registry uses semantic versioning:
 
 4. **Check Firestore meta:**
    - Open Firebase Console
-   - Navigate to Firestore → `settings/attributes/meta`
+   - Navigate to Firestore → `settings/attributesMeta`
    - Verify `registry_version` matches local file
 
 ### Attributes not appearing in UI

--- a/scripts/verify-attributes-meta.js
+++ b/scripts/verify-attributes-meta.js
@@ -35,7 +35,7 @@ const db = admin.firestore();
   }
   
   const meta = metaSnap.data();
-  console.log('settings/attributes/meta:', JSON.stringify(meta, null, 2));
+  console.log('settings/attributesMeta:', JSON.stringify(meta, null, 2));
 
   // Read local registry version
   const registryPath = path.resolve(__dirname, '../packages/sdk/config/attributeRegistry.json');


### PR DESCRIPTION
## Summary
Corrects documentation to use the canonical Firestore meta path `settings/attributesMeta` (single-doc path) instead of the previously documented `settings/attributes/meta` (which implied a subcollection structure).

## Changes
- `docs/ATTRIBUTE-REGISTRY.md`: 4 path corrections
- `scripts/verify-attributes-meta.js`: 1 log message fix

## LP
`LP-service-account-ropi-deploy-1.0.0` — Step E (documentation cleanup)

## Verification
- Runtime code in `packages/api/src/tasks/syncAttributeRegistry.ts` already uses correct path
- Firestore `settings/attributesMeta` doc exists and verified
- No functional change; documentation-only fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated attribute registry documentation, including Firestore schema, sync/write steps, validation checks, and troubleshooting guides to reflect revised metadata path naming conventions.

* **Chores**
  * Updated internal verification tooling to align with new metadata path naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->