### PR TITLE
chore(ci): add SmartRules log-collection workflow (staging, uses GCP_SA_KEY_BASE64)

### DIFF
--- a/.github/workflows/smartrules-log-collection.yml
+++ b/.github/workflows/smartrules-log-collection.yml
@@ -1,0 +1,139 @@
+name: SmartRules Log Collection (Staging)
+
+on:
+  workflow_dispatch:
+    inputs:
+      staging_host:
+        description: 'Staging host (e.g., staging-api.ropi-bccee.app)'
+        required: true
+      product_ids:
+        description: 'Comma-separated productIds to patch (or single id)'
+        required: true
+      sample_count:
+        description: 'Number of sample writes per product'
+        required: false
+        default: '1'
+
+jobs:
+  collect-logs:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ropi-bccee
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          install_components: 'gcloud' # ensure gcloud CLI available
+
+      - name: Decode and activate service account
+        env:
+          GCP_SA_KEY_BASE64: ${{ secrets.GCP_SA_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "Decoding service account key..."
+          echo "$GCP_SA_KEY_BASE64" | base64 --decode > "${HOME}/sa.json"
+          chmod 600 "${HOME}/sa.json"
+          echo "Activating service account..."
+          gcloud auth activate-service-account --key-file="${HOME}/sa.json"
+          gcloud config set project "${PROJECT_ID}"
+          echo "gcloud auth list:"
+          gcloud auth list --format="value(account)"
+
+      - name: Install utilities
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq curl
+
+      - name: Enable verbose logging on functions (100% sampling)
+        run: |
+          echo "Updating functions to LOG_VERBOSE=true, LOG_SAMPLING_RATE=100"
+          FNS=(importCSV onProductWrite)
+          for FN in "${FNS[@]}"; do
+            echo "Updating $FN..."
+            gcloud functions deploy "$FN" \
+              --project="${PROJECT_ID}" \
+              --region=us-central1 \
+              --update-env-vars LOG_VERBOSE=true,LOG_SAMPLING_RATE=100 \
+              --quiet
+          done
+
+      - name: Get identity token
+        id: idtoken
+        run: |
+          TOKEN=$(gcloud auth print-identity-token)
+          echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger sample writes
+        env:
+          TOKEN: ${{ steps.idtoken.outputs.token }}
+        run: |
+          set -euo pipefail
+          HOST="${{ github.event.inputs.staging_host }}"
+          IFS=',' read -ra PIDS <<< "${{ github.event.inputs.product_ids }}"
+          COUNT=${{ github.event.inputs.sample_count }}
+          mkdir -p artifacts
+          for pid in "${PIDS[@]}"; do
+            for i in $(seq 1 "$COUNT"); do
+              TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              echo "PATCH product $pid ($i) @ $TS"
+              # capture response
+              curl -s -H "Authorization: Bearer $TOKEN" \
+                -H "Content-Type: application/json" \
+                -X PATCH "https://${HOST}/api/products/${pid}/attributes" \
+                -d "{\"attributes\":{\"smr_test_trigger\":\"force-update-${TS}\"}}" \
+                -o "artifacts/patch_${pid}_${i}.json" || true
+              sleep 3
+            done
+          done
+
+      - name: Wait for logs to flush
+        run: sleep 15
+
+      - name: Collect smartrule.eval logs
+        run: |
+          gcloud logging read 'resource.type="cloud_function" AND jsonPayload.event="smartrule.eval"' \
+            --project="${PROJECT_ID}" --limit=200 --format=json > artifacts/smartrule_eval_samples.json || true
+
+      - name: Collect smartrule.apply logs
+        run: |
+          gcloud logging read 'resource.type="cloud_function" AND jsonPayload.event="smartrule.apply"' \
+            --project="${PROJECT_ID}" --limit=200 --format=json > artifacts/smartrule_apply_samples.json || true
+
+      - name: Collect smartrule.error logs
+        run: |
+          gcloud logging read 'resource.type="cloud_function" AND jsonPayload.event="smartrule.error"' \
+            --project="${PROJECT_ID}" --limit=200 --format=json > artifacts/smartrule_error_samples.json || true
+
+      - name: Extract a traceId and collect trace
+        run: |
+          TRACE_ID=$(jq -r '.[0].jsonPayload.traceId' artifacts/smartrule_eval_samples.json || echo "")
+          if [ -n "$TRACE_ID" ] && [ "$TRACE_ID" != "null" ]; then
+            echo "Collecting logs for trace $TRACE_ID"
+            gcloud logging read "resource.type=\"cloud_function\" AND jsonPayload.traceId=\"$TRACE_ID\"" \
+              --project="${PROJECT_ID}" --limit=200 --format=json > "artifacts/trace_${TRACE_ID}.json" || true
+          else
+            echo "No trace ID found in eval samples; skipping trace collection"
+          fi
+
+      - name: Revert verbose logging
+        run: |
+          echo "Reverting functions to LOG_VERBOSE=false, LOG_SAMPLING_RATE=1"
+          FNS=(importCSV onProductWrite)
+          for FN in "${FNS[@]}"; do
+            echo "Updating $FN..."
+            gcloud functions deploy "$FN" \
+              --project="${PROJECT_ID}" \
+              --region=us-central1 \
+              --update-env-vars LOG_VERBOSE=false,LOG_SAMPLING_RATE=1 \
+              --quiet
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: smartrule-artifacts
+          path: artifacts/

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,19 @@
+This workflow automates SmartRules staging log collection using the GCP service account secret stored in GCP_SA_KEY_BASE64.
+
+It:
+- Decodes and activates the service account (base64 secret)
+- Enables verbose logging for importCSV/onProductWrite
+- Triggers sample product writes
+- Collects Cloud Logging events for smartrule.eval/apply/error
+- Reverts verbose logging and uploads artifacts
+
+Usage (trigger via GitHub Actions -> Run workflow):
+- staging_host: staging host (e.g., staging-api.ropi-bccee.app)
+- product_ids: comma-separated product IDs to test
+- sample_count: number of patches per product (default 1)
+
+Security:
+- Uses GCP_SA_KEY_BASE64 (base64 encoded service account JSON)
+- No secrets are printed in logs; service account key is only decoded on the runner.
+
+After merge, run the workflow, attach artifacts, and update HES with VERIFIED SUCCESS.


### PR DESCRIPTION
This workflow automates SmartRules staging log collection using the GCP service account secret stored in GCP_SA_KEY_BASE64.

It:
- Decodes and activates the service account (base64 secret)
- Enables verbose logging for importCSV/onProductWrite
- Triggers sample product writes
- Collects Cloud Logging events for smartrule.eval/apply/error
- Reverts verbose logging and uploads artifacts

Usage (trigger via GitHub Actions -> Run workflow):
- staging_host: staging host (e.g., staging-api.ropi-bccee.app)
- product_ids: comma-separated product IDs to test
- sample_count: number of patches per product (default 1)

Security:
- Uses GCP_SA_KEY_BASE64 (base64 encoded service account JSON)
- No secrets are printed in logs; service account key is only decoded on the runner.

After merge, run the workflow, attach artifacts, and update HES with VERIFIED SUCCESS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new automated log collection workflow for staging environments. Accepts configurable input parameters, temporarily enables enhanced logging on backend services, triggers sample test writes to staging systems, collects diagnostic logs from multiple sources, restores standard logging configuration, and archives all results as artifacts for detailed analysis and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->