### PR TITLE
feat(observations): LP-obs-studio-cleanup-1.2.1 - Tag Removal Queue + E2E

### DIFF
--- a/packages/api/src/apiApp.ts
+++ b/packages/api/src/apiApp.ts
@@ -70,6 +70,7 @@ import {
   updateObservationHandler,
   analyzeImageHandler,
   analyzeImageStandaloneHandler,
+  removeObservationTagHandler,
 } from './endpoints/observations';
 
 // Import / batch / sync
@@ -195,6 +196,7 @@ api.post('/observations', createObservationHandler);
 api.post('/observations/analyze-image', analyzeImageStandaloneHandler);
 api.get('/observations/:id', getObservationHandler);
 api.patch('/observations/:id', updateObservationHandler);
+api.post('/observations/:id/tags/remove', removeObservationTagHandler);
 api.post('/observations/:id/analyze-image', analyzeImageHandler);
 
 /**

--- a/packages/api/src/endpoints/observations.ts
+++ b/packages/api/src/endpoints/observations.ts
@@ -383,6 +383,89 @@ export async function updateObservationHandler(req: Request, res: Response) {
 }
 
 /**
+ * POST /api/observations/:id/tags/remove
+ * 
+ * LP-obs-studio-cleanup-1.2.1: Remove a tag from an observation using arrayRemove.
+ * Used by optimistic UI delete with background sync.
+ * 
+ * Only the creator or an admin can remove tags from an observation.
+ */
+export async function removeObservationTagHandler(req: Request, res: Response) {
+  await requireAuth(req, res, async () => {
+    const authReq = req as AuthenticatedRequest;
+    const observationId = req.params.id;
+    const { tag } = req.body;
+
+    if (!observationId) {
+      res.status(400).json({
+        error: 'MISSING_OBSERVATION_ID',
+        message: 'Observation ID is required',
+      });
+      return;
+    }
+
+    if (!tag || typeof tag !== 'string') {
+      res.status(400).json({
+        error: 'INVALID_TAG',
+        message: 'tag must be a non-empty string',
+      });
+      return;
+    }
+
+    const db = admin.firestore();
+
+    try {
+      const docRef = db.collection('observations').doc(observationId);
+      const doc = await docRef.get();
+
+      if (!doc.exists) {
+        res.status(404).json({
+          error: 'NOT_FOUND',
+          message: `Observation '${observationId}' not found`,
+        });
+        return;
+      }
+
+      const data = doc.data();
+      const creatorUid = data?.createdBy?.uid;
+      const callerUid = authReq.auth?.uid;
+      const isAdmin = authReq.auth?.admin === true;
+
+      // Only creator or admin can remove tags
+      if (creatorUid !== callerUid && !isAdmin) {
+        res.status(403).json({
+          error: 'FORBIDDEN',
+          message: 'Only the observation creator or an admin can remove tags',
+        });
+        return;
+      }
+
+      // Use arrayRemove to atomically remove the tag
+      await docRef.update({
+        tags: admin.firestore.FieldValue.arrayRemove(tag),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedBy: {
+          uid: callerUid || 'unknown',
+          name: authReq.auth?.name || authReq.auth?.email || 'Unknown User',
+        },
+      });
+
+      res.status(200).json({
+        success: true,
+        observationId,
+        removedTag: tag,
+      });
+    } catch (error) {
+      console.error('Error removing tag from observation:', error);
+      res.status(500).json({
+        error: 'INTERNAL_ERROR',
+        message: 'Failed to remove tag from observation',
+      });
+    }
+  });
+}
+
+/**
  * POST /api/observations/analyze-image
  * 
  * AI image analysis endpoint (dev stub) - standalone version.

--- a/packages/web/e2e/capture-loop.spec.ts
+++ b/packages/web/e2e/capture-loop.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * E2E Tests: Capture Loop (N=3)
+ * 
+ * LP-obs-studio-cleanup-1.2.1: Tests the observation capture workflow
+ * with multiple captures in sequence, verifying:
+ * - Tags are persisted correctly
+ * - "Finish & Next" CTA works
+ * - Offline capture queues and syncs when online
+ * 
+ * Source-of-truth: Workflow W1 — Observations
+ * https://www.notion.so/2b845ee1ec5a81b5a4a6d3ea439ec277
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import {
+  TEST_USERS,
+  signInWithEmail,
+  generateTestId,
+  waitForFirestoreWrite,
+} from './helpers';
+
+const TEST_MPN = '211737-90H1-8'; // Seeded test product
+
+/**
+ * Navigate to the observations studio/capture page
+ */
+async function navigateToCapture(page: Page) {
+  await page.goto('/observations/capture');
+  // Wait for the capture UI to load
+  await page.waitForSelector('text=/scan|search|mpn/i', { timeout: 10000 });
+}
+
+/**
+ * Select a product by MPN
+ */
+async function selectProduct(page: Page, mpn: string) {
+  // Look for MPN input or search field
+  const mpnInput = page.locator('input[placeholder*="MPN"], input[name="mpn"], input[aria-label*="MPN"]').first();
+  
+  if (await mpnInput.isVisible({ timeout: 3000 })) {
+    await mpnInput.fill(mpn);
+    // Wait for autocomplete/search results
+    await page.waitForTimeout(500);
+    
+    // Click on the matching result if dropdown appears
+    const resultItem = page.locator(`text="${mpn}"`).first();
+    if (await resultItem.isVisible({ timeout: 2000 })) {
+      await resultItem.click();
+    }
+  } else {
+    // Try scanner button fallback
+    const scanButton = page.locator('button:has-text("Scan"), button[aria-label*="scan"]').first();
+    if (await scanButton.isVisible()) {
+      // For E2E, we'll need to mock scanner - skip for now
+      throw new Error('Scanner mode not supported in E2E - needs MPN input field');
+    }
+  }
+  
+  // Wait for product to be selected
+  await page.waitForSelector(`text="${mpn}"`, { timeout: 5000 });
+}
+
+/**
+ * Create an observation with tags
+ */
+async function createObservationWithTags(
+  page: Page,
+  observationText: string,
+  tags: string[]
+) {
+  // Fill observation text
+  const textArea = page.locator(
+    'textarea[name="observation"], textarea[placeholder*="observation"], ' +
+    'input[name="observation"], input[placeholder*="observation"]'
+  ).first();
+  await textArea.fill(observationText);
+  
+  // Add tags
+  const tagInput = page.locator(
+    'input[name="tags"], input[placeholder*="tag"], input[aria-label*="tag"]'
+  ).first();
+  
+  if (await tagInput.isVisible({ timeout: 2000 })) {
+    for (const tag of tags) {
+      await tagInput.fill(tag);
+      await tagInput.press('Enter');
+      await page.waitForTimeout(100);
+    }
+    
+    // Verify tags are shown as chips
+    for (const tag of tags) {
+      await expect(page.locator(`text="${tag}"`)).toBeVisible({ timeout: 2000 });
+    }
+  }
+  
+  // Click save/finish button
+  const saveButton = page.locator(
+    'button:has-text("Finish"), button:has-text("Save"), button[type="submit"]'
+  ).first();
+  await saveButton.click();
+  
+  // Wait for save to complete
+  await waitForFirestoreWrite(page);
+}
+
+test.describe('Capture Loop - N=3', () => {
+  test.beforeEach(async ({ page }) => {
+    // Sign in as admin (has permission to create observations)
+    await signInWithEmail(page, TEST_USERS.admin.email, TEST_USERS.admin.password);
+  });
+
+  test('should complete 3 captures with tags persisted', async ({ page }) => {
+    const testId = generateTestId('capture');
+    const captures = [
+      { text: `Capture 1 - ${testId}`, tags: ['urgent', 'quality'] },
+      { text: `Capture 2 - ${testId}`, tags: ['packaging', 'damage'] },
+      { text: `Capture 3 - ${testId}`, tags: ['review', 'follow-up'] },
+    ];
+
+    await navigateToCapture(page);
+
+    for (let i = 0; i < captures.length; i++) {
+      const capture = captures[i];
+      
+      // Select product
+      await selectProduct(page, TEST_MPN);
+      
+      // Create observation with tags
+      await createObservationWithTags(page, capture.text, capture.tags);
+      
+      // Verify success message
+      await expect(
+        page.locator('text=/success|saved|created/i')
+      ).toBeVisible({ timeout: 5000 });
+      
+      // If "Finish & Next" was clicked, scanner should reopen
+      if (i < captures.length - 1) {
+        // Verify scanner/search is ready for next capture
+        await expect(
+          page.locator('input[placeholder*="MPN"], text=/scan|search/i')
+        ).toBeVisible({ timeout: 5000 });
+      }
+    }
+    
+    // Navigate to observations list to verify all 3 were created
+    await page.goto('/observations');
+    await page.waitForLoadState('networkidle');
+    
+    // Verify all 3 observations exist
+    for (const capture of captures) {
+      await expect(page.locator(`text="${capture.text}"`)).toBeVisible({ timeout: 10000 });
+    }
+  });
+
+  test('should handle offline capture and sync', async ({ page, context }) => {
+    const testId = generateTestId('offline');
+    
+    await navigateToCapture(page);
+    
+    // Create first observation while online
+    await selectProduct(page, TEST_MPN);
+    await createObservationWithTags(
+      page,
+      `Online capture - ${testId}`,
+      ['online', 'test']
+    );
+    await expect(page.locator('text=/success/i')).toBeVisible({ timeout: 5000 });
+    
+    // Go offline (simulate)
+    await context.setOffline(true);
+    
+    // Wait for offline indicator
+    await page.waitForTimeout(500);
+    
+    // Create second observation while offline
+    await selectProduct(page, TEST_MPN);
+    const offlineText = `Offline capture - ${testId}`;
+    await createObservationWithTags(
+      page,
+      offlineText,
+      ['offline', 'queued']
+    );
+    
+    // Verify pending indicator appears
+    await expect(
+      page.locator('text=/pending|queued|offline/i')
+    ).toBeVisible({ timeout: 5000 });
+    
+    // Go back online
+    await context.setOffline(false);
+    
+    // Wait for auto-sync
+    await page.waitForTimeout(3000);
+    
+    // Verify sync success or pending count decreases
+    await expect(
+      page.locator('text=/synced|success|0 pending/i')
+    ).toBeVisible({ timeout: 10000 });
+    
+    // Navigate to observations list
+    await page.goto('/observations');
+    await page.waitForLoadState('networkidle');
+    
+    // Verify offline observation was synced
+    await expect(page.locator(`text="${offlineText}"`)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should display tag chips and allow removal', async ({ page }) => {
+    await navigateToCapture(page);
+    await selectProduct(page, TEST_MPN);
+    
+    // Add tags
+    const tagInput = page.locator(
+      'input[name="tags"], input[placeholder*="tag"]'
+    ).first();
+    
+    if (!await tagInput.isVisible({ timeout: 3000 })) {
+      test.skip();
+      return;
+    }
+    
+    // Add 3 tags
+    const tags = ['alpha', 'beta', 'gamma'];
+    for (const tag of tags) {
+      await tagInput.fill(tag);
+      await tagInput.press('Enter');
+    }
+    
+    // Verify all 3 chips visible
+    for (const tag of tags) {
+      await expect(page.locator(`text="${tag}"`)).toBeVisible();
+    }
+    
+    // Remove middle tag by clicking X
+    const betaChip = page.locator('text="beta"').locator('..').locator('button, [role="button"]');
+    if (await betaChip.isVisible({ timeout: 1000 })) {
+      await betaChip.click();
+      
+      // Verify beta is removed
+      await expect(page.locator('text="beta"')).not.toBeVisible({ timeout: 2000 });
+      
+      // Verify other tags still present
+      await expect(page.locator('text="alpha"')).toBeVisible();
+      await expect(page.locator('text="gamma"')).toBeVisible();
+    }
+    
+    // Test backspace removal
+    await tagInput.focus();
+    await tagInput.press('Backspace');
+    
+    // Verify last tag (gamma) is removed
+    await expect(page.locator('text="gamma"')).not.toBeVisible({ timeout: 2000 });
+    await expect(page.locator('text="alpha"')).toBeVisible();
+  });
+});

--- a/packages/web/src/services/ObservationsSync.ts
+++ b/packages/web/src/services/ObservationsSync.ts
@@ -252,6 +252,8 @@ export async function syncIfOnline(apiBaseUrl: string = '/api'): Promise<void> {
 export function registerAutoSync(apiBaseUrl: string = '/api'): () => void {
   const handler = () => {
     syncIfOnline(apiBaseUrl);
+    // LP-obs-studio-cleanup-1.2.1: Also flush tag removals when coming online
+    flushTagRemovalQueue(apiBaseUrl);
   };
   
   window.addEventListener('online', handler);
@@ -262,6 +264,186 @@ export function registerAutoSync(apiBaseUrl: string = '/api'): () => void {
   };
 }
 
+// ============================================================================
+// LP-obs-studio-cleanup-1.2.1: Tag Removal Queue
+// Lightweight queue using localStorage for background tag removal with retry
+// ============================================================================
+
+interface PendingTagRemoval {
+  id: string;
+  observationId: string;
+  tag: string;
+  status: 'pending' | 'syncing' | 'failed';
+  retryCount: number;
+  createdAt: number;
+}
+
+const TAG_REMOVAL_QUEUE_KEY = 'ropi-tag-removal-queue';
+
+// Callbacks for UI notification
+let onTagRemovalFailed: ((removal: PendingTagRemoval) => void) | null = null;
+
+/**
+ * Set callback for tag removal failure (to show undo toast)
+ */
+export function setTagRemovalFailedCallback(
+  callback: ((removal: PendingTagRemoval) => void) | null
+): void {
+  onTagRemovalFailed = callback;
+}
+
+/**
+ * Get all pending tag removals from localStorage
+ */
+function getTagRemovalQueue(): PendingTagRemoval[] {
+  try {
+    const data = localStorage.getItem(TAG_REMOVAL_QUEUE_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save tag removal queue to localStorage
+ */
+function saveTagRemovalQueue(queue: PendingTagRemoval[]): void {
+  localStorage.setItem(TAG_REMOVAL_QUEUE_KEY, JSON.stringify(queue));
+}
+
+/**
+ * Enqueue a tag removal for background processing
+ */
+export function enqueueTagRemoval(observationId: string, tag: string): string {
+  const queue = getTagRemovalQueue();
+  const removal: PendingTagRemoval = {
+    id: `tagrem_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+    observationId,
+    tag,
+    status: 'pending',
+    retryCount: 0,
+    createdAt: Date.now(),
+  };
+  queue.push(removal);
+  saveTagRemovalQueue(queue);
+  
+  // Trigger immediate flush if online
+  if (navigator.onLine) {
+    flushTagRemovalQueue();
+  }
+  
+  return removal.id;
+}
+
+/**
+ * Cancel a pending tag removal (for undo)
+ */
+export function cancelTagRemoval(removalId: string): boolean {
+  const queue = getTagRemovalQueue();
+  const index = queue.findIndex(r => r.id === removalId);
+  if (index >= 0) {
+    queue.splice(index, 1);
+    saveTagRemovalQueue(queue);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Process a single tag removal
+ */
+async function processTagRemoval(
+  removal: PendingTagRemoval,
+  apiBaseUrl: string
+): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `${apiBaseUrl}/observations/${removal.observationId}/tags/remove`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({ tag: removal.tag }),
+      }
+    );
+    
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || `Server error: ${response.status}`);
+    }
+    
+    return true;
+  } catch (err) {
+    console.error(`Failed to remove tag from observation ${removal.observationId}:`, err);
+    return false;
+  }
+}
+
+/**
+ * Flush pending tag removals with retry logic
+ */
+export async function flushTagRemovalQueue(
+  apiBaseUrl: string = '/api'
+): Promise<{ processed: number; failed: number }> {
+  const queue = getTagRemovalQueue();
+  const pending = queue.filter(r => r.status !== 'failed' || r.retryCount < 2);
+  
+  let processed = 0;
+  let failed = 0;
+  
+  for (const removal of pending) {
+    // Skip if max retries reached
+    if (removal.retryCount >= 2) {
+      removal.status = 'failed';
+      failed++;
+      // Notify UI about failure
+      if (onTagRemovalFailed) {
+        onTagRemovalFailed(removal);
+      }
+      continue;
+    }
+    
+    removal.status = 'syncing';
+    saveTagRemovalQueue(queue);
+    
+    const success = await processTagRemoval(removal, apiBaseUrl);
+    
+    if (success) {
+      // Remove from queue on success
+      const idx = queue.findIndex(r => r.id === removal.id);
+      if (idx >= 0) queue.splice(idx, 1);
+      saveTagRemovalQueue(queue);
+      processed++;
+    } else {
+      removal.status = 'pending';
+      removal.retryCount++;
+      saveTagRemovalQueue(queue);
+      
+      // If this was the last retry, notify UI
+      if (removal.retryCount >= 2) {
+        removal.status = 'failed';
+        saveTagRemovalQueue(queue);
+        failed++;
+        if (onTagRemovalFailed) {
+          onTagRemovalFailed(removal);
+        }
+      } else {
+        // Schedule retry with backoff (1s, 2s)
+        const delay = removal.retryCount * 1000;
+        setTimeout(() => {
+          if (navigator.onLine) {
+            flushTagRemovalQueue(apiBaseUrl);
+          }
+        }, delay);
+      }
+    }
+  }
+  
+  return { processed, failed };
+}
+
 /**
  * Export for testing
  */
@@ -270,4 +452,6 @@ export const __testing = {
   generateId,
   DB_NAME,
   DB_VERSION,
+  getTagRemovalQueue,
+  saveTagRemovalQueue,
 };


### PR DESCRIPTION
## LP-obs-studio-cleanup-1.2.1

### Overview
Implements optimistic tag deletion infrastructure with background Firestore sync and E2E capture-loop tests.

### Changes

#### API Endpoint: `POST /api/observations/:id/tags/remove`
- Authorization check: creator or admin only
- Uses `FieldValue.arrayRemove()` for atomic tag removal
- Returns `{ success: true, observationId, removedTag }`

#### Tag Removal Queue (`ObservationsSync.ts`)
- `enqueueTagRemoval(observationId, tag)` - Queue for background processing
- `cancelTagRemoval(removalId)` - Undo support
- `flushTagRemovalQueue()` - Process with retry (1s, 2s backoff)
- `setTagRemovalFailedCallback()` - UI notification hook
- Auto-flush when coming back online

#### E2E Test: `capture-loop.spec.ts`
- N=3 capture workflow verification
- Tags persistence validation
- Offline capture and sync test
- Tag chip UI and removal test

### Testing
- `pnpm build` passes for api and web packages
- Observations unit tests pass
- E2E tests ready for CI execution

### Verification Checklist
- [ ] API endpoint returns 200 on valid tag removal
- [ ] API returns 403 for unauthorized users
- [ ] Queue flushes automatically when online
- [ ] Failed removals trigger callback after retries
- [ ] E2E capture-loop tests pass

---
**LP:** LP-obs-studio-cleanup-1.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remove tags from observations – observation owners and admins can now delete tags from any observation
  * Offline support for tag removal – removals are queued locally and automatically synced when connection is restored
  * Enhanced validation and error handling for tag management operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->