### PR TITLE
fix: use canonical completionRules field on settings/exportSettings

### DIFF
--- a/COMPLETION_RULES_BACKEND_CONFIG.md
+++ b/COMPLETION_RULES_BACKEND_CONFIG.md
@@ -24,14 +24,15 @@ This document defines the **authoritative backend configuration schema** for Com
 
 ## Configuration Storage
 
-**Firestore Path:**
+**Firestore Location:**
 ```
-settings/exportSettings/completionRules
+Document: settings/exportSettings
+Field:    completionRules
 ```
 
-**Document Type:** Single JSON document  
+**Document Type:** settings/exportSettings is a single JSON document; `completionRules` is a top-level field on that doc  
 **Access:** Read by backend services, written by admin UI  
-**Versioning:** Immutable snapshots stored in `completionRulesVersions/{version}` subcollection
+**Versioning:** Immutable snapshots stored in `completionRulesVersions/{version}` subcollection under the same document
 
 ---
 

--- a/COMPLETION_RULES_UI_SPEC.md
+++ b/COMPLETION_RULES_UI_SPEC.md
@@ -30,6 +30,14 @@ This document defines the **authoritative UI specification** for Completion Rule
 **Access Control:** Admin users only  
 **Navigation:** From Settings page → "Export Settings" link
 
+**Storage Location (canonical):**
+```
+Document: settings/exportSettings
+Field:    completionRules
+Versioned snapshots: settings/exportSettings/completionRulesVersions/{version}
+```
+All UI reads/writes target the `completionRules` field on `settings/exportSettings` (merge writes only).
+
 ---
 
 ## Page Structure

--- a/packages/api/src/services/completionRulesService.ts
+++ b/packages/api/src/services/completionRulesService.ts
@@ -79,20 +79,24 @@ export async function loadCompletionRules(forceLatest = false): Promise<Completi
   
   try {
     // Load live configuration from settings
-    const rulesRef = db.doc('settings/exportSettings/completionRules');
-    const snapshot = await rulesRef.get();
+    const settingsRef = db.doc('settings/exportSettings');
+    const snapshot = await settingsRef.get();
     
     if (!snapshot.exists) {
-      throw new Error('No completion rules configured in settings/exportSettings/completionRules');
+      throw new Error('No settings/exportSettings document found');
     }
     
     const data = snapshot.data();
     if (!data) {
       throw new Error('Completion rules document is empty');
     }
+    const rules = (data as Record<string, unknown>).completionRules;
+    if (!rules) {
+      throw new Error('completionRules field missing on settings/exportSettings');
+    }
     
     // Validate required fields
-    const config = data as CompletionRulesConfig;
+    const config = rules as CompletionRulesConfig;
     validateCompletionRulesConfig(config);
     
     return config;

--- a/packages/web/src/services/completionRulesClient.ts
+++ b/packages/web/src/services/completionRulesClient.ts
@@ -53,16 +53,23 @@ export interface CompletionRulesConfig {
 export async function fetchCompletionRules(): Promise<CompletionRulesConfig | null> {
   try {
     const db = getFirestore();
-    const rulesRef = doc(db, 'settings/exportSettings/completionRules');
-    const snapshot = await getDoc(rulesRef);
+    const settingsRef = doc(db, 'settings', 'exportSettings');
+    const snapshot = await getDoc(settingsRef);
 
     if (!snapshot.exists()) {
-      console.warn('[CompletionRulesClient] No completion rules found in Firestore');
+      console.warn('[CompletionRulesClient] settings/exportSettings document not found');
       return null;
     }
 
     const data = snapshot.data();
-    return data as CompletionRulesConfig;
+    const rules = data?.completionRules;
+
+    if (!rules) {
+      console.warn('[CompletionRulesClient] completionRules field missing on settings/exportSettings');
+      return null;
+    }
+
+    return rules as CompletionRulesConfig;
   } catch (error) {
     console.error('[CompletionRulesClient] Failed to fetch completion rules:', error);
     throw error;
@@ -89,8 +96,8 @@ export async function saveCompletionRules(rules: CompletionRulesConfig): Promise
     validateRules(rules);
 
     // Persist without client-side metadata/version mutation
-    const rulesRef = doc(db, 'settings/exportSettings/completionRules');
-    await setDoc(rulesRef, rules);
+    const settingsRef = doc(db, 'settings', 'exportSettings');
+    await setDoc(settingsRef, { completionRules: rules }, { merge: true });
 
     console.log('[CompletionRulesClient] Completion rules saved successfully');
   } catch (error) {


### PR DESCRIPTION
## Summary
- Point web completionRulesClient to `settings/exportSettings` document and read/write the `completionRules` field (merge writes, no magic doc IDs)
- Align API completionRulesService to load the same canonical field and error clearly if missing
- Update backend + UI docs to reflect the canonical storage (live rules field on settings/exportSettings; versioned snapshots remain under completionRulesVersions/{version})

## Root Cause
Live completion rules were stored as a standalone document at `settings/exportSettings/completionRules` (odd segment count), causing Firestore doc() to reject the path ("documentPath must point to a document"). This broke completion evaluation reads in staging (`/api/products/:id/completion`).

## Tests
- `pnpm -C packages/api build`

## Notes
- Minimal scope: only storage path alignment + docs
- Version history remains unchanged (subcollection under settings/exportSettings)
- Staging will need a deploy after merge to pick up the new path

## Evidence of failure
- Staging call: `GET https://ropi-aoss-staging.web.app/api/products/211737-90h1-8/completion` returned Firestore path error referencing `settings/exportSettings/completionRules` (invalid document path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified completion rules storage location and structure specifications.

* **Refactor**
  * Updated completion rules storage and retrieval to use a consolidated data structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->