### PR TITLE
LP-export-deploy-fix-1.0.0 — Remove orphaned cloud functions in deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -124,8 +124,9 @@ jobs:
 
           # Deploy functions and hosting to stable staging
           # LP-0.1.3.fix: Add timeouts to prevent runaway deploys
+          # LP-export-deploy-fix-1.0.0: Add --force to allow deletion of orphaned functions in non-interactive CI
           echo "Deploying Cloud Functions (20m timeout)..."
-          timeout 20m firebase deploy --only functions --project ropi-bccee --json
+          timeout 20m firebase deploy --only functions --project ropi-bccee --json --force
 
           echo "Deploying hosting (10m timeout)..."
           timeout 10m firebase deploy --only hosting:aoss-staging --project ropi-bccee --json


### PR DESCRIPTION
LP: LP-export-deploy-fix-1.0.0

## Summary

This PR adds the `--force` flag to the Firebase CLI deploy command in the staging workflow to allow deletion of orphaned Cloud Functions in a non-interactive CI environment.

## Problem

GitHub Actions run [20710169974](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20710169974) failed at step 13 "Deploy to stable staging site" with the error:

```
The following functions are found in your project but do not exist in your local source code:
    api:setAdminClaimOnUserCreate(us-central1)
    api:syncAdminClaimsOnMetadataChange(us-central1)

Aborting because deletion cannot proceed in non-interactive mode.
```

## Root Cause

Two legacy Cloud Functions (`setAdminClaimOnUserCreate`, `syncAdminClaimsOnMetadataChange`) were previously deployed but have since been removed from the codebase. Firebase CLI refuses to auto-delete them without explicit confirmation or the `--force` flag.

## Solution

Add `--force` flag to `firebase deploy --only functions` command in `deploy-staging.yml` (line 129).

## Evidence of orphaned functions (pre-fix)

```
$ firebase functions:list --project ropi-bccee
┌─────────────────────────────────┬─────────┬─────────────────────────────────────────────────┐
│ Function                        │ Version │ Trigger                                         │
├─────────────────────────────────┼─────────┼─────────────────────────────────────────────────┤
│ ...                             │         │                                                 │
│ setAdminClaimOnUserCreate       │ v1      │ providers/firebase.auth/eventTypes/user.create  │
│ syncAdminClaimsOnMetadataChange │ v1      │ providers/cloud.firestore/eventTypes/doc.write  │
│ ...                             │         │                                                 │
└─────────────────────────────────┴─────────┴─────────────────────────────────────────────────┘
```

These functions are NOT in `packages/api/src/index.ts` and are orphaned.

## Rollback Plan

If the deletion results in unexpected failures:
1. Open revert PR referencing LP-export-deploy-fix-1.0.0
2. Escalate to infra/ops for restoration of deleted functions (restore from backups or re-deploy function code)
3. Document any data/service impact
4. Immediately notify Lisa and owners

## Verification Checklist

- [ ] CI passes (Deploy AOSS Staging workflow)
- [ ] `--force` flag appears in deploy logs
- [ ] Orphaned functions deleted (or confirmed absent)
- [ ] Staging URL reachable (HTTP 200)
- [ ] `/export` page functions per VVP

---

**LP:** `LP-export-deploy-fix-1.0.0`
**Directive:** Deploy fix for orphaned Cloud Functions blocking staging deploy
**Triggered by:** Failed run [20710169974](https://github.com/twgallo13/ROPI-V2.1/actions/runs/20710169974)