### PR TITLE
docs: clarify completionRules scope on settings/exportSettings

### DIFF
--- a/COMPLETION_RULES_BACKEND_CONFIG.md
+++ b/COMPLETION_RULES_BACKEND_CONFIG.md
@@ -11,7 +11,7 @@
 This document defines the **authoritative backend configuration schema** for Completion Rules, which drive the export gate evaluation engine. It eliminates ambiguity, defaults, and inferred logic by documenting **actual behavior as implemented**.
 
 **Scope:**
-- Configuration schema stored in `settings/exportSettings/completionRules`
+- Configuration schema stored as `completionRules` field on `settings/exportSettings`
 - Backend services that read, validate, and enforce completion rules
 - Completion evaluation engine behavior and semantics
 


### PR DESCRIPTION
## Summary
- Clarify scope statement to reflect canonical storage: `completionRules` field on the `settings/exportSettings` document
- Keeps version snapshots unchanged (completionRulesVersions/{version})

## Rationale
Earlier PR #439 moved code to the canonical path; this updates the spec wording to match the implemented storage location.

## Tests
- Documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration schema documentation to clarify how the field is structured within the Firestore document, improving accuracy and reducing potential confusion for developers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->