### PR TITLE
Phase 1: Export Readiness API Extension (Feature-Flagged)

### DIFF
--- a/docs/API_READINESS_PHASE1.md
+++ b/docs/API_READINESS_PHASE1.md
@@ -1,0 +1,92 @@
+# Export Readiness Phase 1 Extension
+
+Scope: Non-breaking API extension to expose RetailOps global mode metadata without changing evaluation semantics.
+
+Fields (optional):
+- mode: "GLOBAL" | "SITE_SCOPED" (exposure-only)
+- productLevelReadiness: { ready, completionPct, threshold, hasBlockingSites }
+
+## Feature Flag Configuration
+
+**Canonical Firestore form** (recommended):
+```json
+// Document: settings/exportSettings
+{
+  "exportGlobalMode": {
+    "enabled": true,      // boolean - feature toggle
+    "mode": "GLOBAL"      // "GLOBAL" | "SITE_SCOPED"
+  }
+}
+```
+
+**Legacy/compatibility keys** (normalized):
+- `globalExportModeEnabled` (boolean)
+- `enableGlobalFields` (boolean)
+- `mode` (string; root level)
+
+**Env fallback** (local/CI convenience):
+`EXPORT_GLOBAL_MODE_FEATURE=true`
+
+## Logging
+
+Temporary staging verification logs are gated by `EXPORT_GLOBAL_LOGS=true`. Logs are disabled by default after merge. To enable logs during staging:
+
+```bash
+export EXPORT_GLOBAL_LOGS=true
+```
+
+Log lines include:
+```
+[ExportReadiness:Phase1] mode=GLOBAL (product), productLevelReadiness= { /* JSON */ }
+[ExportReadiness:Phase1] mode=GLOBAL (catalog), productLevelReadiness= { /* JSON */ }
+```
+
+## Examples
+
+Product (feature enabled):
+```json
+{
+  "ready": true,
+  "completionPct": 92,
+  "threshold": 80,
+  "hasBlockingSites": false,
+  "blockingReasons": [],
+  "operatorExplanation": { /* existing fields */ },
+  "mode": "GLOBAL",
+  "productLevelReadiness": {
+    "ready": true,
+    "completionPct": 92,
+    "threshold": 80,
+    "hasBlockingSites": false
+  },
+  "evaluationTimestamp": "2026-01-07T00:00:00Z",
+  "rulesVersion": 1
+}
+```
+
+Catalog (feature enabled):
+```json
+{
+  "ready": false,
+  "completionPct": 0,
+  "threshold": 80,
+  "hasBlockingSites": true,
+  "blockingReasons": [ /* samples */ ],
+  "operatorExplanation": { /* existing fields */ },
+  "catalogStats": { /* existing fields */ },
+  "mode": "GLOBAL",
+  "productLevelReadiness": {
+    "ready": false,
+    "completionPct": 0,
+    "threshold": 80,
+    "hasBlockingSites": true
+  },
+  "evaluationTimestamp": "2026-01-07T00:00:00Z",
+  "rulesVersion": 1
+}
+```
+
+Notes:
+- No change to gating semantics or thresholds in Phase 1.
+- `siteStatus` remains unchanged and present in `operatorExplanation`.
+- Feature flag controls visibility only; evaluation results are identical whether flag is on or off.

--- a/packages/api/src/services/__tests__/phase1_extension.test.ts
+++ b/packages/api/src/services/__tests__/phase1_extension.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock completionRulesService
+vi.mock('../completionRulesService', () => ({
+  loadCompletionRules: async () => ({ exportUnlockThresholdPct: 80, rulesVersion: 1 })
+}));
+
+// Mock exportService
+vi.mock('../exportService', () => ({
+  loadExportableAttributes: async () => new Map()
+}));
+
+// Mock completionEvaluationEngineEntry
+vi.mock('../completionEvaluationEngineEntry', () => ({
+  evaluateCompletion: () => ({
+    totalCompletionPct: 95,
+    hasBlockingSites: false,
+    siteBlockingReasons: [],
+    segmentResults: []
+  })
+}));
+
+import { calculateCompletionDrivenExportReadiness } from '../completionDrivenExportReadiness';
+
+describe('Phase 1 Readiness Extension', () => {
+  beforeEach(() => {
+    // Enable feature via env fallback
+    process.env.EXPORT_GLOBAL_MODE_FEATURE = 'true';
+  });
+
+  it('exposes mode and productLevelReadiness when feature enabled (product)', async () => {
+    const product: any = {
+      id: 'p-1',
+      sites: ['siteA'],
+      attributes: {}
+    };
+
+    const result = await calculateCompletionDrivenExportReadiness(product, false, '2026-01-07T00:00:00Z');
+    expect(result.ready).toBe(true);
+    expect(result.completionPct).toBe(95);
+    expect(result.threshold).toBe(80);
+
+    // Phase 1 fields
+    expect(result.mode).toBe('GLOBAL');
+    expect(result.productLevelReadiness).toBeDefined();
+    expect(result.productLevelReadiness?.ready).toBe(result.ready);
+    expect(result.productLevelReadiness?.completionPct).toBe(result.completionPct);
+  });
+
+  it('does not crash when feature disabled', async () => {
+    process.env.EXPORT_GLOBAL_MODE_FEATURE = 'false';
+    const product: any = { id: 'p-2', sites: ['siteB'], attributes: {} };
+    const result = await calculateCompletionDrivenExportReadiness(product, false, '2026-01-07T00:00:00Z');
+    expect(result.mode).toBeUndefined();
+    expect(result.productLevelReadiness).toBeUndefined();
+  });
+});

--- a/packages/api/src/services/completionDrivenExportReadiness.ts
+++ b/packages/api/src/services/completionDrivenExportReadiness.ts
@@ -38,6 +38,15 @@ export interface CompletionDrivenExportReadiness {
   hasBlockingSites: boolean;
   blockingReasons: ExportBlockingReason[];
   operatorExplanation: OperatorExplanation;
+  // Phase 1 extension (feature-flagged, non-breaking)
+  // mode indicates exposure context only; does not change evaluation semantics
+  mode?: 'GLOBAL' | 'SITE_SCOPED';
+  productLevelReadiness?: {
+    ready: boolean;
+    completionPct: number;
+    threshold: number;
+    hasBlockingSites: boolean;
+  };
   catalogStats?: {
     totalProducts: number;
     blockedByCompletionCount: number;
@@ -316,10 +325,32 @@ export async function calculateCompletionDrivenExportReadiness(
     
     // Load attribute registry
     const attributeRegistry = await loadAttributeRegistryForCompletion();
+
+    // Phase 1 feature flag: expose mode + productLevelReadiness without changing semantics
+    const featureMode = await detectExportModeFeatureFlag().catch(() => 'SITE_SCOPED' as const);
     
     // If no product provided, evaluate catalog-level completion
     if (!product) {
-      return await evaluateCatalogCompletion(completionRules, attributeRegistry, evaluationTimestamp);
+      const result = await evaluateCatalogCompletion(completionRules, attributeRegistry, evaluationTimestamp);
+      if (featureMode === 'GLOBAL') {
+        // Add Phase 1 fields (non-breaking)
+        const extended: CompletionDrivenExportReadiness = {
+          ...result,
+          mode: 'GLOBAL',
+          productLevelReadiness: {
+            ready: result.ready,
+            completionPct: result.completionPct,
+            threshold: result.threshold,
+            hasBlockingSites: result.hasBlockingSites
+          }
+        };
+        // Temporary logging for staging verification (set EXPORT_GLOBAL_LOGS=true to enable)
+        if (process.env.EXPORT_GLOBAL_LOGS === 'true') {
+          console.info('[ExportReadiness:Phase1] mode=GLOBAL (catalog), productLevelReadiness=', extended.productLevelReadiness);
+        }
+        return extended;
+      }
+      return result;
     }
     
     // Convert product to completion engine format
@@ -357,7 +388,7 @@ export async function calculateCompletionDrivenExportReadiness(
     const blockingReasons = generateBlockingReasons(completionResult, completionRules);
     const operatorExplanation = generateOperatorExplanation(completionResult, completionRules, selectedSites);
     
-    return {
+    const base: CompletionDrivenExportReadiness = {
       ready: isReady,
       completionPct: reportedCompletion, // PROMPT B: Force 0 when site-blocked
       threshold: completionRules.exportUnlockThresholdPct,
@@ -367,6 +398,26 @@ export async function calculateCompletionDrivenExportReadiness(
       evaluationTimestamp,
       rulesVersion: completionRules.rulesVersion
     };
+
+    // Attach Phase 1 fields when feature flag is enabled
+    if (featureMode === 'GLOBAL') {
+      const extended: CompletionDrivenExportReadiness = {
+        ...base,
+        mode: 'GLOBAL',
+        productLevelReadiness: {
+          ready: base.ready,
+          completionPct: base.completionPct,
+          threshold: base.threshold,
+          hasBlockingSites: base.hasBlockingSites
+        }
+      };
+      // Temporary logging for staging verification (set EXPORT_GLOBAL_LOGS=true to enable)
+      if (process.env.EXPORT_GLOBAL_LOGS === 'true') {
+        console.info('[ExportReadiness:Phase1] mode=GLOBAL (product), productLevelReadiness=', extended.productLevelReadiness);
+      }
+      return extended;
+    }
+    return base;
     
   } catch (error) {
     console.error('[CompletionDrivenExportReadiness] Evaluation failed:', error);
@@ -451,6 +502,55 @@ export function extractSelectedSites(product: ProductDocument): string[] {
   }
   
   return [];
+}
+
+/**
+ * Phase 1 feature flag detection — detects GLOBAL export mode exposure
+ * 
+ * Canonical Firestore form:
+ *   settings/exportSettings.exportGlobalMode = { enabled: boolean, mode: "GLOBAL" | "SITE_SCOPED" }
+ * 
+ * Legacy/compatibility keys (normalized):
+ *   - globalExportModeEnabled, enableGlobalFields, mode at root level
+ * 
+ * Fallback: env var EXPORT_GLOBAL_MODE_FEATURE=true (local/CI convenience only)
+ * 
+ * Logs: temporary console.info behind this flag; set EXPORT_GLOBAL_LOGS=true to enable,
+ * or set EXPORT_GLOBAL_MODE_FEATURE=true (logs enabled by default when feature active).
+ * 
+ * Returns 'GLOBAL' when enabled, otherwise 'SITE_SCOPED'
+ */
+async function detectExportModeFeatureFlag(): Promise<'GLOBAL' | 'SITE_SCOPED'> {
+  try {
+    const admin = require('firebase-admin');
+    if (admin?.apps?.length === 0 && admin?.initializeApp) {
+      // Best-effort init in non-functions context
+      admin.initializeApp();
+    }
+    const db = admin.firestore();
+    const doc = await db.collection('settings').doc('exportSettings').get();
+    const data = doc.exists ? doc.data() || {} : {};
+    
+    // Canonical form: exportGlobalMode.enabled
+    const canonical = data.exportGlobalMode;
+    if (canonical && typeof canonical === 'object') {
+      const enabled = !!(canonical.enabled === true);
+      return enabled ? 'GLOBAL' : 'SITE_SCOPED';
+    }
+    
+    // Legacy/compatibility keys (normalize to canonical)
+    const legacyEnabled = !!(
+      data.globalExportModeEnabled === true ||
+      data.enableGlobalFields === true ||
+      data.mode === 'GLOBAL'
+    );
+    return legacyEnabled ? 'GLOBAL' : 'SITE_SCOPED';
+  } catch {
+    // Fallback to env var (local/CI convenience)
+    const fromEnv = (process.env.EXPORT_GLOBAL_MODE_FEATURE || '').toLowerCase();
+    const enabled = fromEnv === '1' || fromEnv === 'true' || fromEnv === 'yes';
+    return enabled ? 'GLOBAL' : 'SITE_SCOPED';
+  }
 }
 
 /**


### PR DESCRIPTION
# Phase 1: Export Readiness API Extension (Feature-Flagged)

## Summary

This PR adds non-breaking API fields to expose RetailOps' global export mode capability without changing any evaluation semantics or decision logic.

**Link to design:** [HES_B_LP-export-global-1.0.0 Manifest](docs/HES_B_LP-export-global-1.0.0.json)

**Explicit guarantee:** This PR only adds API fields behind a feature flag. No evaluation semantics changed. No gating logic modified.

---

## Changes

### 1. API Extension: Optional Fields

Added to `CompletionDrivenExportReadiness` response:
- `mode?: "GLOBAL" | "SITE_SCOPED"` — indicates exposure context
- `productLevelReadiness?: { ready, completionPct, threshold, hasBlockingSites }` — replicated state from parent fields for global mode

**Backward compatibility:** Fields are optional and only present when feature flag enabled. Existing clients ignore them.

**No evaluation change:** `productLevelReadiness` is computed identically to the parent response fields; no new logic.

### 2. Feature Flag: Firestore + Environment

**Canonical Firestore configuration** (`settings/exportSettings`):
```json
{
  "exportGlobalMode": {
    "enabled": true,
    "mode": "GLOBAL"
  }
}
```

**Legacy/compatibility keys** (automatically normalized):
- `globalExportModeEnabled` (boolean)
- `enableGlobalFields` (boolean)
- `mode` (string; root level)

**Environment fallback** (local/developer convenience):
```bash
EXPORT_GLOBAL_MODE_FEATURE=true
```

Detection logic: Read canonical form first, fall back to legacy keys, then env var.

### 3. Implementation Details

**File:** `packages/api/src/services/completionDrivenExportReadiness.ts`

- Added `detectExportModeFeatureFlag()` function (canonical form + legacy support + env fallback).
- Extended `calculateCompletionDrivenExportReadiness()` to conditionally attach Phase 1 fields.
- Both product-level and catalog-level evaluation paths support the extension.

**Logging:**
- Temporary `console.info` statements for staging verification (disabled by default).
- Enable logs with `EXPORT_GLOBAL_LOGS=true`.
- Logs are feature-flagged and will be removed or moved to ephemeral flag post-verification.

Example log:
```
[ExportReadiness:Phase1] mode=GLOBAL (product), productLevelReadiness= { "ready": true, "completionPct": 92, ... }
```

### 4. Tests

**File:** `packages/api/src/services/__tests__/phase1_extension.test.ts`

- Vitest unit tests verify response includes `mode` and `productLevelReadiness` when flag enabled.
- Tests verify fields are absent when flag disabled.
- Mocks `loadCompletionRules`, `loadExportableAttributes`, and `evaluateCompletion`.

**Run tests locally:**
```bash
cd packages/api
EXPORT_GLOBAL_MODE_FEATURE=true npm run test
```

Or with pnpm monorepo:
```bash
EXPORT_GLOBAL_MODE_FEATURE=true pnpm --filter @ropi-aoss/api test
```

### 5. Documentation

**File:** `docs/API_READINESS_PHASE1.md`

- Canonical flag configuration with examples.
- Legacy key compatibility rules.
- Example JSON responses (product and catalog) with Phase 1 fields.
- Logging control and staging verification steps.
- Explicit note that siteStatus is preserved and no semantics changed.

---

## HES C Verification Plan (Post-Merge, Staging Deploy)

Follow these steps to verify Phase 1 in staging:

### Step 1: Baseline (Feature OFF)
```bash
# Ensure flag is disabled in Firestore or env
unset EXPORT_GLOBAL_MODE_FEATURE

# Call readiness endpoint as admin
curl -X GET "https://staging-api.retailops.example/api/products/{productId}/completion" \
  -H "Authorization: Bearer $ADMIN_TOKEN"

# Expected response:
# - siteStatus present in operatorExplanation
# - productLevelReadiness ABSENT or null
# - mode ABSENT or null
# Save as: staging_response_flag_off.json
```

### Step 2: Feature ON
```bash
# Enable flag in Firestore
# Document: settings/exportSettings
# Set: { "exportGlobalMode": { "enabled": true, "mode": "GLOBAL" } }

# Or use env (local override):
export EXPORT_GLOBAL_MODE_FEATURE=true

# Re-deploy or trigger re-evaluation
# Call readiness endpoint as admin with logs enabled
export EXPORT_GLOBAL_LOGS=true
curl -X GET "https://staging-api.retailops.example/api/products/{productId}/completion" \
  -H "Authorization: Bearer $ADMIN_TOKEN"

# Expected response:
# - mode == "GLOBAL"
# - productLevelReadiness present with correct shape
# - siteStatus preserved in operatorExplanation
# - Logs should show: [ExportReadiness:Phase1] mode=GLOBAL (product), productLevelReadiness=...
# Save as: staging_response_flag_on.json
```

### Step 3: Toggle Verification
```bash
# Disable flag again
# Redeploy and call same endpoint
# Confirm response reverts to Step 1 format (no Phase 1 fields)
# Save as: staging_response_toggle_off.json
```

### Step 4: Test Suites
```bash
# Run backend tests (should all pass, no regressions)
pnpm --filter @ropi-aoss/api test

# Run frontend tests (should all pass)
pnpm --filter @ropi-aoss/web test

# Capture CI output and any deploy receipts
```

### Step 5: Checklist
- [ ] Flag OFF: `siteStatus` present, `productLevelReadiness` absent
- [ ] Flag ON: `mode == "GLOBAL"`, `productLevelReadiness` present with correct fields
- [ ] Toggle: behavior reverts when flag disabled
- [ ] `siteStatus` preserved in both ON and OFF states
- [ ] Logs show `[ExportReadiness:Phase1]` when flag ON and `EXPORT_GLOBAL_LOGS=true`
- [ ] All test suites pass
- [ ] CI/deploy receipts captured

**Deliverables:** Save three JSON response samples and test output to `evidence/hes-c-stage-verification-YYYY-MM-DD.json` directory.

---

## Constraints Met

✓ **No evaluation semantics change** — evaluation engine unchanged; only response fields modified.  
✓ **Feature-flagged** — controlled by Firestore flag + env var; rollback is flag toggle.  
✓ **Single PR per LP** — all Phase 1 changes in this PR only.  
✓ **Unit/integration tests** — Vitest coverage for enabled/disabled states.  
✓ **Backward compatible** — new fields optional; existing clients unaffected.  
✓ **Documented** — comprehensive API docs, flag configuration, logging control.  
✓ **Temporary logs** — gated and removable via `EXPORT_GLOBAL_LOGS`.  

---

## Merge Instructions

- **Target branch:** `aoss-main`
- **Merge method:** Squash (per governance)
- **Post-merge:** Deploy to staging and follow HES C verification plan above
- **No production merge** until HES C verified and documented

---

## Files Changed

- `packages/api/src/services/completionDrivenExportReadiness.ts` — feature flag detection, optional fields
- `packages/api/src/services/__tests__/phase1_extension.test.ts` — unit tests (new)
- `docs/API_READINESS_PHASE1.md` — API documentation and examples (new)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Export Readiness Phase 1 Extension documentation detailing new optional fields and configuration options.

* **New Features**
  * Added optional `mode` and `productLevelReadiness` fields to export readiness responses.
  * Feature flag controls visibility of Phase 1 extension fields.
  * Added optional logging for export global mode operations.

* **Tests**
  * Added comprehensive test coverage for Phase 1 Readiness Extension behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->