### PR TITLE
feat(api): register search-mpn endpoint and fix case-insensitive MPN lookup (LP-obs-studio-cleanup-1.1.0)

### DIFF
--- a/packages/api/src/apiApp.ts
+++ b/packages/api/src/apiApp.ts
@@ -59,6 +59,7 @@ import {
   getProductHandler,
   listProductsHandler,
   getProductByMpnHandler,
+  searchProductsByMpnHandler,
 } from './endpoints/products';
 
 // Observations handlers (LP-1.1.1)
@@ -180,6 +181,8 @@ api.patch('/users/me', updateMeHandler);
  * Products endpoints
  */
 api.get('/products', listProductsHandler);
+// LP-obs-studio-cleanup-1.1.0: Register search-mpn BEFORE :productId to avoid route shadowing
+api.get('/products/search-mpn', searchProductsByMpnHandler);
 api.get('/products/by-mpn/:mpn', getProductByMpnHandler);
 api.get('/products/:productId', getProductHandler);
 api.patch('/products/:productId/attributes', patchProductAttributesHandler);

--- a/packages/api/src/endpoints/products.ts
+++ b/packages/api/src/endpoints/products.ts
@@ -443,12 +443,35 @@ export async function getProductByMpnHandler(req: Request, res: Response) {
     const db = admin.firestore();
 
     try {
-      // Query products by MPN
-      const snapshot = await db
+      // LP-obs-studio-cleanup-1.1.0: Case-insensitive MPN lookup
+      // Try uppercase-normalized MPN first (most common storage format)
+      const normalizedMpn = mpn.toUpperCase();
+      let snapshot = await db
         .collection('products')
-        .where('mpn', '==', mpn)
+        .where('mpn', '==', normalizedMpn)
         .limit(1)
         .get();
+
+      // Fallback: try original case if normalized fails (for legacy data)
+      if (snapshot.empty && mpn !== normalizedMpn) {
+        snapshot = await db
+          .collection('products')
+          .where('mpn', '==', mpn)
+          .limit(1)
+          .get();
+      }
+
+      // Fallback: try lowercase (edge case for mixed-case data)
+      if (snapshot.empty) {
+        const lowercaseMpn = mpn.toLowerCase();
+        if (lowercaseMpn !== mpn && lowercaseMpn !== normalizedMpn) {
+          snapshot = await db
+            .collection('products')
+            .where('mpn', '==', lowercaseMpn)
+            .limit(1)
+            .get();
+        }
+      }
 
       if (snapshot.empty) {
         res.status(404).json({ 

--- a/packages/web/src/components/observations/MobileMPNScanner.tsx
+++ b/packages/web/src/components/observations/MobileMPNScanner.tsx
@@ -112,14 +112,17 @@ export default function MobileMPNScanner({
   }, [apiBaseUrl]);
 
   // LP-1.1.10: Search products by partial MPN
+  // LP-obs-studio-cleanup-1.1.0: Add auth headers for search endpoint
   const searchProducts = useCallback(async (query: string): Promise<ScannedProduct[]> => {
     const cleanQuery = query.trim();
     if (cleanQuery.length < 2) return [];
     
     try {
+      // LP-obs-studio-cleanup-1.1.0: Get auth headers with Bearer token
+      const headers = await getAuthHeaders();
       const response = await fetch(
         `${apiBaseUrl}/products/search-mpn?q=${encodeURIComponent(cleanQuery)}&limit=10`,
-        { credentials: 'include' }
+        { headers }
       );
       
       if (!response.ok) {


### PR DESCRIPTION
## LP-obs-studio-cleanup-1.1.0: Product Lookup UX Fixes

**PhaseSlug:** `obs-studio-cleanup.v1`
**LP:** `LP-obs-studio-cleanup-1.1.0`
**Version:** `1.1.0`

---

## Intent

Register the missing `search-mpn` endpoint, make `by-mpn` case-insensitive, and wire MobileMPNScanner to show debounced autocomplete results for manual MPN entry.

---

## Changes

### 1. Register search-mpn route in apiApp.ts

- Import `searchProductsByMpnHandler` from products.ts
- Register `GET /products/search-mpn` **BEFORE** `/products/:productId` to avoid route shadowing

### 2. Make by-mpn case-insensitive

- Normalize MPN to uppercase and query
- Fallback: try original case if normalized fails
- Fallback: try lowercase for edge cases

### 3. Add auth headers to MobileMPNScanner

- Call `getAuthHeaders()` for search-mpn requests
- Replace `credentials: include` with proper Bearer token headers

---

## Acceptance Criteria

| # | Criterion | Verification |
|---|-----------|--------------|
| 1 | `GET /api/products/search-mpn?q=211&limit=10` returns results | HTTP 200, includes `211737-90H1-8` |
| 2 | `GET /api/products/by-mpn/211737-90h1-8` (lowercase) works | HTTP 200 |
| 3 | `GET /api/products/by-mpn/211737-90H1-8` (uppercase) works | HTTP 200 (no regression) |
| 4 | Route ordering correct | Code inspection |
| 5 | UI autocomplete works | Type `211` → results appear |
| 6 | No attribute registry changes | `git diff` confirms |

---

## Files Changed

- `packages/api/src/apiApp.ts` - Register search-mpn route
- `packages/api/src/endpoints/products.ts` - Case-insensitive by-mpn
- `packages/web/src/components/observations/MobileMPNScanner.tsx` - Auth headers for search

---

## Test Plan

```bash
TOKEN=$(node scripts/get-admin-token.js 2>/dev/null)

# Test 1: search-mpn
curl -s "https://ropi-aoss-staging.web.app/api/products/search-mpn?q=211&limit=10" \
  -H "Authorization: Bearer $TOKEN" | jq ".results | length"

# Test 2: by-mpn lowercase
curl -s "https://ropi-aoss-staging.web.app/api/products/by-mpn/211737-90h1-8" \
  -H "Authorization: Bearer $TOKEN" | jq ".product_mpn"

# Test 3: by-mpn uppercase
curl -s "https://ropi-aoss-staging.web.app/api/products/by-mpn/211737-90H1-8" \
  -H "Authorization: Bearer $TOKEN" | jq ".product_mpn"
```

---

## Constraints

- ✅ No changes to `packages/sdk/config/attributeRegistry.json`
- ✅ No changes to `settings/attributes/*`
- ✅ Staging only (`ropi-bccee`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated search endpoint for product lookups by MPN identifier.

* **Bug Fixes**
  * Enhanced product lookup to handle MPN queries with different case variations (uppercase, lowercase, mixed case).

* **Improvements**
  * Optimized authentication handling for search requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->