### PR TITLE
docs(ai-boot): add Quick Prompts for starting & resuming phases — LP-service-account-ropi-deploy-1.0.0

### DIFF
--- a/AI_BOOTSTRAP.md
+++ b/AI_BOOTSTRAP.md
@@ -30,4 +30,113 @@ ROPI AOSS — Admin Order & Staging System. Monorepo: `packages/cli`, `packages/
 - `registry_firestore_meta`: `settings/attributesMeta`  
 - `lp_label_prefix`: `lp:` (labels start `lp:<PhaseSlug>-<SemVer>`)
 
+---
+
+## Quick Prompts (copy/paste for chat)
+
+Use these prompts to start or resume phases without terminal commands.
+
+### 1. Start a New Phase
+
+```
+Start phase "<PhaseSlug>" version <SemVer>.
+
+Before any action:
+1. Read AI_BOOTSTRAP.md and GOVERNANCE.md.
+2. List open PRs with lp:* labels — confirm no conflicting phase.
+3. Request explicit Phase Readiness (PRD link, acceptance criteria, scope).
+4. Do NOT create branches or PRs until I approve the PRD.
+
+Output: Draft PRD for my review.
+```
+
+### 2. Resume an Existing Chat
+
+```
+Resume phase "<PhaseSlug>-<SemVer>".
+
+Steps:
+1. Read AI_BOOTSTRAP.md and GOVERNANCE.md.
+2. List open PRs with label lp:<PhaseSlug>-<SemVer>.
+3. Summarize: current step, last HES, pending actions.
+4. Wait for my instruction before any new action.
+
+Output: Status summary and next recommended action.
+```
+
+### 3. Request a HES (Handoff Evidence Summary)
+
+```
+Produce a HES for step <StepLetter> of phase "<PhaseSlug>-<SemVer>".
+
+Include:
+- Branch and commit SHA
+- PR number and URL
+- Files changed (with line counts)
+- CI status (gh pr checks output)
+- Labels applied
+- Any verification evidence (grep, curl, Firestore checks)
+- Final line: "Phase step <StepLetter>: VERIFIED SUCCESS" or "BLOCKED: <reason>"
+```
+
+### 4. Request a PRD (Phase Requirements Document)
+
+```
+Draft a PRD for phase "<PhaseSlug>-<SemVer>".
+
+Include:
+- Phase title and slug
+- Problem statement (one paragraph)
+- Acceptance criteria (numbered list)
+- Scope: files, packages, Firestore paths affected
+- Out of scope (explicit exclusions)
+- Steps (A, B, C, ...) with HES checkpoints
+- Rollback plan
+
+Output: PRD for my approval before any implementation.
+```
+
+### 5. Quick Tests / Verification
+
+```
+Run verification for phase "<PhaseSlug>-<SemVer>".
+
+Checks:
+1. Confirm branch exists and is up to date with aoss-main.
+2. Run CI checks (gh pr checks <PR_NUMBER>).
+3. Verify Firestore paths if applicable (settings/attributesMeta, etc.).
+4. Grep for known patterns to confirm changes applied.
+5. Curl staging endpoint if applicable.
+
+Output: Pass/fail summary with evidence.
+```
+
+### 6. Merge Authorization
+
+```
+I authorize merging PR #<NUMBER>.
+
+Use squash merge and delete the branch:
+gh pr merge <NUMBER> --squash --delete-branch --body "<commit message>"
+
+After merge:
+1. Update labels: remove state:in-progress, cleanup:required; add state:merged, cleanup:done.
+2. Confirm branch deleted.
+3. Return merge commit SHA and final PR state as evidence.
+```
+
+### 7. Close / Archive a Phase
+
+```
+Close phase "<PhaseSlug>-<SemVer>".
+
+Steps:
+1. Confirm all PRs with lp:<PhaseSlug>-<SemVer> are merged or closed.
+2. Update any remaining labels to state:merged or state:closed.
+3. Summarize: PRs merged, commits, deploy status, Firestore verification.
+4. Output: Final phase closure HES.
+```
+
+---
+
 This file is the AI re-entry contract. Any AI session must follow it before taking actions.


### PR DESCRIPTION
Adds the Chat Bootstrap prompts (Start Phase, Resume Chat, HES, PRD, Quick Tests, Merge Authorization, Close Phase) to AI_BOOTSTRAP.md to make phase bootstrapping simple for non-developers.

## Summary
This PR adds 7 copy/paste prompt templates to `AI_BOOTSTRAP.md`:
1. **Start a New Phase** — Bootstrap a new LP with PRD requirement
2. **Resume an Existing Chat** — Re-orient in a new session
3. **Request a HES** — Get structured handoff evidence
4. **Request a PRD** — Draft phase requirements document
5. **Quick Tests / Verification** — Run verification checks
6. **Merge Authorization** — Standard merge command template
7. **Close / Archive a Phase** — Formal phase closure

## Acceptance criteria
- [x] AI_BOOTSTRAP.md updated with Quick Prompts section
- [ ] PR labeled: state:in-progress, lp:service-account-ropi-deploy-1.0.0, type:docs, cleanup:required
- [ ] CI passes (docs checks)

## LP
`LP-service-account-ropi-deploy-1.0.0` — Step F (documentation enhancement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Quick Prompts section featuring seven reusable prompt templates designed to streamline development phase management. Templates cover phase initiation, work session resumption, specification requests, documentation generation, testing workflows, merge authorization, and completion. Each template specifies preconditions and expected outputs for consistent execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->