### PR TITLE
feat(LP-observations-consolidation-1.0.0): Make product.observation canonical SRoT

### DIFF
--- a/packages/web/src/components/observations/MobileObservationCapture.tsx
+++ b/packages/web/src/components/observations/MobileObservationCapture.tsx
@@ -1,25 +1,29 @@
 /**
  * Mobile Observation Capture Component
  * 
+ * LP-observations-consolidation-1.0.0: Hydrates tags from product.observation (SRoT).
  * LP-obs-studio-cleanup-1.6.6: Simplified tags-only observation capture.
+ * 
  * Captures product-level observation tags and stores directly on product document.
  * 
  * Workflow:
  * 1. Scan/select product by MPN
- * 2. Add observation tags (quick keywords)
- * 3. Optionally capture images
- * 4. Save to product.observation
+ * 2. Hydrate existing tags from product.observation (SRoT)
+ * 3. Add observation tags (quick keywords)
+ * 4. Optionally capture images
+ * 5. Save to product.observation via PATCH endpoint
  * 
  * References:
  * - Workflow W1 — Observations: https://www.notion.so/2b845ee1ec5a81b5a4a6d3ea439ec277
  * - LP-obs-studio-cleanup-1.6.6: Collapse observations into product-level
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import MobileMPNScanner, { ScannedProduct } from './MobileMPNScanner';
 import ObservationImageUploader, { ImageFile } from './ObservationImageUploader';
 import AIAnalyzeChips from './AIAnalyzeChips';
 import { useObservationsSync } from '../../hooks/useObservationsSync';
+import { listenToProductObservation, type ProductObservation } from '../../services/observations';
 import './MobileObservationCapture.css';
 
 interface MobileObservationCaptureProps {
@@ -48,6 +52,9 @@ function MobileObservationCapture({ apiBaseUrl = '/api' }: MobileObservationCapt
   const [tagInput, setTagInput] = useState('');
   const [images, setImages] = useState<ImageFile[]>([]);
   
+  // LP-observations-consolidation-1.0.0: Existing product observation state (for hydration display)
+  const [_existingObservation, setExistingObservation] = useState<ProductObservation | null>(null);
+  
   // AI analysis state
   const [showAIAnalysis, setShowAIAnalysis] = useState(false);
 
@@ -55,6 +62,29 @@ function MobileObservationCapture({ apiBaseUrl = '/api' }: MobileObservationCapt
   const [saving, setSaving] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // LP-observations-consolidation-1.0.0: Listen to product.observation when product is selected
+  useEffect(() => {
+    if (!selectedProduct?.id) {
+      setExistingObservation(null);
+      return;
+    }
+
+    const unsubscribe = listenToProductObservation(selectedProduct.id, (observation) => {
+      setExistingObservation(observation);
+      // Hydrate tags from product.observation if not already editing
+      // Only on initial load (when tags are empty)
+      if (tags.length === 0 && observation.tags.length > 0) {
+        setTags(observation.tags);
+      }
+    });
+
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+    // Only re-run when product changes, not when tags change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProduct?.id]);
 
   // Handle MPN selection from scanner or autocomplete
   const handleProductSelect = useCallback((product: ScannedProduct) => {

--- a/packages/web/src/components/product/AIActionsTab.tsx
+++ b/packages/web/src/components/product/AIActionsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import type { Product, AIHistoryEntry } from '../../types/product';
 import { useSuggestions } from '../../hooks/useSuggestions';
 import TargetAccordion, { type TargetResult, type Candidate, type SEOData } from './TargetAccordion';
@@ -7,11 +7,13 @@ import aiDescribeClient, {
   getDefaultTargets,
   type DescribeRequest,
 } from '../../services/AIDescribeClient';
+import { listenToProductObservation, type ProductObservation } from '../../services/observations';
 import './AIActionsTab.css';
 
 /**
  * AIActionsTab Component
  * 
+ * LP-observations-consolidation-1.0.0: Uses product.observation as canonical SRoT.
  * LP-obs-studio-cleanup-1.6.5: Refactored to per-target aggregated model.
  * 
  * Tab 5: Describe Engine Controls and AI Power Features
@@ -21,7 +23,7 @@ import './AIActionsTab.css';
  * - Tone Preset Overrides
  * - Targets row with selectable target cards
  * - Per-target accordion panels with candidates
- * - Aggregated observations per target
+ * - Aggregated observations per target (from product.observation SRoT)
  * - SEO generation per target
  * - Apply/Edit/Try Again controls
  * - Show contributing observations
@@ -91,6 +93,14 @@ function AIActionsTab({ product, onUpdate }: AIActionsTabProps) {
     message: '',
   });
 
+  // LP-observations-consolidation-1.0.0: SRoT - product.observation listener state
+  const [productObservation, setProductObservation] = useState<ProductObservation>({
+    tags: [],
+    images: [],
+    updatedAt: null,
+    updatedBy: null,
+  });
+
   // LP-obs-studio-cleanup-1.4.0: Suggestions from observations
   const {
     suggestions,
@@ -126,6 +136,19 @@ function AIActionsTab({ product, onUpdate }: AIActionsTabProps) {
     }
   };
 
+  // LP-observations-consolidation-1.0.0: Listen to product.observation (SRoT)
+  useEffect(() => {
+    if (!product?.id) return;
+
+    const unsubscribe = listenToProductObservation(product.id, (observation) => {
+      setProductObservation(observation);
+    });
+
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+  }, [product?.id]);
+
   // LP-obs-studio-cleanup-1.4.0: Apply a single suggestion
   const handleApplySuggestion = async (suggestion: typeof suggestions[0]) => {
     if (!product?.id) return;
@@ -147,12 +170,24 @@ function AIActionsTab({ product, onUpdate }: AIActionsTabProps) {
     }
   };
 
-  // Collect observations for the product
+  // LP-observations-consolidation-1.0.0: Collect observations from product.observation SRoT
+  // Combines canonical product.observation tags with legacy product.observations array
   const observations = useMemo(() => {
-    // In production, this would come from the observations service
-    const productObs = (product as unknown as { observations?: Array<{ id: string; text?: string; tags?: string[] }> }).observations || [];
-    return productObs;
-  }, [product]);
+    // Get tags from canonical product.observation (SRoT)
+    const srotTags = productObservation.tags || [];
+    
+    // Get legacy observations from product.observations array (for backward compatibility)
+    const legacyObs = (product as unknown as { observations?: Array<{ id: string; text?: string; tags?: string[] }> }).observations || [];
+    
+    // Combine: Create observation entries from canonical tags + legacy observations
+    const fromSrot = srotTags.length > 0 ? [{
+      id: 'product-observation-srot',
+      text: srotTags.join(', '),
+      tags: srotTags,
+    }] : [];
+    
+    return [...fromSrot, ...legacyObs];
+  }, [productObservation.tags, product]);
 
   // Aggregate observations data
   const aggregatedData = useMemo(() => {

--- a/packages/web/src/components/product/ObservationsPanel.test.tsx
+++ b/packages/web/src/components/product/ObservationsPanel.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Smoke Tests for ObservationsPanel component
  * 
+ * LP-observations-consolidation-1.0.0: Updated to test listenToProductObservation (SRoT)
+ * 
  * Basic rendering and integration tests for ObservationsPanel
  * with Firestore service integration.
  * 
@@ -8,7 +10,7 @@
  * These tests verify component renders correctly with mocked service.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
@@ -44,6 +46,12 @@ vi.mock('firebase/firestore', () => ({
 }));
 
 describe('ObservationsPanel - Smoke Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // LP-observations-consolidation-1.0.0: Mock SRoT listener
+    vi.mocked(observationsService.listenToProductObservation).mockReturnValue(vi.fn());
+  });
+
   it('renders with basic structure', () => {
     vi.mocked(firebaseConfig.isFirebaseAvailable).mockReturnValue(true);
     vi.mocked(observationsService.listenToObservations).mockReturnValue(vi.fn());
@@ -75,6 +83,25 @@ describe('ObservationsPanel - Smoke Tests', () => {
     );
 
     expect(mockListen).toHaveBeenCalledWith('prod123', expect.any(Function));
+  });
+
+  // LP-observations-consolidation-1.0.0: Test canonical SRoT listener
+  it('calls listenToProductObservation on mount (SRoT)', () => {
+    vi.mocked(firebaseConfig.isFirebaseAvailable).mockReturnValue(true);
+    vi.mocked(observationsService.listenToObservations).mockReturnValue(vi.fn());
+
+    const mockProductListen = vi.fn().mockReturnValue(vi.fn());
+    vi.mocked(observationsService.listenToProductObservation).mockImplementation(mockProductListen);
+
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <ObservationsPanel productId="prod123" />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    expect(mockProductListen).toHaveBeenCalledWith('prod123', expect.any(Function));
   });
 
   it('shows offline banner when Firebase unavailable', () => {

--- a/packages/web/src/components/product/ObservationsPanel.tsx
+++ b/packages/web/src/components/product/ObservationsPanel.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Observation } from '../../types/observation';
-import { listenToObservations, resolveObservation, syncLocalToFirestore } from '../../services/observations';
+import { 
+  listenToObservations, 
+  listenToProductObservation, 
+  resolveObservation, 
+  syncLocalToFirestore,
+  type ProductObservation 
+} from '../../services/observations';
 import { useAuth } from '@/hooks/useAuth';
 import { isFirebaseAvailable } from '../../firebaseConfig';
 import SignInModal from '@/components/Auth/SignInModal';
@@ -11,11 +17,14 @@ import './ObservationsPanel.css';
 /**
  * Observations Panel - Product Editor Sidebar
  * 
+ * LP-observations-consolidation-1.0.0: Uses product.observation as canonical SRoT.
  * LP-obs-studio-cleanup-1.6.6: Simplified tags-only observation model.
+ * 
  * Displays existing observations and allows adding product-level tags.
  * 
  * Features:
- * - Real-time observation updates via Firestore listener
+ * - Real-time observation updates via product.observation listener (SRoT)
+ * - Legacy observations displayed for backward compatibility
  * - Simplified tags-only add modal (no title/description/severity/linkedField)
  * - Product-level observation stored on product.observation
  * - Offline mode banner with sync retry
@@ -33,6 +42,13 @@ interface ObservationsPanelProps {
 function ObservationsPanel({ productId }: ObservationsPanelProps) {
   const { currentUser, isAdmin, loading: authLoading } = useAuth();
   const [observations, setObservations] = useState<Observation[]>([]);
+  // LP-observations-consolidation-1.0.0: SRoT - product.observation listener
+  const [productObservation, setProductObservation] = useState<ProductObservation>({
+    tags: [],
+    images: [],
+    updatedAt: null,
+    updatedBy: null,
+  });
   const [showModal, setShowModal] = useState(false);
   const [showSignInModal, setShowSignInModal] = useState(false);
   const [isOffline, setIsOffline] = useState(!isFirebaseAvailable());
@@ -47,7 +63,22 @@ function ObservationsPanel({ productId }: ObservationsPanelProps) {
 
   const openObservations = observations.filter(obs => obs.status === 'open');
 
-  // Set up real-time listener for observations
+  // LP-observations-consolidation-1.0.0: Listen to canonical product.observation (SRoT)
+  useEffect(() => {
+    if (!productId) return;
+
+    const unsubscribe = listenToProductObservation(productId, (observation) => {
+      setProductObservation(observation);
+      setIsOffline(!isFirebaseAvailable());
+    });
+
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+  }, [productId]);
+
+  // Legacy: Set up real-time listener for legacy observations collection
+  // This will be deprecated in a future LP after migration
   useEffect(() => {
     if (!productId) return;
 
@@ -225,7 +256,9 @@ function ObservationsPanel({ productId }: ObservationsPanelProps) {
     <div className="product-panel">
       <div className="product-panel-header">
         <h4 className="product-panel-title">Observations</h4>
-        <span className="product-panel-badge">{openObservations.length}</span>
+        <span className="product-panel-badge">
+          {productObservation.tags.length + openObservations.length}
+        </span>
       </div>
       
       {/* Auth banner when not signed in */}
@@ -260,10 +293,61 @@ function ObservationsPanel({ productId }: ObservationsPanelProps) {
       )}
       
       <div className="product-panel-content">
-        {openObservations.length === 0 ? (
+        {/* LP-observations-consolidation-1.0.0: Display canonical product.observation tags (SRoT) */}
+        {productObservation.tags.length > 0 && (
+          <div className="observation-tags-section">
+            <div className="observation-tags-header">
+              <span className="observation-tags-label">Product Tags</span>
+              {productObservation.updatedAt && productObservation.updatedBy && (
+                <span className="observation-tags-meta">
+                  Last updated by {productObservation.updatedBy}
+                </span>
+              )}
+            </div>
+            <div className="observation-tags-list" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '12px' }}>
+              {productObservation.tags.map((tag) => (
+                <span 
+                  key={tag} 
+                  className="observation-tag"
+                  style={{ 
+                    background: '#e3f2fd', 
+                    color: '#1565c0', 
+                    borderRadius: '16px', 
+                    padding: '4px 12px', 
+                    fontSize: '13px',
+                    fontWeight: 500 
+                  }}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            {productObservation.images.length > 0 && (
+              <div className="observation-images" style={{ marginBottom: '12px' }}>
+                {productObservation.images.map((imgUrl, idx) => (
+                  <img 
+                    key={idx} 
+                    src={imgUrl} 
+                    alt={`Observation image ${idx + 1}`} 
+                    className="observation-image"
+                    onClick={() => window.open(imgUrl, '_blank')}
+                    style={{ cursor: 'pointer', maxWidth: '80px', maxHeight: '80px', marginRight: '8px', borderRadius: '4px' }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Legacy observations (will be migrated in LP-observations-consolidation-1.4.0) */}
+        {openObservations.length === 0 && productObservation.tags.length === 0 ? (
           <p className="panel-empty">No open observations</p>
-        ) : (
-          openObservations.map((obs) => (
+        ) : openObservations.length > 0 && (
+          <div className="legacy-observations-section">
+            <span className="observation-tags-label" style={{ fontSize: '12px', color: '#999', marginBottom: '8px', display: 'block' }}>
+              Legacy Observations
+            </span>
+            {openObservations.map((obs) => (
             <div key={obs.id} className="observation-item">
               <div className="observation-header">
                 <span className={`observation-severity severity-${obs.severity}`}>
@@ -317,7 +401,8 @@ function ObservationsPanel({ productId }: ObservationsPanelProps) {
                 {formatTime(obs.createdAt)} by {obs.createdBy.name}
               </div>
             </div>
-          ))
+          ))}
+          </div>
         )}
         
         <button 

--- a/packages/web/src/services/observations.ts
+++ b/packages/web/src/services/observations.ts
@@ -410,6 +410,78 @@ export function listenToObservations(
 }
 
 /**
+ * Product observation structure (SRoT on product document)
+ * LP-observations-consolidation-1.0.0: Canonical source of truth for product-scoped observations
+ */
+export interface ProductObservation {
+  tags: string[];
+  images: string[];
+  updatedAt: string | null;
+  updatedBy: string | null;
+  source?: string;
+}
+
+/**
+ * Listen to real-time updates for product-level observation (SRoT)
+ * LP-observations-consolidation-1.0.0: Subscribes to product.observation field
+ * 
+ * This is the canonical listener for product-scoped observation data.
+ * UIs should use this instead of listenToObservations() for product-specific displays.
+ * 
+ * @param productId - The product document ID
+ * @param onUpdate - Callback when observation data changes
+ * @returns Unsubscribe function
+ */
+export function listenToProductObservation(
+  productId: string,
+  onUpdate: (observation: ProductObservation) => void
+): Unsubscribe {
+  const emptyObservation: ProductObservation = {
+    tags: [],
+    images: [],
+    updatedAt: null,
+    updatedBy: null,
+  };
+
+  if (isFirebaseAvailable() && db) {
+    try {
+      const productRef = doc(db, 'products', productId);
+      
+      return onSnapshot(
+        productRef,
+        (docSnapshot) => {
+          if (!docSnapshot.exists()) {
+            onUpdate(emptyObservation);
+            return;
+          }
+
+          const data = docSnapshot.data();
+          const observation = data?.observation || emptyObservation;
+          
+          onUpdate({
+            tags: observation.tags || [],
+            images: observation.images || [],
+            updatedAt: observation.updatedAt || null,
+            updatedBy: observation.updatedBy || null,
+            source: observation.source,
+          });
+        },
+        (error) => {
+          console.error('Error listening to product observation:', error);
+          onUpdate(emptyObservation);
+        }
+      );
+    } catch (error) {
+      console.error('Failed to set up product observation listener:', error);
+    }
+  }
+  
+  // Fallback: Return empty observation and no-op unsubscribe
+  onUpdate(emptyObservation);
+  return () => {};
+}
+
+/**
  * Sync local observations to Firestore
  * Used when connectivity is restored
  * 


### PR DESCRIPTION
LP: LP-observations-consolidation-1.0.0
PhaseSlug: observations-consolidation

## Phase Readiness

This PR implements LP-observations-consolidation-1.0.0 as part of the Observations Consolidation phase.

**Phase Goal:** Make Observations a single coherent, tags-first, product-scoped system: unify source-of-truth to `product.observation`, produce equivalent mobile/desktop flows, replace legacy add/required-title flows, ensure reliable uploads/sync, and harden CI/automation for phase readiness.

## HES (placeholder)

```json
{
  "from": "Homer",
  "to": "Lisa",
  "lp": "LP-observations-consolidation-1.0.0",
  "actions": [
    "Branch created: fix/obs-srot-1.0.0",
    "Commits: cb049d3",
    "Files changed: packages/web/src/services/observations.ts, packages/web/src/components/product/ObservationsPanel.tsx, packages/web/src/components/observations/MobileObservationCapture.tsx, packages/web/src/components/product/AIActionsTab.tsx, packages/web/src/components/product/ObservationsPanel.test.tsx"
  ],
  "artifacts": {
    "pr": "#<pending>",
    "ci_runs": [],
    "test_results": {
      "ObservationsPanel.test.tsx": "4/4 passed",
      "typecheck": "passed"
    },
    "acceptance_criteria": {
      "listenToProductObservation_exists": true,
      "product_uis_use_srot_listener": true,
      "write_paths_use_patch_endpoint": true,
      "backward_compatible_with_legacy": true
    }
  },
  "outcome": "PENDING CI VERIFICATION"
}
```

## Changes

- **observations.ts**: Add `listenToProductObservation()` function as canonical SRoT listener and `ProductObservation` type interface
- **ObservationsPanel.tsx**: Subscribe to `product.observation` via new listener; display canonical tags with legacy fallback for backward compatibility
- **MobileObservationCapture.tsx**: Hydrate tags from `product.observation` when product is selected
- **AIActionsTab.tsx**: Collect observations from `product.observation` SRoT, combine with legacy `product.observations` for AI analysis
- **ObservationsPanel.test.tsx**: Add test for `listenToProductObservation` being called on mount

## Verification & Acceptance

### Acceptance Criteria (machine-checkable)

1. ✅ `grep "listenToProductObservation" packages/web/src` returns results in all primary files
2. ✅ No product UI uses only `listenToObservations(productId, ...)` pattern without also using `listenToProductObservation`
3. ✅ Unit/E2E tests pass (4/4 in ObservationsPanel.test.tsx)
4. ✅ TypeScript compilation passes

### Smoke Tests

- [ ] When a product observation PATCH is committed, ObservationsPanel reflects updated `product.observation` tags
- [ ] MobileObservationCapture hydrates existing tags when product is selected
- [ ] AIActionsTab includes `product.observation` tags in aggregated observations for AI describe

## Labels

- state:in-progress
- lp:observations-consolidation-1.0.0
- type:feature
- cleanup:required

## Reviewers

- Lisa
- Infra
- Backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product observations now sync and display in real-time, showing tags and associated images.
  * Added last-updated metadata (timestamp and contributor info) for observation entries.
  * Observations panel consolidates current and legacy observation data into a unified view.

* **Tests**
  * Added test coverage for real-time observation data synchronization during component initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->