### PR TITLE
feat(api): add GET /api/admin/exports/readiness endpoint — LP-export-ui-readiness-1.0.0

### DIFF
--- a/packages/api/src/apiApp.ts
+++ b/packages/api/src/apiApp.ts
@@ -115,6 +115,9 @@ import {
   importDryRunHandler,
 } from './endpoints/import';
 
+// LP-export-ui-readiness-1.0.0: Export readiness endpoint
+import { readinessHandler } from './endpoints/export';
+
 // LP-registry-health-1.0.0: Registry health check
 import {
   registryHealthHandler,
@@ -281,6 +284,8 @@ api.post('/processImportBatch', requireAdmin, processImportBatchHandler);
 api.get('/importBatchStatus', getBatchStatusHandler);
 // PVS-0.3.1 Import preview with mapping support
 api.post('/admin/imports/preview', importPreviewHandler);
+// LP-export-ui-readiness-1.0.0: Export readiness endpoint
+api.get('/admin/exports/readiness', requireAdmin, readinessHandler);
 // LP-1.1.0: Protect syncAttributeRegistry endpoint (require admin + dryRun default true)
 api.post('/syncAttributeRegistry', requireAdmin, async (req, res) => {
   try {

--- a/packages/api/src/endpoints/export.readiness.test.ts
+++ b/packages/api/src/endpoints/export.readiness.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Export Readiness Endpoint Tests
+ * LP-export-ui-readiness-1.0.0
+ * 
+ * Tests for GET /api/admin/exports/readiness endpoint:
+ * - Returns 200 with readiness payload when ready === true
+ * - Returns 423 with readiness payload when ready === false
+ * - Requires admin authentication
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+// Mock completionDrivenExportReadiness service
+vi.mock('../services/completionDrivenExportReadiness', () => ({
+  calculateCompletionDrivenExportReadiness: vi.fn()
+}));
+
+import { readinessHandler } from './export';
+import { calculateCompletionDrivenExportReadiness } from '../services/completionDrivenExportReadiness';
+
+describe('Export Readiness Endpoint (LP-export-ui-readiness-1.0.0)', () => {
+  
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockJson: ReturnType<typeof vi.fn>;
+  let mockStatus: ReturnType<typeof vi.fn>;
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockJson = vi.fn();
+    mockStatus = vi.fn(() => ({ json: mockJson }));
+    
+    mockReq = {};
+    
+    mockRes = {
+      status: mockStatus,
+      json: mockJson
+    };
+  });
+
+  describe('GET /api/admin/exports/readiness', () => {
+    
+    it('returns 200 with success:true when readiness.ready === true', async () => {
+      // Mock ready readiness
+      const readyReadiness = {
+        ready: true,
+        completionPct: 85,
+        threshold: 80,
+        hasBlockingSites: false,
+        blockingReasons: [],
+        operatorExplanation: {
+          summary: 'Export ready: all products meet completion requirements',
+          blockingIssues: [],
+          completionBreakdown: [],
+          siteStatus: [
+            { site: 'shiekh.com', blocked: false }
+          ],
+          actionRequired: []
+        },
+        catalogStats: {
+          totalProducts: 10,
+          blockedByCompletionCount: 0,
+          blockedBySiteCount: 0,
+          readyCount: 10
+        },
+        evaluationTimestamp: '2026-01-07T10:00:00.000Z',
+        rulesVersion: 1
+      };
+      
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockResolvedValue(readyReadiness);
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      // Verify 200 status
+      expect(mockStatus).toHaveBeenCalledWith(200);
+      
+      // Verify response structure
+      expect(mockJson).toHaveBeenCalledWith({
+        success: true,
+        readiness: readyReadiness
+      });
+    });
+
+    it('returns 423 with success:false when readiness.ready === false', async () => {
+      // Mock blocked readiness
+      const blockedReadiness = {
+        ready: false,
+        completionPct: 75,
+        threshold: 80,
+        hasBlockingSites: false,
+        blockingReasons: [{
+          type: 'COMPLETION_BELOW_THRESHOLD',
+          severity: 'BLOCKING',
+          message: 'Product prod-123: 75% below threshold 80%',
+          details: {
+            productId: 'prod-123',
+            currentCompletion: 75,
+            requiredCompletion: 80
+          }
+        }],
+        operatorExplanation: {
+          summary: 'Export blocked: 1 products below 80% threshold',
+          blockingIssues: ['Product prod-123: 75% below threshold 80%'],
+          completionBreakdown: [],
+          siteStatus: [],
+          actionRequired: ['Increase completion for 1 products to 80% or higher']
+        },
+        catalogStats: {
+          totalProducts: 10,
+          blockedByCompletionCount: 1,
+          blockedBySiteCount: 0,
+          readyCount: 9
+        },
+        evaluationTimestamp: '2026-01-07T10:00:00.000Z',
+        rulesVersion: 1
+      };
+      
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockResolvedValue(blockedReadiness);
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      // Verify 423 status (Locked)
+      expect(mockStatus).toHaveBeenCalledWith(423);
+      
+      // Verify response structure
+      expect(mockJson).toHaveBeenCalledWith({
+        success: false,
+        readiness: blockedReadiness
+      });
+    });
+
+    it('returns 423 when blocked by site Description/SEO requirements', async () => {
+      // Mock site-blocked readiness
+      const siteBlockedReadiness = {
+        ready: false,
+        completionPct: 90,
+        threshold: 80,
+        hasBlockingSites: true,
+        blockingReasons: [{
+          type: 'SITE_DESCRIPTION_SEO_MISSING',
+          severity: 'BLOCKING',
+          message: 'Site shiekh.com blocked: missing description, seo_title',
+          details: {
+            productId: 'prod-456',
+            site: 'shiekh.com',
+            missingAttributes: ['description', 'seo_title']
+          }
+        }],
+        operatorExplanation: {
+          summary: 'Export blocked: site requirements not met',
+          blockingIssues: ['Site shiekh.com blocked: missing description, seo_title'],
+          completionBreakdown: [],
+          siteStatus: [
+            { site: 'shiekh.com', blocked: true, reason: 'Missing description, seo_title', missingAttributes: ['description', 'seo_title'] }
+          ],
+          actionRequired: ['Add description and seo_title for shiekh.com']
+        },
+        catalogStats: {
+          totalProducts: 10,
+          blockedByCompletionCount: 0,
+          blockedBySiteCount: 1,
+          readyCount: 9
+        },
+        evaluationTimestamp: '2026-01-07T10:00:00.000Z',
+        rulesVersion: 1
+      };
+      
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockResolvedValue(siteBlockedReadiness);
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      // Verify 423 status
+      expect(mockStatus).toHaveBeenCalledWith(423);
+      
+      // Verify hasBlockingSites flag
+      const responsePayload = mockJson.mock.calls[0][0];
+      expect(responsePayload.readiness.hasBlockingSites).toBe(true);
+      expect(responsePayload.readiness.blockingReasons[0].type).toBe('SITE_DESCRIPTION_SEO_MISSING');
+    });
+
+    it('returns 500 when service throws error', async () => {
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockRejectedValue(
+        new Error('Firestore connection failed')
+      );
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      // Verify 500 status
+      expect(mockStatus).toHaveBeenCalledWith(500);
+      
+      // Verify error response
+      expect(mockJson).toHaveBeenCalledWith({
+        success: false,
+        error: 'EXPORT_READINESS_CHECK_FAILED',
+        message: 'Firestore connection failed'
+      });
+    });
+
+    it('calls calculateCompletionDrivenExportReadiness with correct parameters', async () => {
+      const mockReadiness = {
+        ready: true,
+        completionPct: 85,
+        threshold: 80,
+        hasBlockingSites: false,
+        blockingReasons: [],
+        operatorExplanation: {
+          summary: 'Export ready',
+          blockingIssues: [],
+          completionBreakdown: [],
+          siteStatus: [],
+          actionRequired: []
+        },
+        evaluationTimestamp: '2026-01-07T10:00:00.000Z',
+        rulesVersion: 1
+      };
+      
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockResolvedValue(mockReadiness);
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      // Verify service called with expected parameters
+      expect(calculateCompletionDrivenExportReadiness).toHaveBeenCalledTimes(1);
+      
+      const callArgs = vi.mocked(calculateCompletionDrivenExportReadiness).mock.calls[0];
+      
+      // First arg: undefined (catalog-level, no specific product)
+      expect(callArgs[0]).toBeUndefined();
+      
+      // Second arg: false (don't force rules refresh)
+      expect(callArgs[1]).toBe(false);
+      
+      // Third arg: ISO timestamp string
+      expect(typeof callArgs[2]).toBe('string');
+      expect(callArgs[2]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('includes siteStatus in response when product has selected sites', async () => {
+      const readinessWithSites = {
+        ready: true,
+        completionPct: 80,
+        threshold: 80,
+        hasBlockingSites: false,
+        blockingReasons: [],
+        operatorExplanation: {
+          summary: 'Export ready',
+          blockingIssues: [],
+          completionBreakdown: [],
+          siteStatus: [
+            { site: 'shiekh.com', blocked: false },
+            { site: 'ropi-web', blocked: false }
+          ],
+          actionRequired: []
+        },
+        catalogStats: {
+          totalProducts: 5,
+          blockedByCompletionCount: 0,
+          blockedBySiteCount: 0,
+          readyCount: 5
+        },
+        evaluationTimestamp: '2026-01-07T10:00:00.000Z',
+        rulesVersion: 1
+      };
+      
+      vi.mocked(calculateCompletionDrivenExportReadiness).mockResolvedValue(readinessWithSites);
+      
+      await readinessHandler(mockReq as Request, mockRes as Response);
+      
+      expect(mockStatus).toHaveBeenCalledWith(200);
+      
+      const responsePayload = mockJson.mock.calls[0][0];
+      expect(responsePayload.readiness.operatorExplanation.siteStatus).toHaveLength(2);
+      expect(responsePayload.readiness.operatorExplanation.siteStatus[0].site).toBe('shiekh.com');
+    });
+  });
+});

--- a/packages/api/src/endpoints/export.ts
+++ b/packages/api/src/endpoints/export.ts
@@ -239,6 +239,55 @@ export async function previewExportHandler(
   }
 }
 
+/**
+ * GET /api/admin/exports/readiness
+ * LP-export-ui-readiness-1.0.0
+ * 
+ * Check catalog-level export readiness status.
+ * Returns CompletionDrivenExportReadiness JSON:
+ * - 200: Export is ready (ready === true)
+ * - 423: Export is blocked (ready === false)
+ */
+export async function readinessHandler(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    // GOVERNANCE: Capture timestamp at request start for deterministic evaluation
+    const evaluatedAt = new Date().toISOString();
+    console.log('[Export] Checking export readiness...', { evaluatedAt });
+
+    const readinessResult = await calculateCompletionDrivenExportReadiness(
+      undefined,  // No specific product - catalog-level
+      false,      // Don't force rules refresh
+      evaluatedAt
+    );
+
+    console.log('[Export] Readiness check complete:', {
+      ready: readinessResult.ready,
+      completionPct: readinessResult.completionPct,
+      threshold: readinessResult.threshold,
+      blockingReasons: readinessResult.blockingReasons.length
+    });
+
+    // Return 200 when ready, 423 when blocked
+    const statusCode = readinessResult.ready ? 200 : 423;
+    
+    res.status(statusCode).json({
+      success: readinessResult.ready,
+      readiness: readinessResult
+    });
+  } catch (error) {
+    console.error('[Export] Readiness check error:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({
+      success: false,
+      error: 'EXPORT_READINESS_CHECK_FAILED',
+      message
+    });
+  }
+}
+
 // ============================================================================
 // Routes
 // ============================================================================
@@ -256,6 +305,11 @@ app.post('/', (req, res) => {
 // Preview endpoint
 app.get('/preview', (req, res) => {
   requireAdmin(req, res, () => previewExportHandler(req, res));
+});
+
+// Readiness endpoint (LP-export-ui-readiness-1.0.0)
+app.get('/readiness', (req, res) => {
+  requireAdmin(req, res, () => readinessHandler(req, res));
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds the missing `GET /api/admin/exports/readiness` endpoint to support the Export Manager UI.

**LP:** LP-export-ui-readiness-1.0.0

## Problem

The frontend `useExportCompletion` hook calls `GET /api/admin/exports/readiness` to determine catalog-level export readiness. This endpoint was never created, causing:
- 404 response on `/api/admin/exports/readiness`
- Export Manager UI (`/export`) fails to load readiness data
- Users see loading state indefinitely then error state

## Solution

### 1. Add `readinessHandler` in `packages/api/src/endpoints/export.ts`

```typescript
export async function readinessHandler(req, res): Promise<void> {
  const evaluatedAt = new Date().toISOString();
  const readinessResult = await calculateCompletionDrivenExportReadiness(
    undefined,  // catalog-level
    false,      // don't force rules refresh
    evaluatedAt
  );
  
  const statusCode = readinessResult.ready ? 200 : 423;
  res.status(statusCode).json({
    success: readinessResult.ready,
    readiness: readinessResult
  });
}
```

### 2. Register route in `packages/api/src/apiApp.ts`

```typescript
api.get('/admin/exports/readiness', requireAdmin, readinessHandler);
```

### 3. Response Contract

| Status | Condition | Response Shape |
|--------|-----------|----------------|
| 200 | `ready === true` | `{ success: true, readiness: CompletionDrivenExportReadiness }` |
| 423 | `ready === false` | `{ success: false, readiness: CompletionDrivenExportReadiness }` |
| 500 | Service error | `{ success: false, error: 'EXPORT_READINESS_CHECK_FAILED', message }` |

## Files Changed

| Path | Action |
|------|--------|
| `packages/api/src/endpoints/export.ts` | Add `readinessHandler` function |
| `packages/api/src/apiApp.ts` | Add route registration and import |
| `packages/api/src/endpoints/export.readiness.test.ts` | Add 6 integration tests |

## Tests

New test file with 6 test cases:
- ✅ Returns 200 with `success: true` when `ready === true`
- ✅ Returns 423 with `success: false` when `ready === false`
- ✅ Returns 423 when blocked by site Description/SEO requirements
- ✅ Returns 500 when service throws error
- ✅ Calls `calculateCompletionDrivenExportReadiness` with correct parameters
- ✅ Includes `siteStatus` in response when product has selected sites

```
 ✓ src/endpoints/export.readiness.test.ts (6)
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Verification Plan (HES C)

After merge and staging deploy:
1. Call `GET /api/admin/exports/readiness` — expect 200/423 with valid JSON
2. Load `/export` — Export Manager UI mounts successfully
3. Confirm product `211737-90h1-8` appears in `siteStatus` (not "No sites selected")

## Labels

- `state:in-progress`
- `lp:LP-export-ui-readiness-1.0.0`
- `type:fix`
- `cleanup:required`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin-only export readiness validation endpoint that provides comprehensive system status and readiness checks. Returns readiness indicators, blocking reasons, detailed site-specific status information, and diagnostic error data. Administrators can now validate export system readiness and quickly identify issues blocking exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->