### PR TITLE
ci: deploy Firestore rules to staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -122,10 +122,13 @@ jobs:
           # LP-0.1.3: Deploy preview channel (fail-fast, no tolerance)
           firebase hosting:channel:deploy aoss-main-staging --project ropi-bccee --json
 
-          # Deploy functions and hosting to stable staging
+          # Deploy functions, Firestore rules, and hosting to stable staging
           # LP-0.1.3.fix: Add timeouts to prevent runaway deploys
           echo "Deploying Cloud Functions (20m timeout)..."
           timeout 20m firebase deploy --only functions --project ropi-bccee --json
+
+          echo "Deploying Firestore rules..."
+          firebase deploy --only firestore:rules --project ropi-bccee --json
 
           echo "Deploying hosting (10m timeout)..."
           timeout 10m firebase deploy --only hosting:aoss-staging --project ropi-bccee --json


### PR DESCRIPTION
## Summary
Add Firestore rules deployment to the staging workflow to fix permission errors.

## Changes
- Added `firebase deploy --only firestore:rules --project ropi-bccee --json` step
- Runs after functions deploy, before hosting deploy

## Why
The staging site currently shows Firestore permission errors on:
- `/settings/export-settings` page
- `/api/products/{id}/completion` endpoint

This is because `firestore.rules` exists in the repo but was never deployed to staging.

## Verification
After merge & deploy:
1. Reload https://ropi-aoss-staging.web.app/settings/export-settings
2. Expected: No permission errors, page loads normally
3. Theo can save/create completion rules
4. Check https://ropi-aoss-staging.web.app/api/products/211737-90h1-8/completion

## Evidence Required
- [ ] Staging deploy log shows "Deploying Firestore rules"
- [ ] Theo confirms settings page loads without permission error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment workflow to include Firestore security rules deployment alongside function and hosting deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->