### PR TITLE
LP-export-readiness-diagnostics-1.0.0: Fix export schema validation (Task 2)

### DIFF
--- a/packages/sdk/src/schema/attribute.ts
+++ b/packages/sdk/src/schema/attribute.ts
@@ -42,6 +42,15 @@ export const ExportMetadataSchema = z.object({
 
 export type ExportMetadata = z.infer<typeof ExportMetadataSchema>;
 
+/**
+ * Combined export field schema - accepts legacy boolean or new object format
+ * LP-export-readiness-diagnostics-1.0.0: Added boolean support for legacy attributes
+ */
+export const ExportFieldSchema = z.union([
+  z.boolean(),          // Legacy format: export: true/false
+  ExportMetadataSchema, // New format: export: { key, omitIfEmpty, targets }
+]).optional();
+
 export const AttributeSchema = z.object({
   attribute_id: z.string().min(1).regex(/^[a-z0-9-_.]+$/),
   label: z.string().min(1),
@@ -65,8 +74,8 @@ export const AttributeSchema = z.object({
   requiredForExport: z.boolean().optional().default(false),
   /** Whether this attribute is for internal use only and should never be exposed to external channels */
   internalOnly: z.boolean().optional().default(false),
-  /** Channel-specific export configuration */
-  export: ExportMetadataSchema,
+  /** Channel-specific export configuration - accepts boolean OR object */
+  export: ExportFieldSchema,
   
   createdBy: z.string().optional(),
   createdAt: z.union([z.string(), z.object({}).passthrough()]).optional(),


### PR DESCRIPTION
## LP-export-readiness-diagnostics-1.0.0 HES B - Task 2

**Priority:** P0-CRITICAL  
**Type:** Bug Fix  
**Commit:** 32763a0

### Problem
`AttributeSchema.export` only accepts `ExportMetadataSchema` (object), rejects legacy `export: true` (boolean) → causes 400 validation errors when updating attributes.

### Solution
Created `ExportFieldSchema = z.union([z.boolean(), ExportMetadataSchema]).optional()` to accept both formats.

**Schema Change:**
```typescript
// Before
export: ExportMetadataSchema,

// After
export const ExportFieldSchema = z.union([
  z.boolean(),          // Legacy: export: true/false
  ExportMetadataSchema, // New: export: { key, omitIfEmpty, targets }
]).optional();

export: ExportFieldSchema,
```

### Files Changed
- ✅ `packages/sdk/src/schema/attribute.ts`

### Impact
- Fixes 400 errors when updating attributes with `export: true`
- Backward compatible with legacy data
- Allows gradual migration to new object format
- Supports mixed registry (boolean + object exports)

### Testing
- [ ] Manual: Update attribute with `export: true` → expect 200
- [ ] Manual: Update attribute with `export: { key: 'foo' }` → expect 200
- [ ] Unit: Schema validation tests
- [ ] Regression: Existing attribute CRUD tests

### Related
- Part of LP-export-readiness-diagnostics-1.0.0 HES B
- Merge order: **SECOND** (after auth fix)
- Depends on: PR #TBD (auth injection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The export field now supports both boolean format (for legacy compatibility) and object format for advanced metadata configuration, providing greater flexibility in export options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->