### PR TITLE
LP-export-readiness-diagnostics-1.0.0: Remove legacy ExportReadinessPanel (Task 4)

### DIFF
--- a/packages/web/src/pages/ProductEditorPage.tsx
+++ b/packages/web/src/pages/ProductEditorPage.tsx
@@ -12,7 +12,6 @@ import AIActionsTab from '../components/product/AIActionsTab';
 import DescriptionsTab from '../components/product/DescriptionsTab';
 import ObservationsPanel from '../components/product/ObservationsPanel';
 import SmartSuggestionsPanel from '../components/product/SmartSuggestionsPanel';
-import ExportReadinessPanel from '../components/product/ExportReadinessPanel';
 import { CompletionExportGatePanel } from '../components/product/CompletionExportGatePanel';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { safeArray } from '../lib/productUtils';
@@ -115,8 +114,6 @@ function ProductEditorPage() {
   }
 
   // LP-3.0.7: Ensure safe defaults for product data
-  const safeExportReadiness = product.exportReadiness ?? { overall: 0, byWebsite: {} };
-  const safeWebsites = safeArray(product.websites);
   const safeSuggestions = safeArray(product.smartSuggestions);
 
   // LP-0.4.2: Updated tab order - Technical (4), AI Actions (5), Descriptions (6)
@@ -195,12 +192,6 @@ function ProductEditorPage() {
               suggestions={safeSuggestions}
               onApplySuggestion={applySuggestion}
               onIgnoreSuggestion={ignoreSuggestion}
-            />
-            
-            <ExportReadinessPanel
-              readiness={safeExportReadiness}
-              websites={safeWebsites}
-              onJumpToTab={handleTabChange}
             />
           </div>
         </div>


### PR DESCRIPTION
## LP-export-readiness-diagnostics-1.0.0 HES B - Task 4

**Priority:** P2-MEDIUM  
**Type:** UI Cleanup  
**Commit:** c4f41fb

### Problem
Two export panels displayed in ProductEditor sidebar:
1. `ExportReadinessPanel` (legacy) - old format
2. `CompletionExportGatePanel` (new) - proper completion API

→ Causes UI confusion, duplicate information.

### Solution
Removed `ExportReadinessPanel` from `ProductEditorPage`, kept `CompletionExportGatePanel` as sole export UI.

### Changes
- ❌ Removed `ExportReadinessPanel` import
- ❌ Removed `<ExportReadinessPanel />` from sidebar
- ❌ Removed `safeExportReadiness` variable (unused)
- ❌ Removed `safeWebsites` variable (unused)
- ✅ Kept `CompletionExportGatePanel` (new, correct implementation)

### Files Changed
- ✅ `packages/web/src/pages/ProductEditorPage.tsx`

### Impact
- Eliminates dual export panel confusion
- UI shows single authoritative completion view
- Reduces visual clutter in sidebar
- Component files remain for potential future use

### Testing
- [ ] Manual: Open ProductEditorPage → verify only ONE export panel
- [ ] Manual: Verify CompletionExportGatePanel loads correctly
- [ ] Manual: Check browser console for no import errors
- [ ] Regression: E2E tests for product editor

### Related
- Part of LP-export-readiness-diagnostics-1.0.0 HES B
- Merge order: **THIRD** (after auth + schema fixes)
- Depends on: PR #TBD (auth injection), PR #TBD (schema)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the export readiness panel from the product editor interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->