### PR TITLE
fix(auth): use authFetch for analyze-image and observation endpoints

### DIFF
--- a/packages/web/src/components/observations/AIAnalyzeChips.tsx
+++ b/packages/web/src/components/observations/AIAnalyzeChips.tsx
@@ -2,9 +2,11 @@
  * AIAnalyzeChips Component
  * 
  * LP-1.1.1: Display AI-suggested observation text as selectable chips.
+ * LP-1.7.1: Fixed 401 by using authFetch with automatic token refresh.
  */
 
 import { useState, useCallback } from 'react';
+import { authFetch } from '../../services/authFetch';
 import './AIAnalyzeChips.css';
 
 export interface AISuggestion {
@@ -44,12 +46,12 @@ export default function AIAnalyzeChips({
     try {
       // Use the first image for analysis (MVP scope)
       // In the future, this could analyze multiple images
-      const response = await fetch(`${apiBaseUrl}/observations/analyze-image`, {
+      // LP-1.7.1: Use authFetch for automatic token attachment and refresh on 401
+      const response = await authFetch(`${apiBaseUrl}/observations/analyze-image`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        credentials: 'include',
         body: JSON.stringify({
           imageUrl: imageUrls[0],
         }),

--- a/packages/web/src/components/product/ObservationsPanel.tsx
+++ b/packages/web/src/components/product/ObservationsPanel.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { isFirebaseAvailable } from '../../firebaseConfig';
 import SignInModal from '@/components/Auth/SignInModal';
 import { fieldLinkToDisplayString, legacyLinkedFieldToFieldLink } from '../../utils/normalizeFieldLink';
+import { authFetch } from '../../services/authFetch';
 import './ObservationsPanel.css';
 
 /**
@@ -102,19 +103,19 @@ function ObservationsPanel({ productId }: ObservationsPanelProps) {
   }, []);
 
   // LP-obs-studio-cleanup-1.6.6: Simplified submit - uses product observation endpoint
+  // LP-1.7.1: Use authFetch for proper Authorization header
   const handleSubmit = async () => {
     if (tags.length === 0 || !currentUser) return;
 
     setIsSubmitting(true);
 
     try {
-      // Call the new product observation endpoint
-      const response = await fetch(`/api/products/${productId}/observation`, {
+      // Call the new product observation endpoint with authFetch
+      const response = await authFetch(`/api/products/${productId}/observation`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
-        credentials: 'include',
         body: JSON.stringify({
           tags,
           images: imagePreviews, // Use data URLs for now, could upload to storage


### PR DESCRIPTION
## Summary

**LP-1.7.1**: Fixed 401 Unauthorized on `POST /api/observations/analyze-image` and `PATCH /api/products/{id}/observation` endpoints.

## Root Cause

Components were using direct `fetch()` with `credentials: 'include'` instead of the `authFetch` helper which attaches the Firebase ID token as `Authorization: Bearer` header.

## Changes

- **AIAnalyzeChips.tsx**: Replace `fetch()` with `authFetch()` for analyze-image
- **ObservationsPanel.tsx**: Replace `fetch()` with `authFetch()` for observation PATCH

## How authFetch works

The `authFetch` helper automatically:
- Attaches Firebase ID token as `Authorization: Bearer` header
- Auto-refreshes token on 401 and retries once
- Provides exponential backoff for transient errors (500, 502, 503, 504)

## Verification

- ✅ Built and deployed to staging
- ✅ Verified analyze flow receives Authorization header
- ✅ AI suggestions returned successfully (no 401)
- ✅ No debug logs in production bundle

## Smoke Test

1. Incognito → https://ropi-aoss-staging.web.app → DevTools Network tab
2. Sign in → navigate to observation capture
3. Upload image → enable AI Analysis → click "Analyze Images with AI"
4. Confirm: suggestions appear, Network shows `Authorization` header on POST request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced authentication token handling for image analysis and product observation features with improved automatic token refresh and security management capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->