### PR TITLE
rules: add completion rules paths to firestore.rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -259,6 +259,35 @@ service cloud.firestore {
     }
     
     // ========================================
+    // COMPLETION RULES CONFIGURATION (LP-completion-model-export-gate-1.0.0)
+    // ========================================
+    // Authoritative configuration document for completion evaluation engine
+    // - Canonical path: settings/exportSettings (top-level doc with completionRules field)
+    // - Versioned snapshots: settings/exportSettings/completionRulesVersions/{rulesVersion}
+    // - Audit trail: settings/exportSettings/completionRulesAudit/{eventId}
+    
+    match /settings/exportSettings {
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    match /settings/exportSettings/completionRulesVersions/{rulesVersion} {
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    match /settings/exportSettings/completionRulesAudit/{eventId} {
+      allow read: if request.auth != null
+                  && (isAdmin() || isAdminViaMetadata());
+      allow write: if request.auth != null
+                   && (isAdmin() || isAdminViaMetadata());
+    }
+    
+    // ========================================
     // DEFAULT DENY
     // ========================================
     // Deny access to all other collections by default


### PR DESCRIPTION
## Summary
Add Firestore security rules for completion rules configuration paths.

## Changes
Authorize admin-only reads/writes to:
- `settings/exportSettings` — Live completion rules document
- `settings/exportSettings/completionRulesVersions/{rulesVersion}` — Versioned rule snapshots
- `settings/exportSettings/completionRulesAudit/{eventId}` — Audit trail for rule changes

## Security Model
- Uses existing `isAdmin() || isAdminViaMetadata()` guards
- Requires `token.role == 'admin'` (custom claims) or email in `metadata/admins`
- Enables admin UI at `/settings/export-settings` to persist completion rules

## Deployment
Once merged, deploy via:
```bash
firebase deploy --only firestore:rules
```

Or trigger **Deploy AOSS Staging** workflow to deploy rules + API + hosting together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access Control**
  * Updated Firestore security rules for export settings management, restricting access to authorized administrators only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->