### PR TITLE
LP-deploy-authority-model-001: Add Deploy Authority Model and Copilot Execution Constraints

### DIFF
--- a/AI_BOOTSTRAP.md
+++ b/AI_BOOTSTRAP.md
@@ -173,6 +173,26 @@ Executor (Homer) or designated repo maintainer
 
 Merge authority is NOT the Acceptance Authority
 
+### Copilot Execution Constraints (Non-Negotiable)
+
+Homer operates exclusively as GitHub Copilot.
+
+Homer executes code, tests, and verification steps only within:
+- CI workflows
+- Service account credentials
+- Repository-scoped secrets
+
+Homer cannot:
+- authenticate as a GitHub user
+- trigger `workflow_dispatch` directly
+- override environment protections
+- access secrets outside CI context
+
+If a task requires unavailable permissions:
+- Homer must emit a Blocker Packet
+- Clearly name the GitHub platform restriction
+- Continue all non-blocked verification work
+
 Prompting Rules (Lisa → Homer)
 
 Every directive must include:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -97,6 +97,31 @@ Absence of evidence = non-verifiable = phase hold.
 - **Acceptance Authority (Human):** Verifies VVP and final receipts. Does NOT merge. Does NOT issue LPs.  
 - **Merge Authority:** Homer or designated repo maintainer (never Acceptance Authority).
 
+### Deploy Authority Model (Canonical)
+
+Homer is an execution agent (GitHub Copilot), not a GitHub user.
+
+Homer does NOT have:
+- a GitHub username
+- a GitHub email
+- personal access tokens
+- the ability to manually trigger GitHub Actions workflows
+
+All deploys and privileged operations occur through one of the following canonical paths:
+
+1. **Automatic deploys**
+   - Triggered by merge or push to protected branches (e.g., `aoss-main`)
+   - Executed via GitHub Actions using repository secrets and service accounts
+
+2. **Maintainer-triggered deploys**
+   - Executed manually by a human maintainer via the GitHub Actions UI
+   - Used when GitHub platform security blocks automated dispatch (e.g., `workflow_dispatch`)
+
+GitHub platform restrictions (such as HTTP 403 on workflow dispatch from GITHUB_TOKEN)
+are infrastructure constraints, not governance or execution failures.
+
+Homer must never assume user-level deploy authority.
+
 ## Phase Readiness quick checklist (for PR templates)
 - `packages/sdk/config/attributeRegistry.json` present and versioned  
 - `settings/attributesMeta` Firestore doc either matches local version or sync scheduled  


### PR DESCRIPTION
**LP:** LP-deploy-authority-model-001
**Phase:** Governance Hardening (Docs-only)

## Objective
Future-proof the repo by making the deploy authority and Copilot execution model explicit.
This is a documentation-only clarification. NO runtime logic, workflows, or permissions changes.

## Changes

### GOVERNANCE.md
Added new section: **Deploy Authority Model (Canonical)**
- Clarifies Homer operates as GitHub Copilot (not a GitHub user)
- Documents canonical deploy paths (automatic vs maintainer-triggered)
- Defines platform restrictions as infrastructure constraints (not execution failures)

### AI_BOOTSTRAP.md
Added new subsection: **Copilot Execution Constraints (Non-Negotiable)**
- Documents Homer's execution boundaries (CI workflows, service accounts, repo secrets)
- Lists operations Homer cannot perform (user auth, workflow_dispatch, etc.)
- Defines Blocker Packet protocol for unavailable permissions

## Verification
- [x] Docs-only changes (no runtime modifications)
- [x] No deletions or rewrites of existing text
- [x] Sections inserted verbatim as specified
- [x] One PR per LP

## HES
HES will be produced after PR creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance and deployment policy documentation to clarify execution constraints, deployment authority models, and operational procedures.
  * Added comprehensive phase readiness requirements and deployment prerequisites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->